### PR TITLE
Instant Shutdown by only writing changes to gamelist.xml

### DIFF
--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -139,6 +139,8 @@ void parseGamelist(SystemData* system)
 			//make sure name gets set if one didn't exist
 			if(file->metadata.get("name").empty())
 				file->metadata.set("name", defaultName);
+
+			file->metadata.resetChangedFlag();
 		}
 	}
 }
@@ -207,19 +209,23 @@ void updateGamelist(SystemData* system)
 	FileData* rootFolder = system->getRootFolder();
 	if (rootFolder != nullptr)
 	{
+		int numUpdated = 0;
+
 		//get only files, no folders
 		std::vector<FileData*> files = rootFolder->getFilesRecursive(GAME | FOLDER);
 		//iterate through all files, checking if they're already in the XML
-		std::vector<FileData*>::const_iterator fit = files.cbegin();
-		while(fit != files.cend())
+		for(std::vector<FileData*>::const_iterator fit = files.cbegin(); fit != files.cend(); ++fit)
 		{
 			const char* tag = ((*fit)->getType() == GAME) ? "game" : "folder";
 
 			// check if current file has metadata, if no, skip it as it wont be in the gamelist anyway.
 			if ((*fit)->metadata.isDefault()) {
-				++fit;
 				continue;
 			}
+
+			// do not touch if it wasn't changed anyway
+			if (!(*fit)->metadata.wasChanged())
+				continue;
 
 			// check if the file already exists in the XML
 			// if it does, remove it before adding
@@ -244,18 +250,21 @@ void updateGamelist(SystemData* system)
 
 			// it was either removed or never existed to begin with; either way, we can add it now
 			addFileDataNode(root, *fit, tag, system);
-
-			++fit;
+			++numUpdated;
 		}
 
 		//now write the file
 
-		//make sure the folders leading up to this path exist (or the write will fail)
-		boost::filesystem::path xmlWritePath(system->getGamelistPath(true));
-		boost::filesystem::create_directories(xmlWritePath.parent_path());
+		if (numUpdated > 0) {
+			//make sure the folders leading up to this path exist (or the write will fail)
+			boost::filesystem::path xmlWritePath(system->getGamelistPath(true));
+			boost::filesystem::create_directories(xmlWritePath.parent_path());
 
-		if (!doc.save_file(xmlWritePath.c_str())) {
-			LOG(LogError) << "Error saving gamelist.xml to \"" << xmlWritePath << "\" (for system " << system->getName() << ")!";
+			LOG(LogInfo) << "Added/Updated " << numUpdated << " entities in '" << xmlReadPath << "'";
+
+			if (!doc.save_file(xmlWritePath.c_str())) {
+				LOG(LogError) << "Error saving gamelist.xml to \"" << xmlWritePath << "\" (for system " << system->getName() << ")!";
+			}
 		}
 	}else{
 		LOG(LogError) << "Found no root folder for system \"" << system->getName() << "\"!";

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -49,7 +49,7 @@ const std::vector<MetaDataDecl>& getMDDByType(MetaDataListType type)
 
 
 MetaDataList::MetaDataList(MetaDataListType type)
-	: mType(type)
+	: mType(type), mWasChanged(false)
 {
 	const std::vector<MetaDataDecl>& mdd = getMDD();
 	for(auto iter = mdd.begin(); iter != mdd.end(); iter++)
@@ -110,11 +110,12 @@ void MetaDataList::appendToXML(pugi::xml_node parent, bool ignoreDefaults, const
 void MetaDataList::set(const std::string& key, const std::string& value)
 {
 	mMap[key] = value;
+	mWasChanged = true;
 }
 
 void MetaDataList::setTime(const std::string& key, const boost::posix_time::ptime& time)
 {
-	mMap[key] = boost::posix_time::to_iso_string(time);
+	set(key, boost::posix_time::to_iso_string(time));
 }
 
 const std::string& MetaDataList::get(const std::string& key) const
@@ -144,4 +145,14 @@ bool MetaDataList::isDefault()
 	}
 
 	return true;
+}
+
+bool MetaDataList::wasChanged() const
+{
+	return mWasChanged;
+}
+
+void MetaDataList::resetChangedFlag()
+{
+	mWasChanged = false;
 }

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -58,10 +58,14 @@ public:
 
 	bool isDefault();
 
+	bool wasChanged() const;
+	void resetChangedFlag();
+
 	inline MetaDataListType getType() const { return mType; }
 	inline const std::vector<MetaDataDecl>& getMDD() const { return getMDDByType(getType()); }
 
 private:
 	MetaDataListType mType;
 	std::map<std::string, std::string> mMap;
+	bool mWasChanged;
 };


### PR DESCRIPTION
This is a proposal to speedup the shutdown of ES and actually make it shutdown instantly. Usually, ES writes back metadata of all files from all systems to the gamelist.xml. With this PR, ES will keep track of changes to the metadata at runtime and only write back changed entities upon shutdown.

When shutting down there will be a summary of changed gamelist.xmls:
```
lvl1: 	OptionListComponent too narrow!
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/3do/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/amiga/gamelist.xml'
lvl2: 	Added/Updated 1 entities in '/home/vbs/.emulationstation/gamelists/atari7800/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/atarijaguar/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/c64/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/dreamcast/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/gb/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/mame-libretro/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/mastersystem/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/megadrive/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/n64/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/nes/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/pcengine/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/psx/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/retropie/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/sega32x/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/segacd/gamelist.xml'
lvl2: 	Added/Updated 0 entities in '/home/vbs/.emulationstation/gamelists/snes/gamelist.xml'
lvl2: 	EmulationStation cleanly shutting down.
```

I think it should be ok but maybe I should ask some people in the forums if they would test it a bit under real-life conditions. What do you think?