### PR TITLE
Add direct launch option for systems that don't need a game list

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -387,8 +387,8 @@ void SystemData::writeExampleConfig(const std::string& path)
 			"		<theme>nes</theme>\n"
 			"\n"
 			"		<!-- Specifies if the item is a direct launch item and won't show it's game list but instead\n"
-				"	will launch the command given. If set to true, every tag except for name and command is optional -->\n"
-				"	<directlaunch>false</directlaunch>\n"
+			"		will launch the command given. If set to true, every tag except for name and command is optional -->\n"
+			"		<directlaunch>false</directlaunch>\n"
 			"	</system>\n"
 			"</systemList>\n";
 

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -161,6 +161,12 @@ void SystemData::launchGame(Window* window, FileData* game)
 
 void SystemData::populateFolder(FileData* folder)
 {
+	if (mDirectLaunch)
+	{
+		LOG(LogInfo) << "System " << mName << " is a direct launch item, not building game lists.";
+		return;
+	}
+
 	const fs::path& folderPath = folder->getPath();
 	if(!fs::is_directory(folderPath))
 	{
@@ -330,12 +336,15 @@ bool SystemData::loadConfig()
 			continue;
 		}
 
-		//convert path to generic directory seperators
-		boost::filesystem::path genericPath(path);
-		path = genericPath.generic_string();
+		if (!directLaunch)
+		{
+			//convert path to generic directory seperators
+			boost::filesystem::path genericPath(path);
+			path = genericPath.generic_string();
+		}
 
 		SystemData* newSys = new SystemData(name, fullname, path, extensions, cmd, platformIds, themeFolder, directLaunch);
-		if(newSys->getRootFolder()->getChildren().size() == 0)
+		if(newSys->getRootFolder()->getChildren().size() == 0 && !directLaunch)
 		{
 			LOG(LogWarning) << "System \"" << name << "\" has no games! Ignoring it.";
 			delete newSys;

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -12,7 +12,7 @@ class SystemData
 {
 public:
 	SystemData(const std::string& name, const std::string& fullName, const std::string& startPath, const std::vector<std::string>& extensions, 
-		const std::string& command, const std::vector<PlatformIds::PlatformId>& platformIds, const std::string& themeFolder);
+		const std::string& command, const std::vector<PlatformIds::PlatformId>& platformIds, const std::string& themeFolder, bool directLaunch=false);
 	~SystemData();
 
 	inline FileData* getRootFolder() const { return mRootFolder; };
@@ -21,6 +21,7 @@ public:
 	inline const std::string& getStartPath() const { return mStartPath; }
 	inline const std::vector<std::string>& getExtensions() const { return mSearchExtensions; }
 	inline const std::string& getThemeFolder() const { return mThemeFolder; }
+	inline const bool getDirectLaunch() const { return mDirectLaunch; }
 
 	inline const std::vector<PlatformIds::PlatformId>& getPlatformIds() const { return mPlatformIds; }
 	inline bool hasPlatformId(PlatformIds::PlatformId id) { return std::find(mPlatformIds.begin(), mPlatformIds.end(), id) != mPlatformIds.end(); }
@@ -73,6 +74,7 @@ private:
 	std::vector<PlatformIds::PlatformId> mPlatformIds;
 	std::string mThemeFolder;
 	std::shared_ptr<ThemeData> mTheme;
+	bool mDirectLaunch;
 
 	void populateFolder(FileData* folder);
 

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -119,7 +119,16 @@ bool SystemView::input(InputConfig* config, Input input)
 		if(config->isMappedTo("a", input))
 		{
 			stopScrolling();
-			ViewController::get()->goToGameList(getSelected());
+			
+			SystemData *systemData = getSelected();
+			
+			// decide whether to show game list or launch the command directly
+			if ( !systemData->getDirectLaunch() )
+			{
+				ViewController::get()->goToGameList(getSelected());
+			}else{
+				systemData->launchGame( mWindow, nullptr );
+			}
 			return true;
 		}
 	}else{

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -72,7 +72,15 @@ void ViewController::goToNextGameList()
 	assert(mState.viewing == GAME_LIST);
 	SystemData* system = getState().getSystem();
 	assert(system);
-	goToGameList(system->getNext());
+	
+	// skip systems that don't have a game list, this will always end since it is called
+	// from a system with a game list and the iterator is cyclic
+	do
+	{
+		system = system->getNext();
+	} while ( system->getDirectLaunch() );
+	
+	goToGameList(system);
 }
 
 void ViewController::goToPrevGameList()
@@ -80,7 +88,15 @@ void ViewController::goToPrevGameList()
 	assert(mState.viewing == GAME_LIST);
 	SystemData* system = getState().getSystem();
 	assert(system);
-	goToGameList(system->getPrev());
+	
+	// skip systems that don't have a game list, this will always end since it is called
+	// from a system with a game list and the iterator is cyclic
+	do
+	{
+		system = system->getPrev();
+	} while ( system->getDirectLaunch() );
+	
+	goToGameList(system);
 }
 
 void ViewController::goToGameList(SystemData* system)

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -38,6 +38,12 @@ void BasicGameListView::onFileChanged(FileData* file, FileChangeType change)
 void BasicGameListView::populateList(const std::vector<FileData*>& files)
 {
 	mList.clear();
+	
+	// file list can be empty if direct launch item
+	if (files.size()==0)
+	{
+		return;
+	}
 
 	mHeaderText.setText(files.at(0)->getSystem()->getFullName());
 


### PR DESCRIPTION
Hi,

this idea came from friends I helped built RetroPie boxes.

For items like Kodi we found it helpful not to have to click twice when starting (once for the Ports meta system, and once for starting the port itself). Instead we wanted to add main menu items that launch items directly instead of showing a game list (this could also be useful for non-console emulators that only have one option in the game list currently).

The pull request adds the option to add a <directlaunch> tag to a system which will then allow this system to start it's command directly without showing the corresponding game list. If <directlaunch> is set to "true" only name and command are mandatory tags for this system. The system will show even if no path is set.

This might not be the cleanest solution to this, but I tried to add it without changing too much of the existing structure. Let me know if this is in any way helpful and if things should be changed to improve this functionality.

Also I only tested this on OS X, but it should work for the other systems as well.