### PR TITLE
fix image ratio for first image in video game list view

### DIFF
--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -94,7 +94,6 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 
 	initMDLabels();
 	initMDValues();
-	updateInfoPanel();
 }
 
 VideoGameListView::~VideoGameListView()
@@ -342,4 +341,10 @@ void VideoGameListView::update(int deltaTime)
 {
 	BasicGameListView::update(deltaTime);
 	mVideo.update(deltaTime);
+}
+
+void VideoGameListView::onShow()
+{
+	GuiComponent::onShow();
+	updateInfoPanel();
 }

--- a/es-app/src/views/gamelist/VideoGameListView.h
+++ b/es-app/src/views/gamelist/VideoGameListView.h
@@ -12,6 +12,8 @@ public:
 	VideoGameListView(Window* window, FileData* root);
 	virtual ~VideoGameListView();
 
+	virtual void onShow() override;
+
 	virtual void onThemeChanged(const std::shared_ptr<ThemeData>& theme) override;
 
 	virtual const char* getName() const override { return "video"; }


### PR DESCRIPTION
Issue reported here.
https://retropie.org.uk/forum/topic/9261/bug-box-art-displaying-incorrect-size-the-first-time-i-enter-a-system/