### PR TITLE
Changes to mitigate white flashes in heavier themes

### DIFF
--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -89,7 +89,7 @@ void AudioManager::init()
 	sAudioFormat.freq = 44100;
 	sAudioFormat.format = AUDIO_S16;
 	sAudioFormat.channels = 2;
-	sAudioFormat.samples = 1024;
+	sAudioFormat.samples = 4096;
 	sAudioFormat.callback = mixAudio;
 	sAudioFormat.userdata = NULL;
 

--- a/es-core/src/Renderer_init_sdlgl.cpp
+++ b/es-core/src/Renderer_init_sdlgl.cpp
@@ -151,7 +151,7 @@ namespace Renderer
 		glMatrixMode(GL_PROJECTION);
 		glOrtho(0, display_width, display_height, 0, -1.0, 1.0);
 		glMatrixMode(GL_MODELVIEW);
-		glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+		glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 
 		return true;
 	}

--- a/es-core/src/components/IList.h
+++ b/es-core/src/components/IList.h
@@ -44,7 +44,7 @@ const ScrollTierList LIST_SCROLL_STYLE_QUICK = { 4, QUICK_SCROLL_TIERS };
 
 const ScrollTier SLOW_SCROLL_TIERS[] = {
 	{500, 500},
-	{0, 150}
+	{0, 200}
 };
 const ScrollTierList LIST_SCROLL_STYLE_SLOW = { 2, SLOW_SCROLL_TIERS };
 
@@ -98,6 +98,11 @@ public:
 	bool isScrolling() const
 	{
 		return (mScrollVelocity != 0 && mScrollTier > 0);
+	}
+
+	int getScrollingVelocity() 
+	{
+		return mScrollVelocity;
 	}
 
 	void stopScrolling()


### PR DESCRIPTION
Hi. I'm proposing to add two options that will help improve the perceived performance in heavier themes.

- Option to not use multithreaded image loading, like old ES (default: use multithread, like today)
- Option to re-use SVG in-memory images in same path (default: not re-use, like today)

In the recent WSOD changes, one improvement was to load images in separate threads. While this works well for non-heavy themes, it causes an unpleasant white screen to show before the actual images are rendered, when they need to be cycled in the texture manager memory. Forcing them to be loaded like the old ES, in the same thread, will cause a potentially less smooth system view scrolling, at the exchange of no more white screens.

Also, SVGs from the same path are not re-used throughout the theme, but actually re-created in memory. In particular, borders and background SVGs take up a significant amount of memory. Adding that option will allow a significant reduction in memory consumption.
I'm not making it default because in the code it stated that it was disabled for SVGs because the same SVG can be rasterized at different sizes, and I imagine this change will just keep the first texture it loads, and then resize in runtime as needed, which - if upscaling - may lead to lower quality if effectively re-used in different sizes. 
Tested Carbon and it rendered just fine - I assume it either loads first the larger-sizes controller SVGs, so in the gamelist view it just resizes them to be smaller - or that it's not an issue, as Carbon does re-use the controller SVGs across system and gamelist views. 