### PR TITLE
Fixing random game selection, and aligning menus

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -383,13 +383,12 @@ SystemData* SystemData::getRandomSystem()
 	}
 
 	// get random number in range
-	int target = std::round(((double)std::rand() / (double)RAND_MAX) * total);
-
+	int target = std::round(((double)std::rand() / (double)RAND_MAX) * (total - 1));
 	for (auto it = sSystemVector.begin(); it != sSystemVector.end(); it++)
 	{
 		if ((*it)->isGameSystem())
 		{
-			if (target >= 0)
+			if (target > 0)
 			{
 				target--;
 			}
@@ -406,7 +405,7 @@ FileData* SystemData::getRandomGame()
 	std::vector<FileData*> list = mRootFolder->getFilesRecursive(GAME, true);
 	unsigned int total = list.size();
 	// get random number in range
-	int target = std::round(((double)std::rand() / (double)RAND_MAX) * total);
+	int target = std::round(((double)std::rand() / (double)RAND_MAX) * (total - 1));
 	return list.at(target);
 }
 

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -69,19 +69,6 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 	row.makeAcceptInputHandler(std::bind(&GuiGamelistOptions::openGamelistFilter, this));
 	mMenu.addRow(row);
 
-	row.elements.clear();
-	row.addElement(std::make_shared<TextComponent>(mWindow, "SURPRISE ME!", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
-	row.input_handler = [&](InputConfig* config, Input input) {
-		if (config->isMappedTo("a", input) && input.value)
-		{
-			ViewController::get()->goToRandomGame();
-			delete this;
-			return true;
-		}
-		return false;
-	};
-	mMenu.addRow(row);
-
 	// center the menu
 	setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
 	mMenu.setPosition((mSize.x() - mMenu.getSize().x()) / 2, (mSize.y() - mMenu.getSize().y()) / 2);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -373,12 +373,8 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 	addChild(&mMenu);
 	addChild(&mVersion);
 
-	/*int menuWidth = Renderer::getScreenWidth() * 0.4f;
-	int menuHeight = Renderer::getScreenHeight() * 0.74f;
-	mMenu.setSize(menuWidth, menuHeight);*/
-
 	setSize(mMenu.getSize());
-	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, Renderer::getScreenHeight() * 0.13f);
+	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, Renderer::getScreenHeight() * 0.15f);
 }
 
 void GuiMenu::openScreensaverOptions() {


### PR DESCRIPTION
- Fixing off-by-one error when selecting games from list
- Update system exclusion list for random selection
- Removed "Surprise Me!" option from menu
- Update menu alignment

---

Sorry about that. A small quick fix from the random selection refactoring. It was crashing with a off-by-one error when the random number ended up being larger than the list size.