### PR TITLE
Fixes for USB sound cards

### DIFF
--- a/es-app/src/VolumeControl.cpp
+++ b/es-app/src/VolumeControl.cpp
@@ -1,4 +1,5 @@
 #include "VolumeControl.h"
+#include "Settings.h"
 
 #include "Log.h"
 
@@ -73,6 +74,10 @@ void VolumeControl::init()
 	//try to open mixer device
 	if (mixerHandle == nullptr)
 	{
+		#ifdef _RPI_
+		mixerName = Settings::getInstance()->getString("AudioDevice").c_str();
+		#endif
+
 		snd_mixer_selem_id_alloca(&mixerSelemId);
 		//sets simple-mixer index and name
 		snd_mixer_selem_id_set_index(mixerSelemId, mixerIndex);

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -81,6 +81,15 @@ void Settings::setDefaults()
 	// we don't get a warning if we encounter it on a different platform
 	mBoolMap["VideoOmxPlayer"] = false;
 	mBoolMap["VideoAudio"] = true;
+	// Audio out device for Video playback using OMX player.
+	mStringMap["OMXAudioDev"] = "both";
+
+	// Audio out device for volume control
+	#ifdef _RPI_
+		mStringMap["AudioDevice"] = "PCM";
+	#else
+		mStringMap["AudioDevice"] = "Master";
+	#endif
 
 }
 


### PR DESCRIPTION
- Ability to change device used for Volume control (PCM/Speaker/Master) only on Pi.
- Ability to change Audio device used for OMX player (local/hdmi/both/ALSA:HW:0,0/ALSA:HW:1,0)
