### PR TITLE
Add Explicit Gamelist Type selection to GUI menu.

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -160,6 +160,24 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 				});
 			}
 
+			// GameList view style
+			auto gamelist_style = std::make_shared< OptionListComponent<std::string> >(mWindow, "GAMELIST VIEW STYLE", false);
+			std::vector<std::string> styles;
+			styles.push_back("automatic");
+			styles.push_back("basic");
+			styles.push_back("detailed");
+			styles.push_back("video");
+			for (auto it = styles.begin(); it != styles.end(); it++)
+				gamelist_style->add(*it, *it, Settings::getInstance()->getString("GamelistViewStyle") == *it);
+			s->addWithLabel("GAMELIST VIEW STYLE", gamelist_style);
+			s->addSaveFunc([gamelist_style] {
+				bool needReload = false;
+				if (Settings::getInstance()->getString("GamelistViewStyle") != gamelist_style->getSelected())
+					needReload = true;
+				Settings::getInstance()->setString("GamelistViewStyle", gamelist_style->getSelected()); 
+				if (needReload)
+					ViewController::get()->reloadAll();
+			});
 			mWindow->pushGui(s);
 	});
 

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -49,6 +49,15 @@ public:
 		GAME_LIST
 	};
 
+	enum GameListViewType
+	{
+		AUTOMATIC,
+		BASIC,
+		DETAILED,
+		VIDEO
+		// GRID TODO!
+	};
+
 	struct State
 	{
 		ViewMode viewing;

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -75,6 +75,7 @@ void Settings::setDefaults()
 	mStringMap["ThemeSet"] = "";
 	mStringMap["ScreenSaverBehavior"] = "dim";
 	mStringMap["Scraper"] = "TheGamesDB";
+	mStringMap["GamelistViewStyle"] = "automatic";
 }
 
 template <typename K, typename V>


### PR DESCRIPTION
Currently supports Basic, Detailed, Video, and Automatic types. The Automatic type checks for the availability of video's first, then screenshots, finally defaulting to Basic view if none are present.