### PR TITLE
Skip hidden *nix files when populating gamelists.

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -63,6 +63,21 @@ void SystemData::setIsGameSystemStatus()
 	mIsGameSystem = (mName != "retropie");
 }
 
+#ifndef WIN32
+// test to see if a file is hidden in *nix (dot-prefixed)
+// could be expanded to check for Windows hidden attribute
+bool isHidden(const fs::path &filePath)
+{
+	fs::path::string_type fileName = filePath.filename().string();
+	if(fileName[0] == '.')
+	{
+		return true;
+	}
+
+	return false;
+}
+#endif
+
 void SystemData::populateFolder(FileData* folder)
 {
 	const fs::path& folderPath = folder->getPath();
@@ -88,6 +103,7 @@ void SystemData::populateFolder(FileData* folder)
 	fs::path filePath;
 	std::string extension;
 	bool isGame;
+	bool showHidden = Settings::getInstance()->getBool("ShowHiddenFiles");
 	for(fs::directory_iterator end, dir(folderPath); dir != end; ++dir)
 	{
 		filePath = (*dir).path();
@@ -105,6 +121,12 @@ void SystemData::populateFolder(FileData* folder)
 		isGame = false;
 		if(std::find(mEnvData->mSearchExtensions.begin(), mEnvData->mSearchExtensions.end(), extension) != mEnvData->mSearchExtensions.end())
 		{
+#ifndef WIN32
+			// skip hidden files
+			if(!showHidden && isHidden(filePath))
+				continue;
+#endif
+
 			FileData* newGame = new FileData(GAME, filePath.generic_string(), mEnvData, this);
 			folder->addChild(newGame);
 			isGame = true;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -268,6 +268,14 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 			s->addWithLabel("PARSE GAMESLISTS ONLY", parse_gamelists);
 			s->addSaveFunc([parse_gamelists] { Settings::getInstance()->setBool("ParseGamelistOnly", parse_gamelists->getState()); });
 
+#ifndef WIN32
+			// hidden files
+			auto hidden_files = std::make_shared<SwitchComponent>(mWindow);
+			hidden_files->setState(Settings::getInstance()->getBool("ShowHiddenFiles"));
+			s->addWithLabel("SHOW HIDDEN FILES", hidden_files);
+			s->addSaveFunc([hidden_files] { Settings::getInstance()->setBool("ShowHiddenFiles", hidden_files->getState()); });
+#endif
+
 #ifdef _RPI_
 			// Video Player - VideoOmxPlayer
 			auto omx_player = std::make_shared<SwitchComponent>(mWindow);

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -50,6 +50,11 @@ bool parseArgs(int argc, char* argv[], unsigned int* width, unsigned int* height
 		}else if(strcmp(argv[i], "--ignore-gamelist") == 0)
 		{
 			Settings::getInstance()->setBool("IgnoreGamelist", true);
+#ifndef WIN32
+		}else if(strcmp(argv[i], "--show-hidden-files") == 0)
+		{
+			Settings::getInstance()->setBool("ShowHiddenFiles", true);			
+#endif
 		}else if(strcmp(argv[i], "--draw-framerate") == 0)
 		{
 			Settings::getInstance()->setBool("DrawFramerate", true);

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -41,6 +41,7 @@ void Settings::setDefaults()
 
 	mBoolMap["BackgroundJoystickInput"] = false;
 	mBoolMap["ParseGamelistOnly"] = false;
+	mBoolMap["ShowHiddenFiles"] = false;
 	mBoolMap["DrawFramerate"] = false;
 	mBoolMap["ShowExit"] = true;
 	mBoolMap["Windowed"] = false;


### PR DESCRIPTION
Re-do of  #182 - turns out adding options was pretty easy to do blind :)

- Has option in 'OTHER SETTINGS' - 'SHOW HIDDEN FILES' - defaults to false
- Re-wrote function myself.
- Removed folder check - existing ES didn't seem to show hidden directories anyway, so it would never go into my function.
- Requires ES restart to take effect.

Will do one final test tonight.