### PR TITLE
move ParseGamelistOnly option to the gui so people can easily enable …

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -175,6 +175,11 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 			s->addWithLabel("SAVE METADATA ON EXIT", save_gamelists);
 			s->addSaveFunc([save_gamelists] { Settings::getInstance()->setBool("SaveGamelistsOnExit", save_gamelists->getState()); });
 
+			auto parse_gamelists = std::make_shared<SwitchComponent>(mWindow);
+			parse_gamelists->setState(Settings::getInstance()->getBool("ParseGamelistOnly"));
+			s->addWithLabel("PARSE GAMESLISTS ONLY", parse_gamelists);
+			s->addSaveFunc([parse_gamelists] { Settings::getInstance()->setBool("ParseGamelistOnly", parse_gamelists->getState()); });
+
 			mWindow->pushGui(s);
 	});
 

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -13,7 +13,6 @@ std::vector<const char*> settings_dont_save = boost::assign::list_of
 	("Debug")
 	("DebugGrid")
 	("DebugText")
-	("ParseGamelistOnly")
 	("ShowExit")
 	("Windowed")
 	("VSync")


### PR DESCRIPTION
…it for faster startup (avoids scanning the roms).

however before enabling it's required to scrape or else you wont have the gameslists generated etc.