### PR TITLE
Added a new (missing) transition style, 'carousel slide'.

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -176,6 +176,7 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 			transitions.push_back("fade");
 			transitions.push_back("slide");
 			transitions.push_back("simple slide");
+			transitions.push_back("carousel slide");
 			transitions.push_back("instant");
 			for(auto it = transitions.begin(); it != transitions.end(); it++)
 				transition_style->add(*it, *it, Settings::getInstance()->getString("TransitionStyle") == *it);

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -286,8 +286,8 @@ void SystemView::onCursorChanged(const CursorState& state)
 			this->mCamOffset = f;
 			this->mExtrasCamOffset = f;
 		}, 500);
-	} else if (transition_style == "simple slide") {
-		// simple slide
+	} else if (transition_style == "simple slide" || transition_style == "carousel slide") {
+		// simple & carousel slide
 		anim = new LambdaAnimation(
 			[this, startPos, endPos, posMax](float t)
 		{


### PR DESCRIPTION
During development of my own EmulationStation skin, I was missing a transition style that only animates the carousel. Instead of creating a feature request I have tried to do it myself.

I was able to create this small change and builded and tested it succesfully on windows and linux.