### PR TITLE
Fix pageup/pagedown by reloading input config after onfinish

### DIFF
--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -348,6 +348,10 @@ void InputManager::writeDeviceConfig(InputConfig* config)
 
 	config->writeToXML(root);
 	doc.save_file(path.c_str());
+	
+	// execute any onFinish commands and re-load the config for changes
+	doOnFinish();
+	loadInputConfig(config);
 }
 
 void InputManager::doOnFinish()

--- a/es-core/src/guis/GuiDetectDevice.cpp
+++ b/es-core/src/guis/GuiDetectDevice.cpp
@@ -107,7 +107,6 @@ void GuiDetectDevice::update(int deltaTime)
 		// If ES starts and if a known device is connected after startup skip controller configuration
 		if(mFirstRun && fs::exists(InputManager::getConfigPath()) && InputManager::getInstance()->getNumConfiguredDevices() > 0)
 		{
-			InputManager::getInstance()->doOnFinish(); // execute possible onFinish commands
 			if(mDoneCallback)
 				mDoneCallback();
 			delete this; // delete GUI element

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -259,7 +259,6 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 	std::vector< std::shared_ptr<ButtonComponent> > buttons;
 	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, "OK", "ok", [this, okCallback] { 
 		InputManager::getInstance()->writeDeviceConfig(mTargetConfig); // save
-        InputManager::getInstance()->doOnFinish();  // execute possible onFinish commands
 		if(okCallback)
 			okCallback();
 		delete this; 


### PR DESCRIPTION
I ran into the issue where pageup/pagedown mappings don't work until you restart. This is because they're written to the initial config file as "leftbottom/rightbottom" and only changed to the required "pageup/pagedown" by the onfinish script.

It appeared to me that the code to write out a configuration file assumed onfinish would be executed afterward, because it wrote to a temporary location. So I think it makes sense to just go ahead and execute onfinish, and reload the resulting file for the current config right there, instead of relying on higher level code to remember to do it.