### PR TITLE
Moving slider entries in the menus back to the top

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -70,6 +70,12 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 		[this] {
 			auto s = new GuiSettings(mWindow, "SOUND SETTINGS");
 
+			// volume
+			auto volume = std::make_shared<SliderComponent>(mWindow, 0.f, 100.f, 1.f, "%");
+			volume->setValue((float)VolumeControl::getInstance()->getVolume());
+			s->addWithLabel("SYSTEM VOLUME", volume);
+			s->addSaveFunc([volume] { VolumeControl::getInstance()->setVolume((int)round(volume->getValue())); });
+
 			#ifdef _RPI_
 				// volume control device
 				auto vol_dev = std::make_shared< OptionListComponent<std::string> >(mWindow, "AUDIO DEVICE", false);
@@ -86,12 +92,6 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 					VolumeControl::getInstance()->init();
 				});
 			#endif
-
-			// volume
-			auto volume = std::make_shared<SliderComponent>(mWindow, 0.f, 100.f, 1.f, "%");
-			volume->setValue((float)VolumeControl::getInstance()->getVolume());
-			s->addWithLabel("SYSTEM VOLUME", volume);
-			s->addSaveFunc([volume] { VolumeControl::getInstance()->setVolume((int)round(volume->getValue())); });
 
 			// disable sounds
 			auto sounds_enabled = std::make_shared<SwitchComponent>(mWindow);
@@ -247,6 +247,12 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 		[this] {
 			auto s = new GuiSettings(mWindow, "OTHER SETTINGS");
 
+			// maximum vram
+			auto max_vram = std::make_shared<SliderComponent>(mWindow, 0.f, 1000.f, 10.f, "Mb");
+			max_vram->setValue((float)(Settings::getInstance()->getInt("MaxVRAM")));
+			s->addWithLabel("VRAM LIMIT", max_vram);
+			s->addSaveFunc([max_vram] { Settings::getInstance()->setInt("MaxVRAM", (int)round(max_vram->getValue())); });
+
 			// gamelists
 			auto save_gamelists = std::make_shared<SwitchComponent>(mWindow);
 			save_gamelists->setState(Settings::getInstance()->getBool("SaveGamelistsOnExit"));
@@ -277,12 +283,6 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 			});
 
 #endif
-
-			// maximum vram
-			auto max_vram = std::make_shared<SliderComponent>(mWindow, 0.f, 1000.f, 10.f, "Mb");
-			max_vram->setValue((float)(Settings::getInstance()->getInt("MaxVRAM")));
-			s->addWithLabel("VRAM LIMIT", max_vram);
-			s->addSaveFunc([max_vram] { Settings::getInstance()->setInt("MaxVRAM", (int)round(max_vram->getValue())); });
 
 			// framerate
 			auto framerate = std::make_shared<SwitchComponent>(mWindow);


### PR DESCRIPTION
As some controllers have trouble navigating the menus when sliders are not on top.
The component hasn’t been changed since Aloshi’s time, so this probably has been around since ever.
Alas, I cannot reproduce it with my controller, so this is the best I can do for the time being.

Addresses #176 .