### PR TITLE
fix default font sizes when running in vertical orientation

### DIFF
--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -11,10 +11,10 @@
 
 class TextCache;
 
-#define FONT_SIZE_MINI ((unsigned int)(0.030f * Renderer::getScreenHeight()))
-#define FONT_SIZE_SMALL ((unsigned int)(0.035f * Renderer::getScreenHeight()))
-#define FONT_SIZE_MEDIUM ((unsigned int)(0.045f * Renderer::getScreenHeight()))
-#define FONT_SIZE_LARGE ((unsigned int)(0.085f * Renderer::getScreenHeight()))
+#define FONT_SIZE_MINI ((unsigned int)(0.030f * std::min(Renderer::getScreenHeight(), Renderer::getScreenWidth())))
+#define FONT_SIZE_SMALL ((unsigned int)(0.035f * std::min(Renderer::getScreenHeight(), Renderer::getScreenWidth())))
+#define FONT_SIZE_MEDIUM ((unsigned int)(0.045f * std::min(Renderer::getScreenHeight(), Renderer::getScreenWidth())))
+#define FONT_SIZE_LARGE ((unsigned int)(0.085f * std::min(Renderer::getScreenHeight(), Renderer::getScreenWidth())))
 
 #define FONT_PATH_LIGHT ":/opensans_hebrew_condensed_light.ttf"
 #define FONT_PATH_REGULAR ":/opensans_hebrew_condensed_regular.ttf"


### PR DESCRIPTION
Adjusts default font sizes when ES is running in vertical orientation.  Previously the font sizes were based on the screen height.  When running in vertical orientation, the screen height is larger, which results in larger default fonts.  This can cause rendering issues for the menus.