### PR TITLE
fix gamelist sizing by using max of computed size vs set size

### DIFF
--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -143,7 +143,7 @@ void TextListComponent<T>::render(const Eigen::Affine3f& parentTrans)
 	if(size() == 0)
 		return;
 
-	const float entrySize = font->getSize() * mLineSpacing;
+	const float entrySize = std::max(font->getHeight(1.0), (float)font->getSize()) * mLineSpacing;
 
 	int startEntry = 0;
 
@@ -350,7 +350,9 @@ void TextListComponent<T>::applyTheme(const std::shared_ptr<ThemeData>& theme, c
 	}
 
 	setFont(Font::getFromTheme(elem, properties, mFont));
-	
+	const float selectorHeight = std::max(mFont->getHeight(1.0), (float)mFont->getSize()) * mLineSpacing;
+	setSelectorHeight(selectorHeight);
+
 	if(properties & SOUND && elem->has("scrollSound"))
 		setSound(Sound::get(elem->get<std::string>("scrollSound")));
 
@@ -384,8 +386,6 @@ void TextListComponent<T>::applyTheme(const std::shared_ptr<ThemeData>& theme, c
 		if(elem->has("selectorHeight"))
 		{
 			setSelectorHeight(elem->get<float>("selectorHeight") * Renderer::getScreenHeight());
-		} else {
-			setSelectorHeight(mFont->getSize() * 1.5);
 		}
 		if(elem->has("selectorOffsetY"))
 		{


### PR DESCRIPTION
When I originally implemented these changes, for the themes that I focused on, the computed size of the font was slightly smaller than the size specified in the theme.  Unexpectedly, for some themes the opposite was true, and in some cases the difference was pretty big.  This caused the issues reported in #164.  The fix is pretty simple, it is just comparing the two sizes and using the larger value.