### PR TITLE
Returned 'JUMP TO LETTER' option back to top of menu, as it is the most

### DIFF
--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -14,26 +14,6 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 	bool isFiltered = system->getIndex()->isFiltered();
 	ComponentListRow row;
 
-	// show filtered menu
-	row.elements.clear();
-	row.addElement(std::make_shared<TextComponent>(mWindow, "FILTER GAMELIST", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
-	row.addElement(makeArrow(mWindow), false);
-	row.makeAcceptInputHandler(std::bind(&GuiGamelistOptions::openGamelistFilter, this));
-	mMenu.addRow(row);
-
-	row.elements.clear();
-	row.addElement(std::make_shared<TextComponent>(mWindow, "SURPRISE ME!", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
-	row.input_handler = [&](InputConfig* config, Input input) {
-		if (config->isMappedTo("a", input) && input.value)
-		{
-			ViewController::get()->goToRandomGame();
-			delete this;
-			return true;
-		}
-		return false;
-	};
-	mMenu.addRow(row);
-
 	if (!fromPlaceholder) {
 
 		if (!isFiltered) {
@@ -80,6 +60,26 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 		row.makeAcceptInputHandler(std::bind(&GuiGamelistOptions::openMetaDataEd, this));
 		mMenu.addRow(row);
 	}
+
+	// show filtered menu
+	row.elements.clear();
+	row.addElement(std::make_shared<TextComponent>(mWindow, "FILTER GAMELIST", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+	row.addElement(makeArrow(mWindow), false);
+	row.makeAcceptInputHandler(std::bind(&GuiGamelistOptions::openGamelistFilter, this));
+	mMenu.addRow(row);
+
+	row.elements.clear();
+	row.addElement(std::make_shared<TextComponent>(mWindow, "SURPRISE ME!", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+	row.input_handler = [&](InputConfig* config, Input input) {
+		if (config->isMappedTo("a", input) && input.value)
+		{
+			ViewController::get()->goToRandomGame();
+			delete this;
+			return true;
+		}
+		return false;
+	};
+	mMenu.addRow(row);
 
 	// center the menu
 	setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());


### PR DESCRIPTION
used/useful feature.

Also, this is where it previously was:
![image](https://user-images.githubusercontent.com/13054748/27883188-972fcaf2-61c7-11e7-8c2b-a91d50d5d7c7.png)

I have seen someone else bothered by how it was changed the forum but can't find the post now :(