### PR TITLE
don't enable video view if current theme doesn't support it

### DIFF
--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -228,13 +228,15 @@ std::shared_ptr<IGameListView> ViewController::getGameListView(SystemData* syste
 	//if we didn't, make it, remember it, and return it
 	std::shared_ptr<IGameListView> view;
 
+	bool themeHasVideoView = system->getTheme()->hasView("video");
+
 	//decide type
 	bool detailed = false;
 	bool video	  = false;
 	std::vector<FileData*> files = system->getRootFolder()->getFilesRecursive(GAME | FOLDER);
 	for(auto it = files.begin(); it != files.end(); it++)
 	{
-		if(!(*it)->getVideoPath().empty())
+		if(themeHasVideoView && !(*it)->getVideoPath().empty())
 		{
 			video = true;
 			break;

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -343,6 +343,11 @@ void ThemeData::parseElement(const pugi::xml_node& root, const std::map<std::str
 	}
 }
 
+bool ThemeData::hasView(const std::string& view)
+{
+	auto viewIt = mViews.find(view);
+	return (viewIt != mViews.end());
+}
 
 const ThemeData::ThemeElement* ThemeData::getElement(const std::string& view, const std::string& element, const std::string& expectedType) const
 {

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -135,6 +135,8 @@ public:
 		BOOLEAN
 	};
 
+	bool hasView(const std::string& view);
+
 	// If expectedType is an empty string, will do no type checking.
 	const ThemeElement* getElement(const std::string& view, const std::string& element, const std::string& expectedType) const;
 


### PR DESCRIPTION
Provides improved compatibility for video view with older themes.  Currently, if using a theme that does not support video, user will get the default white screen theme if they have videos in their gamelist.xml.  This change checks if the active theme supports video and if not it will use the detailed view vs. video.