### PR TITLE
variable support for themes

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -6,7 +6,7 @@ EmulationStation allows each system to have its own "theme." A theme is a collec
 The first place ES will check for a theme is in the system's `<path>` folder, for a theme.xml file:
 * `[SYSTEM_PATH]/theme.xml`
 
-If that file doesn't exist, ES will try to find the theme in the current **theme set**.  Theme sets are just a collection of individual system themes arranged in the "themes" folder under some name.  Here's an example:
+If that file doesn't exist, ES will try to find the theme in the current **theme set**.  Theme sets are just a collection of individual system themes arranged in the "themes" folder under some name.  A theme set can provide a default theme that will be used if there is no matching system theme.  Here's an example:
 
 ```
 ...
@@ -23,6 +23,7 @@ If that file doesn't exist, ES will try to find the theme in the current **theme
          common_resources/
             scroll_sound.wav
 
+         theme.xml (Default theme)
       another_theme_set/
          snes/
             theme.xml
@@ -308,6 +309,40 @@ You can now change the order in which elements are rendered by setting `zIndex` 
 	* `text name="logoText"`
 	* `image name="logo"`
 
+### Theme variables
+
+Theme variables can be used to simplify theme construction.  There are 2 types of variables available.
+* System Variables
+* Theme Defined Variables
+
+#### System Variables
+
+System variables are system specific and are derived from the values in es_systems.cfg.
+* `system.name`
+* `system.fullName`
+* `system.theme`
+
+#### Theme Defined Variables
+Variables can also be defined in the theme.
+```
+<variables>
+	<themeColor>8b0000</themeColor>
+</variables>
+```
+
+#### Usage in themes
+Variables can be used to specify the value of a theme property:
+```
+<color>${themeColor}</color>
+```
+
+or to specify only a portion of the value of a theme property:
+
+```
+<color>${themeColor}c0</color>
+<path>./art/logo/${system.theme}.svg</path>
+````
+
 Reference
 =========
 
@@ -444,8 +479,10 @@ Reference
 	- The help system style for this view.
 * `carousel name="systemcarousel"` -ALL
 	- The system logo carousel
-* `image name="logo"` - PATH
+* `image name="logo"` - PATH | COLOR
 	- A logo image, to be displayed in the system logo carousel.
