### PR TITLE
Fix for carousel theming

### DIFF
--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -310,6 +310,9 @@ void  SystemView::getViewElements(const std::shared_ptr<ThemeData>& theme)
 
 	getDefaultElements();
 
+	if (!theme->hasView("system"))
+		return;
+
 	const ThemeData::ThemeElement* carouselElem = theme->getElement("system", "systemcarousel", "carousel");
 	if (carouselElem)
 		getCarouselFromTheme(carouselElem);


### PR DESCRIPTION
Currently, carousel theming is loaded from first system theme.  If current theme does not support the first system then the carousel theming will not be applied.  This change adds a simple check to see if the current system theme supports system view, if it does not, it try to load the carousel theming from the next system theme.