### PR TITLE
Ignoring Mac OS X ._* files

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -1,6 +1,7 @@
 #include "SystemData.h"
 #include "Gamelist.h"
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include <fstream>
 #include <stdlib.h>
 #include <SDL_joystick.h>
@@ -184,7 +185,8 @@ void SystemData::populateFolder(FileData* folder)
 		//see issue #75: https://github.com/Aloshi/EmulationStation/issues/75
 
 		isGame = false;
-		if(std::find(mSearchExtensions.begin(), mSearchExtensions.end(), extension) != mSearchExtensions.end())
+		if(std::find(mSearchExtensions.begin(), mSearchExtensions.end(), extension) != mSearchExtensions.end()
+		   && (fs::is_directory(filePath) || !boost::starts_with(filePath.filename().string(), "._")))
 		{
 			FileData* newGame = new FileData(GAME, filePath.generic_string(), this);
 			folder->addChild(newGame);


### PR DESCRIPTION
When uploading ROMs via Samba from a Mac, OS X creates those annoying ._* files which show up as duplicates entries in the game list.

This issues seems fairly common among Mac users:
[https://www.google.com/#q=retropie+mac+duplicate](https://www.google.com/#q=retropie+mac+duplicate)

This pull request fixes the issue by ignoring files (not directories) with a name starting in '._'.