### PR TITLE
Skip controller config if known device is added after startup

### DIFF
--- a/es-core/src/guis/GuiDetectDevice.cpp
+++ b/es-core/src/guis/GuiDetectDevice.cpp
@@ -8,10 +8,14 @@
 #include <string>
 #include <sstream>
 #include "Util.h"
+#include <boost/filesystem.hpp>
+#include <boost/locale.hpp>
 
 #define HOLD_TIME 1000
 
 using namespace Eigen;
+
+namespace fs = boost::filesystem;
 
 GuiDetectDevice::GuiDetectDevice(Window* window, bool firstRun, const std::function<void()>& doneCallback) : GuiComponent(window), mFirstRun(firstRun), 
 	mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 5))
@@ -100,15 +104,26 @@ void GuiDetectDevice::update(int deltaTime)
 {
 	if(mHoldingConfig)
 	{
-		mHoldTime -= deltaTime;
-		const float t = (float)mHoldTime / HOLD_TIME;
-		unsigned int c = (unsigned char)(t * 255);
-		mDeviceHeld->setColor((c << 24) | (c << 16) | (c << 8) | 0xFF);
-		if(mHoldTime <= 0)
+		// If ES starts and if a known device is connected after startup skip controller configuration
+		if(mFirstRun && fs::exists(InputManager::getConfigPath()) && InputManager::getInstance()->getNumConfiguredDevices() > 0)
 		{
-			// picked one!
-			mWindow->pushGui(new GuiInputConfig(mWindow, mHoldingConfig, true, mDoneCallback));
-			delete this;
+			InputManager::getInstance()->doOnFinish();  	// execute possible onFinish commands
+			if(mDoneCallback)				
+				mDoneCallback();
+			delete this;					// delete GUI element
+		}
+		else
+		{
+			mHoldTime -= deltaTime;
+			const float t = (float)mHoldTime / HOLD_TIME;
+			unsigned int c = (unsigned char)(t * 255);
+			mDeviceHeld->setColor((c << 24) | (c << 16) | (c << 8) | 0xFF);
+			if(mHoldTime <= 0)
+			{
+				// picked one!
+				mWindow->pushGui(new GuiInputConfig(mWindow, mHoldingConfig, true, mDoneCallback));
+				delete this;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fix for problems like this:
http://blog.petrockblock.com/forums/topic/retropie-wont-recognize-ps3-controller-unless-ps-button-is-hit-before-es-start/
http://blog.petrockblock.com/forums/topic/elegent-method-of-detecting-wireless-controller-before-starting-es/

No controller found message pops up if no controller is connected. If a known controller is connected and any button is pressed system selection menu will show up instantly.

https://github.com/RetroPie/EmulationStation/issues/7