### PR TITLE
Backup previous session's Log file

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -222,6 +222,7 @@ int main(int argc, char* argv[])
 		return 1;
 
 	//start the logger
+	Log::init();
 	Log::open();
 	LOG(LogInfo) << "EmulationStation - v" << PROGRAM_VERSION_STRING << ", built " << PROGRAM_BUILT_STRING;
 

--- a/es-core/src/Log.cpp
+++ b/es-core/src/Log.cpp
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>
+#include <stdio.h>
 #include "platform.h"
 
 LogLevel Log::reportingLevel = LogInfo;
@@ -21,6 +22,14 @@ std::string Log::getLogPath()
 void Log::setReportingLevel(LogLevel level)
 {
 	reportingLevel = level;
+}
+
+void Log::init()
+{
+	remove((getLogPath() + ".bak").c_str());
+	// rename previous log file
+	rename(getLogPath().c_str(), (getLogPath() + ".bak").c_str());
+	return;
 }
 
 void Log::open()

--- a/es-core/src/Log.h
+++ b/es-core/src/Log.h
@@ -24,6 +24,7 @@ public:
 	static std::string getLogPath();
 
 	static void flush();
+	static void init();
 	static void open();
 	static void close();
 protected:


### PR DESCRIPTION
Small change to always keeps one session’s log backup file. It's hard to request logs from our users as restarting ES/RetroPie will always erase the previous session's log file.

