### PR TITLE
use clip rects to prevent views overflow onto other views

### DIFF
--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -455,6 +455,7 @@ void SystemView::renderExtras(const Eigen::Affine3f& trans, float lower, float u
 		else
 			extrasTrans.translate(Eigen::Vector3f(0, (i - mExtrasCamOffset) * mSize.y(), 0));
 
+		Renderer::pushClipRect(Eigen::Vector2i(extrasTrans.translation()[0], extrasTrans.translation()[1]), mSize.cast<int>());
 		SystemViewData data = mEntries.at(index).data;
 		for(unsigned int j = 0; j < data.backgroundExtras.size(); j++)
 		{
@@ -463,6 +464,7 @@ void SystemView::renderExtras(const Eigen::Affine3f& trans, float lower, float u
 				extra->render(extrasTrans);
 			}
 		}
+		Renderer::popClipRect();
 	}
 	Renderer::popClipRect();
 }

--- a/es-app/src/views/gamelist/IGameListView.cpp
+++ b/es-app/src/views/gamelist/IGameListView.cpp
@@ -41,3 +41,11 @@ HelpStyle IGameListView::getHelpStyle()
 	style.applyTheme(mTheme, getName());
 	return style;
 }
+
+void IGameListView::render(const Eigen::Affine3f& parentTrans)
+{
+	Eigen::Affine3f trans = parentTrans * getTransform();
+	Renderer::pushClipRect(Eigen::Vector2i(trans.translation()[0],trans.translation()[1]), Eigen::Vector2i(Renderer::getScreenWidth(), Renderer::getScreenHeight()));
+	renderChildren(trans);
+	Renderer::popClipRect();
+}

--- a/es-app/src/views/gamelist/IGameListView.h
+++ b/es-app/src/views/gamelist/IGameListView.h
@@ -37,6 +37,8 @@ public:
 	virtual const char* getName() const = 0;
 
 	virtual HelpStyle getHelpStyle() override;
+
+	void render(const Eigen::Affine3f& parentTrans) override;
 protected:
 	FileData* mRoot;
 	std::shared_ptr<ThemeData> mTheme;


### PR DESCRIPTION
Fix for issues with view elements overflowing into "adjacent" views.

https://retropie.org.uk/forum/topic/10635/theme-backgrounds-getting-cut-1-4
https://retropie.org.uk/forum/topic/9785/z-index-support-for-themes/27