### PR TITLE
Vastly improve loading time of EmulationStation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ CMakeCache.txt
 CMakeFiles
 cmake_install.cmake
 Makefile
+
+# Eclipse
+.cproject
+.project
+.settings/

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -56,8 +56,7 @@ FileData::~FileData()
 	if(mParent)
 		mParent->removeChild(this);
 
-	while(mChildren.size())
-		delete mChildren.back();
+		mChildren.clear();
 }
 
 std::string FileData::getDisplayName() const
@@ -107,15 +106,20 @@ void FileData::addChild(FileData* file)
 	assert(mType == FOLDER);
 	assert(file->getParent() == NULL);
 
-	mChildren.push_back(file);
-	file->mParent = this;
+	const std::string key = file->getPath().filename().string();
+	if (mChildrenByFilename.find(key) == mChildrenByFilename.end())
+	{
+		mChildrenByFilename[key] = file;
+		mChildren.push_back(file);
+		file->mParent = this;
+	}
 }
 
 void FileData::removeChild(FileData* file)
 {
 	assert(mType == FOLDER);
 	assert(file->getParent() == this);
-
+	mChildrenByFilename.erase(file->getPath().filename().string());
 	for(auto it = mChildren.begin(); it != mChildren.end(); it++)
 	{
 		if(*it == file)
@@ -127,6 +131,7 @@ void FileData::removeChild(FileData* file)
 
 	// File somehow wasn't in our children.
 	assert(false);
+
 }
 
 void FileData::sort(ComparisonFunction& comparator, bool ascending)

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <vector>
+#include <unordered_map>
 #include <string>
+#include <vector>
 #include <boost/filesystem.hpp>
 #include "MetaData.h"
 
@@ -39,6 +40,7 @@ public:
 	inline FileType getType() const { return mType; }
 	inline const boost::filesystem::path& getPath() const { return mPath; }
 	inline FileData* getParent() const { return mParent; }
+	inline const std::unordered_map<std::string, FileData*>& getChildrenByFilename() const { return mChildrenByFilename; }
 	inline const std::vector<FileData*>& getChildren() const { return mChildren; }
 	inline SystemData* getSystem() const { return mSystem; }
 	
@@ -76,5 +78,6 @@ private:
 	boost::filesystem::path mPath;
 	SystemData* mSystem;
 	FileData* mParent;
+	std::unordered_map<std::string,FileData*> mChildrenByFilename;
 	std::vector<FileData*> mChildren;
 };

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -198,7 +198,7 @@ void SystemData::populateFolder(FileData* folder)
 			populateFolder(newFolder);
 
 			//ignore folders that do not contain games
-			if(newFolder->getChildren().size() == 0)
+			if(newFolder->getChildrenByFilename().size() == 0)
 				delete newFolder;
 			else
 				folder->addChild(newFolder);
@@ -311,7 +311,7 @@ bool SystemData::loadConfig()
 		path = genericPath.generic_string();
 
 		SystemData* newSys = new SystemData(name, fullname, path, extensions, cmd, platformIds, themeFolder);
-		if(newSys->getRootFolder()->getChildren().size() == 0)
+		if(newSys->getRootFolder()->getChildrenByFilename().size() == 0)
 		{
 			LOG(LogWarning) << "System \"" << name << "\" has no games! Ignoring it.";
 			delete newSys;

--- a/es-core/src/Util.cpp
+++ b/es-core/src/Util.cpp
@@ -100,6 +100,20 @@ fs::path resolvePath(const fs::path& path, const fs::path& relativeTo, bool allo
 	return path;
 }
 
+fs::path removeCommonPathUsingStrings(const fs::path& path, const fs::path& relativeTo, bool& contains)
+{
+	std::string pathStr = path.c_str();
+	std::string relativeToStr = relativeTo.c_str();
+	if (pathStr.find_first_of(relativeToStr) == 0) {
+		contains = true;
+		return pathStr.substr(relativeToStr.size() + 1);
+	}
+	else {
+		contains = false;
+		return path;
+	}
+}
+
 // example: removeCommonPath("/home/pi/roms/nes/foo/bar.nes", "/home/pi/roms/nes/") returns "foo/bar.nes"
 fs::path removeCommonPath(const fs::path& path, const fs::path& relativeTo, bool& contains)
 {

--- a/es-core/src/Util.h
+++ b/es-core/src/Util.h
@@ -19,6 +19,7 @@ float round(float num);
 
 std::string getCanonicalPath(const std::string& str);
 
+boost::filesystem::path removeCommonPathUsingStrings(const boost::filesystem::path& path, const boost::filesystem::path& relativeTo, bool& contains);
 // example: removeCommonPath("/home/pi/roms/nes/foo/bar.nes", "/home/pi/roms/nes/") returns "foo/bar.nes"
 boost::filesystem::path removeCommonPath(const boost::filesystem::path& path, const boost::filesystem::path& relativeTo, bool& contains);
 


### PR DESCRIPTION
Included in this pull request are two changes that vastly improve the loading time of EmulationStation for users who have a large amount of games.

1. The `ParseGamelistOnly` option no longer checks files exist in the filesystem
2. The `FileData` class uses a `vector` to store files but also tries to insert elements into the vector if and only if they do not already exist. This is O(n). I have added an `unordered_map` to track elements and so the algorithm is now O(1).

On my Pi with about 20,000 games, this reduced loading time from over 30 minutes to roughly a minute or so.