### PR TITLE
Make Scraper non-blocking

### DIFF
--- a/es-app/src/components/ScraperSearchComponent.cpp
+++ b/es-app/src/components/ScraperSearchComponent.cpp
@@ -205,6 +205,8 @@ void ScraperSearchComponent::updateViewStyle()
 
 void ScraperSearchComponent::search(const ScraperSearchParams& params)
 {
+	mBlockAccept = true;
+
 	mResultList->clear();
 	mScraperResults.clear();
 	mThumbnailReq.reset();

--- a/es-app/src/scrapers/Scraper.cpp
+++ b/es-app/src/scrapers/Scraper.cpp
@@ -41,7 +41,7 @@ void ScraperSearchHandle::update()
 	if(mStatus == ASYNC_DONE)
 		return;
 
-	while(!mRequestQueue.empty())
+	if(!mRequestQueue.empty())
 	{
 		auto& req = mRequestQueue.front();
 		AsyncHandleStatus status = req->status();
@@ -62,7 +62,6 @@ void ScraperSearchHandle::update()
 		if(status == ASYNC_DONE)
 		{
 			mRequestQueue.pop();
-			continue;
 		}
 
 		// status == ASYNC_IN_PROGRESS


### PR DESCRIPTION
The changes in scrapper.cpp make it non-blocking and the 'mBlockAccept = true;' makes ScraperSearchComponent::render and ::update use and show mBusyAnim.

Maybe there's a better way to show the BusyComponent but it works for me.