### PR TITLE
Implement Power Savings feature

### DIFF
--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -86,7 +86,7 @@ protected:
 	virtual void onCursorChanged(const CursorState& state);
 
 private:
-	static const int MARQUEE_DELAY = 2000;
+	static const int MARQUEE_DELAY = 1000;
 	static const int MARQUEE_SPEED = 8;
 	static const int MARQUEE_RATE = 1;
 

--- a/es-app/src/guis/GuiGameScraper.cpp
+++ b/es-app/src/guis/GuiGameScraper.cpp
@@ -6,6 +6,7 @@
 #include "scrapers/Scraper.h"
 #include "Renderer.h"
 #include "Log.h"
+#include "PowerSaver.h"
 #include "Settings.h"
 
 GuiGameScraper::GuiGameScraper(Window* window, ScraperSearchParams params, std::function<void(const ScraperSearchResult&)> doneFunc) : GuiComponent(window), 
@@ -14,6 +15,7 @@ GuiGameScraper::GuiGameScraper(Window* window, ScraperSearchParams params, std::
 	mSearchParams(params),
 	mClose(false)
 {
+	PowerSaver::setState(false);
 	addChild(&mBox);
 	addChild(&mGrid);
 
@@ -96,6 +98,7 @@ bool GuiGameScraper::input(InputConfig* config, Input input)
 {
 	if(config->isMappedTo("b", input) && input.value)
 	{
+		PowerSaver::setState(true);
 		delete this;
 		return true;
 	}

--- a/es-app/src/guis/GuiScraperMulti.cpp
+++ b/es-app/src/guis/GuiScraperMulti.cpp
@@ -3,6 +3,7 @@
 #include "Log.h"
 #include "views/ViewController.h"
 #include "Gamelist.h"
+#include "PowerSaver.h"
 
 #include "components/TextComponent.h"
 #include "components/ButtonComponent.h"
@@ -18,6 +19,7 @@ GuiScraperMulti::GuiScraperMulti(Window* window, const std::queue<ScraperSearchP
 {
 	assert(mSearchQueue.size());
 
+	PowerSaver::setState(false);
 	addChild(&mBackground);
 	addChild(&mGrid);
 
@@ -93,6 +95,7 @@ void GuiScraperMulti::doNextSearch()
 {
 	if(mSearchQueue.empty())
 	{
+		PowerSaver::setState(true);
 		finish();
 		return;
 	}

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -2,6 +2,7 @@
 #include "Log.h"
 #include "SystemData.h"
 #include "Settings.h"
+#include "PowerSaver.h"
 
 #include "views/gamelist/BasicGameListView.h"
 #include "views/gamelist/DetailedGameListView.h"
@@ -71,6 +72,7 @@ void ViewController::goToSystemView(SystemData* system)
 
 	systemList->goToSystem(system, false);
 	mCurrentView = systemList;
+	PowerSaver::setState(true);
 
 	playViewTransition();
 }

--- a/es-core/CMakeLists.txt
+++ b/es-core/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CORE_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/InputManager.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Log.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/platform.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/PowerSaver.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Renderer.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Settings.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Sound.h
@@ -73,6 +74,7 @@ set(CORE_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/InputManager.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Log.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/platform.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/PowerSaver.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Renderer_draw_gl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Renderer_init_sdlgl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Settings.cpp

--- a/es-core/src/PowerSaver.cpp
+++ b/es-core/src/PowerSaver.cpp
@@ -1,0 +1,44 @@
+#include "PowerSaver.h"
+#include "Settings.h"
+#include <string.h>
+
+bool PowerSaver::mState = true;
+int PowerSaver::mTimeout = PowerSaver::ps_default;
+
+void PowerSaver::init(bool state)
+{
+	setState(true);
+	updateTimeout();
+}
+
+int PowerSaver::getTimeout()
+{
+	return mTimeout;
+}
+
+void PowerSaver::updateTimeout()
+{
+	std::string mode = Settings::getInstance()->getString("PowerSaverMode");
+	
+	if (mode == "disabled") {
+		mTimeout = ps_disabled;
+	} else if (mode == "instant") {
+		mTimeout = ps_instant;
+	} else if (mode == "enhanced") {
+		mTimeout = ps_enhanced;
+	} else { // default
+		mTimeout = ps_default;
+	}
+}
+
+bool PowerSaver::getState()
+{
+	return mState;
+}
+
+void PowerSaver::setState(bool state)
+{
+	bool ps_enabled = Settings::getInstance()->getString("PowerSaverMode") != "disabled";
+	mState = ps_enabled && state;
+}
+

--- a/es-core/src/PowerSaver.h
+++ b/es-core/src/PowerSaver.h
@@ -1,0 +1,17 @@
+class PowerSaver
+{
+public:
+	enum ps_state : int { ps_disabled = -1, ps_instant = 200, ps_enhanced = 3000, ps_default = 10000 };
+	
+	static void init(bool state = true);
+	
+	static int getTimeout();
+	static void updateTimeout();
+
+	static bool getState();
+	static void setState(bool state);
+	
+private:
+	static bool mState;
+	static int mTimeout;
+};

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -81,6 +81,7 @@ void Settings::setDefaults()
 	mBoolMap["ScreenSaverControls"] = true;
 	mStringMap["ScreenSaverGameInfo"] = "never";
 	mBoolMap["StretchVideoOnScreenSaver"] = false;
+	mStringMap["PowerSaverMode"] = "default";
 
 	// This setting only applies to raspberry pi but set it for all platforms so
 	// we don't get a warning if we encounter it on a different platform

--- a/es-core/src/components/ScrollableContainer.cpp
+++ b/es-core/src/components/ScrollableContainer.cpp
@@ -2,8 +2,8 @@
 #include "Renderer.h"
 #include "Log.h"
 
-#define AUTO_SCROLL_RESET_DELAY 10000 // ms to reset to top after we reach the bottom
-#define AUTO_SCROLL_DELAY 8000 // ms to wait before we start to scroll
+#define AUTO_SCROLL_RESET_DELAY 3000 // ms to reset to top after we reach the bottom
+#define AUTO_SCROLL_DELAY 1000 // ms to wait before we start to scroll
 #define AUTO_SCROLL_SPEED 50 // ms between scrolls
 
 ScrollableContainer::ScrollableContainer(Window* window) : GuiComponent(window), 

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -3,11 +3,13 @@
 #include "ThemeData.h"
 #include "Util.h"
 #include "Settings.h"
+#include "PowerSaver.h"
+
 #ifdef WIN32
 #include <codecvt>
 #endif
 
-libvlc_instance_t*		VideoVlcComponent::mVLC = NULL;
+libvlc_instance_t* VideoVlcComponent::mVLC = NULL;
 
 // VLC prepares to render a video frame.
 static void *lock(void *data, void **p_pixels) {
@@ -289,7 +291,7 @@ void VideoVlcComponent::startVideo()
 			mMedia = libvlc_media_new_path(mVLC, path.c_str());
 			if (mMedia)
 			{
-				unsigned 	track_count;
+				unsigned track_count;
 				// Get the media metadata so we can find the aspect ratio
 				libvlc_media_parse(mMedia);
 				libvlc_media_track_t** tracks;
@@ -328,6 +330,7 @@ void VideoVlcComponent::startVideo()
 						}
 					}
 #endif
+					PowerSaver::setState(false);
 					setupContext();
 
 					// Setup the media player
@@ -358,6 +361,7 @@ void VideoVlcComponent::stopVideo()
 	// Release the media player so it stops calling back to us
 	if (mMediaPlayer)
 	{
+		PowerSaver::setState(true);
 		libvlc_media_player_stop(mMediaPlayer);
 		libvlc_media_player_release(mMediaPlayer);
 		libvlc_media_release(mMedia);


### PR DESCRIPTION
Major changes:

- Change Power Saver (PS) from Other Settings menu
- 4 Modes are available : Disabled, Default [default], Enhanced, Instant
- Disabled : PS is disabled and redundant frames are rendered constantly
- Default : PS is triggered after Description has scrolled once
- Enhanced : PS is triggered after Game Name scrolls once. Use when you don't need/read Description. 
- Instant : Goes well with Instant Transition Style and Carousel transition disabled.
- All modes work well with Screensavers and Video previews.
- PS is disabled while running Videos through VLC.
- PS is disabled while Scrapping 
- Game counts are shown immediately if in Instant Mode
- PS mode defaults if Transitions are changed while in Instant Mode

Saves 40-45% CPU consumption on single core Pi 1/0/0w and 10% on quad core Pi 2/3

**Notice to those planning on Features with animations**
You need to disable(pause) PS before starting animations and enable(resume) it back after animation ends to honour user settings. This can be done on a higer level by calling corresponding functions at a prior stage of processing. `set` method is forced by the parameter passed and user settings. PS is only enabled when PS is set to true and User has selected to have PS enabled. If even one of the conditions is not met then PS is disabled. This allows both, the user and developer to have maximum control on PowerSaver settings. If user has disabled PS, `set` method does nothing. PS takes care of this behind the scenes to simplify Devs work.

```c++
#import "PowerSaver.h

// To pause PS 
PowerSaver::set(false);

// To resume PS as per user setting
PowerSaver::set(true);

// To have different behaviour based on PS state (eg check if in Instant Mode)
// PowerSaver Modes : ps_disabled, ps_default, ps_enhanced, ps_instant
if (PowerSaver::ps_instant == PowerSaver::getTimeout()) {}
```  