### PR TITLE
don't call shutdown from ES directly - which causes it to not save the...

### DIFF
--- a/emulationstation.sh
+++ b/emulationstation.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+while true; do
+    rm -f /tmp/es-restart /tmp/es-sysrestart /tmp/es-shutdown
+    ./emulationstation "$@"
+    [ -f /tmp/es-restart ] && continue
+    if [ -f /tmp/es-sysrestart ]; then
+        rm -f /tmp/es-sysrestart
+        sudo reboot
+        break
+    fi
+    if [ -f /tmp/es-shutdown ]; then
+        rm -f /tmp/es-shutdown
+        sudo poweroff
+        break
+    fi
+    break
+done

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -178,9 +178,20 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 
 			ComponentListRow row;
 			row.makeAcceptInputHandler([window] {
+				window->pushGui(new GuiMsgBox(window, "REALLY RESTART?", "YES",
+				[] {
+					if(quitES("/tmp/es-restart") != 0)
+						LOG(LogWarning) << "Restart terminated with non-zero result!";
+				}, "NO", nullptr));
+			});
+			row.addElement(std::make_shared<TextComponent>(window, "RESTART EMULATIONSTATION", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+			s->addRow(row);
+
+			row.elements.clear();
+			row.makeAcceptInputHandler([window] {
 				window->pushGui(new GuiMsgBox(window, "REALLY RESTART?", "YES", 
 				[] { 
-					if(runRestartCommand() != 0)
+					if(quitES("/tmp/es-sysrestart") != 0)
 						LOG(LogWarning) << "Restart terminated with non-zero result!";
 				}, "NO", nullptr));
 			});
@@ -191,7 +202,7 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 			row.makeAcceptInputHandler([window] {
 				window->pushGui(new GuiMsgBox(window, "REALLY SHUTDOWN?", "YES", 
 				[] { 
-					if(runShutdownCommand() != 0)
+					if(quitES("/tmp/es-shutdown") != 0)
 						LOG(LogWarning) << "Shutdown terminated with non-zero result!";
 				}, "NO", nullptr));
 			});

--- a/es-core/src/platform.cpp
+++ b/es-core/src/platform.cpp
@@ -1,7 +1,9 @@
 #include "platform.h"
 #include <stdlib.h>
 #include <boost/filesystem.hpp>
+#include <SDL.h>
 #include <iostream>
+#include <fcntl.h>
 
 #ifdef WIN32
 #include <codecvt>
@@ -69,4 +71,20 @@ int runSystemCommand(const std::string& cmd_utf8)
 #else
 	return system(cmd_utf8.c_str());
 #endif
+}
+
+int quitES(const std::string& filename)
+{
+	touch(filename);
+	SDL_Event* quit = new SDL_Event();
+	quit->type = SDL_QUIT;
+	SDL_PushEvent(quit);
+	return 0;
+}
+
+void touch(const std::string& filename)
+{
+	int fd = open(filename.c_str(), O_CREAT|O_WRONLY, 0644);
+	if (fd >= 0)
+		close(fd);
 }

--- a/es-core/src/platform.h
+++ b/es-core/src/platform.h
@@ -22,3 +22,5 @@ std::string getHomePath();
 int runShutdownCommand(); // shut down the system (returns 0 if successful)
 int runRestartCommand(); // restart the system (returns 0 if successful)
 int runSystemCommand(const std::string& cmd_utf8); // run a utf-8 encoded in the shell (requires wstring conversion on Windows)
+int quitES(const std::string& filename);
+void touch(const std::string& filename);


### PR DESCRIPTION
 gameslists on exit. Instead create files

/tmp/es-restart /tmp/es-sysrestart /tmp/es-shutdown to decide what we want to do, which is then handled by our launch script.

@gizmo98 @herbfargus What do you think ? This is a similar technique as recalbox uses, and means ES quits nicely saving the gameslists in all cases. should solve #15 and #16 (can restart ES to rescan roms - ideally I would have liked it not to have to quit to do this, but I was unable to implement stable rom rescanning functionality into ES) 

Will submit the related retropie-setup PR in a moment.