+* `text name="logoText"` - FONT_PATH | COLOR | FORCE_UPPERCASE
+	- A logo text, to be displayed system name in the system logo carousel when no logo is available.
 * `text name="systemInfo"` - ALL
 	- Displays details of the system currently selected in the carousel.
 * You can use extra elements (elements with `extra="true"`) to add your own backgrounds, etc.  They will be displayed behind the carousel, and scroll relative to the carousel.

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -43,21 +43,27 @@ void SystemView::populate()
 		// make logo
 		if(theme->getElement("system", "logo", "image"))
 		{
-			ImageComponent* logo = new ImageComponent(mWindow, false, false);
-			logo->setMaxSize(Eigen::Vector2f(mCarousel.logoSize.x(), mCarousel.logoSize.y()));
-			logo->applyTheme((*it)->getTheme(), "system", "logo", ThemeFlags::PATH);
-			logo->setPosition((mCarousel.logoSize.x() - logo->getSize().x()) / 2,
-				(mCarousel.logoSize.y() - logo->getSize().y()) / 2); // center
-			e.data.logo = std::shared_ptr<GuiComponent>(logo);
+			std::string path = theme->getElement("system", "logo", "image")->get<std::string>("path");
 
-			ImageComponent* logoSelected = new ImageComponent(mWindow, false, false);
-			logoSelected->setMaxSize(Eigen::Vector2f(mCarousel.logoSize.x() * mCarousel.logoScale, mCarousel.logoSize.y() * mCarousel.logoScale));
-			logoSelected->applyTheme((*it)->getTheme(), "system", "logo", ThemeFlags::PATH | ThemeFlags::COLOR);
-			logoSelected->setPosition((mCarousel.logoSize.x() - logoSelected->getSize().x()) / 2,
-				(mCarousel.logoSize.y() - logoSelected->getSize().y()) / 2); // center
-			e.data.logoSelected = std::shared_ptr<GuiComponent>(logoSelected);
+			if(!path.empty() && ResourceManager::getInstance()->fileExists(path))
+			{
+				ImageComponent* logo = new ImageComponent(mWindow, false, false);
+				logo->setMaxSize(Eigen::Vector2f(mCarousel.logoSize.x(), mCarousel.logoSize.y()));
+				logo->applyTheme((*it)->getTheme(), "system", "logo", ThemeFlags::PATH | ThemeFlags::COLOR);
+				logo->setPosition((mCarousel.logoSize.x() - logo->getSize().x()) / 2,
+					(mCarousel.logoSize.y() - logo->getSize().y()) / 2); // center
+				e.data.logo = std::shared_ptr<GuiComponent>(logo);
 
-		}else{
+				ImageComponent* logoSelected = new ImageComponent(mWindow, false, false);
+				logoSelected->setMaxSize(Eigen::Vector2f(mCarousel.logoSize.x() * mCarousel.logoScale, mCarousel.logoSize.y() * mCarousel.logoScale));
+				logoSelected->applyTheme((*it)->getTheme(), "system", "logo", ThemeFlags::PATH | ThemeFlags::COLOR);
+				logoSelected->setPosition((mCarousel.logoSize.x() - logoSelected->getSize().x()) / 2,
+					(mCarousel.logoSize.y() - logoSelected->getSize().y()) / 2); // center
+				e.data.logoSelected = std::shared_ptr<GuiComponent>(logoSelected);
+			}
+		}
+		if (!e.data.logo)
+		{
 			// no logo in theme; use text
 			TextComponent* text = new TextComponent(mWindow,
 				(*it)->getName(),
@@ -65,14 +71,16 @@ void SystemView::populate()
 				0x000000FF,
 				ALIGN_CENTER);
 			text->setSize(mCarousel.logoSize);
+			text->applyTheme((*it)->getTheme(), "system", "logoText", ThemeFlags::FONT_PATH | ThemeFlags::COLOR | ThemeFlags::FORCE_UPPERCASE);
 			e.data.logo = std::shared_ptr<GuiComponent>(text);
 
-			TextComponent* textSelected = new TextComponent(mWindow,
-				(*it)->getName(),
-				Font::get((int)(FONT_SIZE_LARGE * 1.5)),
+			TextComponent* textSelected = new TextComponent(mWindow, 
+				(*it)->getName(), 
+				Font::get((int)(FONT_SIZE_LARGE * mCarousel.logoScale)),
 				0x000000FF,
 				ALIGN_CENTER);
 			textSelected->setSize(mCarousel.logoSize);
+			textSelected->applyTheme((*it)->getTheme(), "system", "logoText", ThemeFlags::FONT_PATH | ThemeFlags::COLOR | ThemeFlags::FORCE_UPPERCASE);
 			e.data.logoSelected = std::shared_ptr<GuiComponent>(textSelected);
 		}
 

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <boost/filesystem.hpp>
 #include <boost/variant.hpp>
+#include <boost/xpressive/xpressive.hpp>
 #include <Eigen/Dense>
 #include "pugixml/src/pugixml.hpp"
 #include "GuiComponent.h"
@@ -111,7 +112,7 @@ public:
 	ThemeData();
 
 	// throws ThemeException
-	void loadFile(const std::string& path);
+	void loadFile(std::map<std::string, std::string> sysDataMap, const std::string& path);
 
 	enum ElementPropertyType
 	{
@@ -145,6 +146,7 @@ private:
 
 	void parseFeatures(const pugi::xml_node& themeRoot);
 	void parseIncludes(const pugi::xml_node& themeRoot);
+	void parseVariables(const pugi::xml_node& root);
 	void parseViews(const pugi::xml_node& themeRoot);
 	void parseView(const pugi::xml_node& viewNode, ThemeView& view);
 	void parseElement(const pugi::xml_node& elementNode, const std::map<std::string, ElementPropertyType>& typeMap, ThemeElement& element);


### PR DESCRIPTION
Themes can define variables that can then be referenced later in the the theme.  There are also a few predefined variables that are populated based on values in es_systems.cfg.
Example:
```
<!-- Defined Variables -->
<variables>
	<themeColor>8b0000</themeColor>
</variables>

<!-- Reference variables -->
<color>${themeColor}c0</color>
<path>./art/logo/${system.theme}.svg</path>
```

Themes can also provide a default theme that will be used when there isn't a matching system theme.  Default theme must be named theme.xml and be found in root of theme directory.

In addition, logoText (used on system view when a logo is unavailable) can now be themed.

Use of variables is optional and existing themes should continue to work as before.

Here is an example of how theme creation can be simplified with this feature.  I modified carbon to use variables.  With these changes the theme only has 1 xml file.
https://github.com/jrassa/es-theme-carbon-var
