### PR TITLE
Fix for long exit times while saving metadata

### DIFF
--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -215,6 +215,12 @@ void updateGamelist(SystemData* system)
 		{
 			const char* tag = ((*fit)->getType() == GAME) ? "game" : "folder";
 
+			// check if current file has metadata, if no, skip it as it wont be in the gamelist anyway.
+			if ((*fit)->metadata.isDefault()) {
+				++fit;
+				continue;
+			}
+
 			// check if the file already exists in the XML
 			// if it does, remove it before adding
 			for(pugi::xml_node fileNode = root.child(tag); fileNode; fileNode = fileNode.next_sibling(tag))

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -133,3 +133,12 @@ boost::posix_time::ptime MetaDataList::getTime(const std::string& key) const
 {
 	return string_to_ptime(get(key), "%Y%m%dT%H%M%S%F%q");
 }
+
+bool MetaDataList::isDefault()
+{
+	for (int i = 1; i < mMap.size(); i++) {
+		if (mMap.at(gameDecls[i].key) != gameDecls[i].defaultValue) return false;
+	}
+
+	return true;
+}

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -56,6 +56,8 @@ public:
 	float getFloat(const std::string& key) const;
 	boost::posix_time::ptime getTime(const std::string& key) const;
 
+	bool isDefault();
+
 	inline MetaDataListType getType() const { return mType; }
 	inline const std::vector<MetaDataDecl>& getMDD() const { return getMDDByType(getType()); }
 


### PR DESCRIPTION
The cause for long save times for those with large libraries is caused by the games that don't have metadata.  Before it appends the new game's metadata node to the tree it first finds the old one and deletes it using a for loop.  The problem is that a game that has no metadata also will not be in the gamelist.xml file so it will loop through the whole tree until it hits the last node.

This fix adds a function to metadata that will return true if all metadata is still set at its defaults.  This is then used to just skip that game and not try looking for it in the gamelist.

I threw together a [spreadsheet](https://docs.google.com/spreadsheets/d/1k4rUefg8XoclnI8LD-8hj6-LqY1_LfYyok3ZkHsNQos/edit?usp=sharing) that shows the difference in performance.  These results are from retropie.org.uk user Meleu who reports a time save from just under 5 minutes to 8-9 seconds.
Cycles were incremented every pass through the loop.  
