### PR TITLE
Adding metadata to folders

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -83,28 +83,12 @@ const std::string& FileData::getThumbnailPath() const
 
 const std::string& FileData::getVideoPath() const
 {
-	if (mType == GAME)
-	{
-		return metadata.get("video");
-	}
-	else
-	{
-		static std::string empty;
-		return empty;
-	}
+	return metadata.get("video");
 }
 
 const std::string& FileData::getMarqueePath() const
 {
-	if (mType == GAME)
-	{
-		return metadata.get("marquee");
-	}
-	else
-	{
-		static std::string empty;
-		return empty;
-	}
+	return metadata.get("marquee");
 }
 
 

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -25,10 +25,18 @@ MetaDataDecl gameDecls[] = {
 const std::vector<MetaDataDecl> gameMDD(gameDecls, gameDecls + sizeof(gameDecls) / sizeof(gameDecls[0]));
 
 MetaDataDecl folderDecls[] = { 
-	{"name",		MD_STRING,				"", 	false}, 
-	{"desc",		MD_MULTILINE_STRING,	"", 	false},
-	{"image",		MD_PATH,				"", 	false},
-	{"thumbnail",	MD_PATH,				"", 	false},
+	{"name",		MD_STRING,				"", 	false,		"name",					"enter game name"}, 
+	{"desc",		MD_MULTILINE_STRING,	"", 	false,		"description",			"enter description"},
+	{"image",		MD_PATH,				"", 	false,		"image",				"enter path to image"},
+	{"thumbnail",	MD_PATH,				"", 	false,		"thumbnail",			"enter path to thumbnail"},
+	{"video",	MD_PATH,				"", 	false,		"video",				"enter path to video"},
+	{"marquee",	MD_PATH,				"", 	false,		"marquee",				"enter path to marquee"},
+	{"rating",		MD_RATING,				"0.000000", 		false,		"rating",				"enter rating"},
+	{"releasedate", MD_DATE,				"not-a-date-time", 	false,		"release date",			"enter release date"},
+	{"developer",	MD_STRING,				"unknown",			false,		"developer",			"enter game developer"},
+	{"publisher",	MD_STRING,				"unknown",			false,		"publisher",			"enter game publisher"},
+	{"genre",		MD_STRING,				"unknown",			false,		"genre",				"enter game genre"},
+	{"players",		MD_INT,					"1",				false,		"players",				"enter number of players"}
 };
 const std::vector<MetaDataDecl> folderMDD(folderDecls, folderDecls + sizeof(folderDecls) / sizeof(folderDecls[0]));
 

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -74,10 +74,22 @@ void GuiGamelistOptions::openMetaDataEd()
 	ScraperSearchParams p;
 	p.game = file;
 	p.system = file->getSystem();
-	mWindow->pushGui(new GuiMetaDataEd(mWindow, &file->metadata, file->metadata.getMDD(), p, file->getPath().filename().string(), 
-		std::bind(&IGameListView::onFileChanged, getGamelist(), file, FILE_METADATA_CHANGED), [this, file] { 
+
+	std::function<void()> deleteBtnFunc;
+
+	if (file->getType() == FOLDER)
+	{
+		deleteBtnFunc = NULL;
+	}
+	else
+	{
+		deleteBtnFunc = [this, file] {
 			getGamelist()->remove(file);
-	}));
+		};
+	}
+
+	mWindow->pushGui(new GuiMetaDataEd(mWindow, &file->metadata, file->metadata.getMDD(), p, file->getPath().filename().string(), 
+		std::bind(&IGameListView::onFileChanged, getGamelist(), file, FILE_METADATA_CHANGED), deleteBtnFunc));
 }
 
 void GuiGamelistOptions::jumpToLetter()

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -192,14 +192,15 @@ void DetailedGameListView::updateInfoPanel()
 		mDescription.setText(file->metadata.get("desc"));
 		mDescContainer.reset();
 
+		mRating.setValue(file->metadata.get("rating"));
+		mReleaseDate.setValue(file->metadata.get("releasedate"));
+		mDeveloper.setValue(file->metadata.get("developer"));
+		mPublisher.setValue(file->metadata.get("publisher"));
+		mGenre.setValue(file->metadata.get("genre"));
+		mPlayers.setValue(file->metadata.get("players"));
+
 		if(file->getType() == GAME)
 		{
-			mRating.setValue(file->metadata.get("rating"));
-			mReleaseDate.setValue(file->metadata.get("releasedate"));
-			mDeveloper.setValue(file->metadata.get("developer"));
-			mPublisher.setValue(file->metadata.get("publisher"));
-			mGenre.setValue(file->metadata.get("genre"));
-			mPlayers.setValue(file->metadata.get("players"));
 			mLastPlayed.setValue(file->metadata.get("lastplayed"));
 			mPlayCount.setValue(file->metadata.get("playcount"));
 		}

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -259,14 +259,15 @@ void VideoGameListView::updateInfoPanel()
 		mDescription.setText(file->metadata.get("desc"));
 		mDescContainer.reset();
 
+		mRating.setValue(file->metadata.get("rating"));
+		mReleaseDate.setValue(file->metadata.get("releasedate"));
+		mDeveloper.setValue(file->metadata.get("developer"));
+		mPublisher.setValue(file->metadata.get("publisher"));
+		mGenre.setValue(file->metadata.get("genre"));
+		mPlayers.setValue(file->metadata.get("players"));
+		
 		if(file->getType() == GAME)
 		{
-			mRating.setValue(file->metadata.get("rating"));
-			mReleaseDate.setValue(file->metadata.get("releasedate"));
-			mDeveloper.setValue(file->metadata.get("developer"));
-			mPublisher.setValue(file->metadata.get("publisher"));
-			mGenre.setValue(file->metadata.get("genre"));
-			mPlayers.setValue(file->metadata.get("players"));
 			mLastPlayed.setValue(file->metadata.get("lastplayed"));
 			mPlayCount.setValue(file->metadata.get("playcount"));
 		}


### PR DESCRIPTION
Hi. It's my second attempt at my first PR. I believe I squashed the commits.

I have no idea why the commit is signed by two authors with my username.

For people who use subfolders in their gamelist, we currently provided a sub-optimal experience:

Allowed to show images, but not videos;
Allowed for editing, but the GUI would show up incomplete;
Did not show some of the metadata, if it existed on the gamelist (i.e. number of players, stars, etc), especially useful for multi-disc games under the same folder, or even for category groupings.
This small change enables video playback for folders, when selected, and also opens up a lot more of the metadata to the folders (in fact, all but the "Last Played" date, and "Play Count").

Hope it suits.

Thanks.