### PR TITLE
emulationstation - add additional scroll speed tier, and slow down fastest speed

### DIFF
--- a/es-core/src/components/IList.h
+++ b/es-core/src/components/IList.h
@@ -36,10 +36,11 @@ struct ScrollTierList
 // default scroll tiers
 const ScrollTier QUICK_SCROLL_TIERS[] = {
 	{500, 500},
-	{5000, 114},
-	{0, 8}
+	{2000, 114},
+	{4000, 32},
+	{0, 16}
 };
-const ScrollTierList LIST_SCROLL_STYLE_QUICK = { 3, QUICK_SCROLL_TIERS };
+const ScrollTierList LIST_SCROLL_STYLE_QUICK = { 4, QUICK_SCROLL_TIERS };
 
 const ScrollTier SLOW_SCROLL_TIERS[] = {
 	{500, 500},


### PR DESCRIPTION
@HerbFargus et al I'm looking for some feedback on this if possible. I find on my system when scrolling ES scrolls quite slowly, but then jumps to a silly speed, meaning you often go past the entry you are looking for in a large list.

I slowed down the fastest scroll speed, and added an additional tier. I also adjusted the timings (2 seconds for first speed increase, then 4 seconds for next). 