### PR TITLE
workaround for analogue trigger configuration - eg with xpad.

### DIFF
--- a/es-core/src/InputManager.h
+++ b/es-core/src/InputManager.h
@@ -26,6 +26,7 @@ private:
 	InputConfig* mKeyboardInputConfig;
 
 	std::map<SDL_JoystickID, int*> mPrevAxisValues;
+	std::map<SDL_JoystickID, int*> mInitAxisValues;
 
 	bool initialized() const;
 


### PR DESCRIPTION
Unlike other axis, they don't default to 0, but instead start at -32768 and go to +32767 when pressed. This confuses the
current ES code axis code. As a workaround, we get the initial value and if it is -32767, we add 32767 and divide by two. This gives it
a range that can be handled with the current code (from 0 to 32767). Note on my X11 machine, I had to plug the joystick in after ES
was loaded or it get 0 as the initial axis value for the triggers. This seems ok on the RPI though, so possible some SDL issue.

With this change on a 360 controller the triggers should be correctly detected as +2 and +5 without seeing two presses for each trigger press.