### PR TITLE
Fixes libGL problem

### DIFF
--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -13,7 +13,6 @@ Window::Window() : mNormalizeNextUpdate(false), mFrameTimeElapsed(0), mFrameCoun
 {
 	mHelp = new HelpComponent(this);
 	mBackgroundOverlay = new ImageComponent(this);
-	mBackgroundOverlay->setImage(":/scroll_gradient.png");
 }
 
 Window::~Window()
@@ -65,6 +64,8 @@ bool Window::init(unsigned int width, unsigned int height)
 		return false;
 	}
 
+	mBackgroundOverlay->setImage(":/scroll_gradient.png");
+	
 	InputManager::getInstance()->init();
 
 	ResourceManager::getInstance()->reloadAll();


### PR DESCRIPTION
Running ES in Udon Quad (i.MX6) crashes with the following bt

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x76c5b08c in glGenTextures () from /usr/lib/arm-linux-gnueabihf/libGL.so.1
(gdb) bt
#0  0x76c5b08c in glGenTextures () from /usr/lib/arm-linux-gnueabihf/libGL.so.1
#1  0x00104f60 in TextureResource::initFromPixels(unsigned char const*, unsigned int, unsigned int) ()
#2  0x0010503a in TextureResource::initFromMemory(char const*, unsigned int) ()
#3  0x00105466 in TextureResource::reload(std::shared_ptr<ResourceManager>&) ()
#4  0x00105ada in TextureResource::get(std::string const&, bool) ()
#5  0x000ed686 in ImageComponent::setImage(std::string, bool) ()
#6  0x000dbc4c in Window::Window() ()
#7  0x0005a800 in main ()

```

The problem seems to be that libGL doesn't like to behave before the GL context has been initialized. The fix moves the offending call to a later stage once the Renderer has been properly configured.