### PR TITLE
add option to hide system view

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -58,6 +58,9 @@ bool parseArgs(int argc, char* argv[], unsigned int* width, unsigned int* height
 		}else if(strcmp(argv[i], "--no-splash") == 0)
 		{
 			Settings::getInstance()->setBool("SplashScreen", false);
+		}else if(strcmp(argv[i], "--hide-systemview") == 0)
+		{
+			Settings::getInstance()->setBool("HideSystemView", true);
 		}else if(strcmp(argv[i], "--debug") == 0)
 		{
 			Settings::getInstance()->setBool("Debug", true);
@@ -95,6 +98,7 @@ bool parseArgs(int argc, char* argv[], unsigned int* width, unsigned int* height
 				"--draw-framerate		display the framerate\n"
 				"--no-exit			don't show the exit option in the menu\n"
 				"--no-splash			don't show the splash screen\n"
+				"--hide-systemview		show only gamelist view, no system view\n"
 				"--debug				more logging, show console on Windows\n"
 				"--scrape			scrape using command line interface\n"
 				"--windowed			not fullscreen, should be used with --resolution\n"

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -46,7 +46,10 @@ void ViewController::goToStart()
 	/* mState.viewing = START_SCREEN;
 	mCurrentView.reset();
 	playViewTransition(); */
-	goToSystemView(SystemData::sSystemVector.at(0));
+	if (Settings::getInstance()->getBool("HideSystemView"))
+	  goToGameList(SystemData::sSystemVector.at(0));
+	else
+	  goToSystemView(SystemData::sSystemVector.at(0));
 }
 
 int ViewController::getSystemId(SystemData* system)

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -116,7 +116,8 @@ std::vector<HelpPrompt> BasicGameListView::getHelpPrompts()
 		prompts.push_back(HelpPrompt("left/right", "system"));
 	prompts.push_back(HelpPrompt("up/down", "choose"));
 	prompts.push_back(HelpPrompt("a", "launch"));
-	prompts.push_back(HelpPrompt("b", "back"));
+	if(!Settings::getInstance()->getBool("HideSystemView"))
+	  prompts.push_back(HelpPrompt("b", "back"));
 	prompts.push_back(HelpPrompt("select", "options"));
 	return prompts;
 }

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -2,6 +2,7 @@
 #include "ThemeData.h"
 #include "Window.h"
 #include "views/ViewController.h"
+#include "Settings.h"
 
 GridGameListView::GridGameListView(Window* window, FileData* root) : ISimpleGameListView(window, root),
 	mGrid(window)
@@ -54,6 +55,7 @@ std::vector<HelpPrompt> GridGameListView::getHelpPrompts()
 	std::vector<HelpPrompt> prompts;
 	prompts.push_back(HelpPrompt("up/down/left/right", "scroll"));
 	prompts.push_back(HelpPrompt("a", "launch"));
-	prompts.push_back(HelpPrompt("b", "back"));
+	if(!Settings::getInstance()->getBool("HideSystemView"))
+	  prompts.push_back(HelpPrompt("b", "back"));
 	return prompts;
 }

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -80,7 +80,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 				setCursor(mCursorStack.top());
 				mCursorStack.pop();
 				Sound::getFromTheme(getTheme(), getName(), "back")->play();
-			}else{
+			}else if (!Settings::getInstance()->getBool("HideSystemView")) {
 				onFocusLost();
 				ViewController::get()->goToSystemView(getCursor()->getSystem());
 			}

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -18,7 +18,8 @@ std::vector<const char*> settings_dont_save = boost::assign::list_of
 	("VSync")
 	("HideConsole")
 	("IgnoreGamelist")
-	("SplashScreen");
+	("SplashScreen")
+	("HideSystemView");
 
 Settings::Settings()
 {
@@ -45,6 +46,7 @@ void Settings::setDefaults()
 	mBoolMap["ShowExit"] = true;
 	mBoolMap["Windowed"] = false;
 	mBoolMap["SplashScreen"] = true;
+	mBoolMap["HideSystemView"] = false;
 
 #ifdef _RPI_
 	// don't enable VSync by default on the Pi, since it already 


### PR DESCRIPTION
Here a proposal to add a `--hide-systemview` flag to ES so

* on boot goes directly to the game list of the 1st system available
* prevents `b` action to go back to the system view
* hides `B BACK` in the help at the bottom.


I'd like to see this feature merged because I plan to only support one system (arcade) in my setup, therefore the system view is pretty useless.