### PR TITLE
Add ability to specify sound when scrolling systems on the system view

### DIFF
--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -76,6 +76,15 @@ void SystemView::populate()
 		e.data.backgroundExtras = std::shared_ptr<ThemeExtras>(new ThemeExtras(mWindow));
 		e.data.backgroundExtras->setExtras(ThemeData::makeExtras((*it)->getTheme(), "system", mWindow));
 
+				// Handle sound
+		const ThemeData::ThemeElement* elem = theme->getElement("system", "systemSound", "sound");
+		if (elem != NULL)
+		{
+			// Load the sound
+			std::string sound = elem->get<std::string>("path");
+			e.sound = Sound::get(sound);
+		}
+
 		this->add(e);
 	}
 }

--- a/es-core/src/components/IList.h
+++ b/es-core/src/components/IList.h
@@ -7,6 +7,7 @@
 #include "components/ImageComponent.h"
 #include "resources/Font.h"
 #include "Renderer.h"
+#include "Sound.h"
 
 enum CursorState
 {
@@ -57,6 +58,7 @@ public:
 		std::string name;
 		UserData object;
 		EntryData data;
+		std::shared_ptr<Sound> sound;
 	};
 
 protected:
@@ -301,5 +303,12 @@ protected:
 	}
 
 	virtual void onCursorChanged(const CursorState& state) {}
-	virtual void onScroll(int amt) {}
+	virtual void onScroll(int amt)
+	{
+		if (mEntries[mCursor].sound.get() != NULL)
+		{
+			mEntries[mCursor].sound->play();
+		}
+	}
+
 };


### PR DESCRIPTION
All credit to @fieldofcows , this is his commit https://github.com/fieldofcows/EmulationStation/commit/3c5bd864c07e45ab4cc2c43fc5b0c3a851492197 which has been tested as working in the Windows environment and so needs testing on a Raspi. 

I am still new to (shit at) Github and I don't know how to pull the commit directly from @fieldofcows branch to here, so apologies if that's what I am meant to do (i.e. that is the done thing). Will close this PR if that is the case.