### PR TITLE
added origin and rotation support to guicomponent, exposed as theme o…

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -517,6 +517,10 @@ Can be created as an extra.
 	- The image will be resized as large as possible so that it fits within this size and maintains its aspect ratio.  Use this instead of `size` when you don't know what kind of image you're using so it doesn't get grossly oversized on one axis (e.g. with a game's image metadata).
 * `origin` - type: NORMALIZED_PAIR.
 	- Where on the image `pos` refers to.  For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the image exactly in the middle of the screen.  If the "POSITION" and "SIZE" attributes are themable, "ORIGIN" is implied.
+* `rotation` - type: FLOAT.
+	- angle in degrees that the image should be rotated.  Positive values will rotate clockwise, negative values will rotate counterclockwise.
+* `rotationOrigin` - type: NORMALIZED_PAIR.
+	- Point around which the image will be rotated. Defaults to `0.5 0.5`.
 * `path` - type: PATH.
 	- Path to the image file.  Most common extensions are supported (including .jpg, .png, and unanimated .gif).
 * `tile` - type: BOOLEAN.
@@ -535,6 +539,10 @@ Can be created as an extra.
 	- The video will be resized as large as possible so that it fits within this size and maintains its aspect ratio.  Use this instead of `size` when you don't know what kind of video you're using so it doesn't get grossly oversized on one axis (e.g. with a game's video metadata).
 * `origin` - type: NORMALIZED_PAIR.
 	- Where on the image `pos` refers to.  For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the image exactly in the middle of the screen.  If the "POSITION" and "SIZE" attributes are themable, "ORIGIN" is implied.
+* `rotation` - type: FLOAT.
+	- angle in degrees that the text should be rotated.  Positive values will rotate clockwise, negative values will rotate counterclockwise.
+* `rotationOrigin` - type: NORMALIZED_PAIR.
+	- Point around which the text will be rotated. Defaults to `0.5 0.5`.
 * `delay` - type: FLOAT.  Default is false.
 	- Delay in seconds before video will start playing.
 * `default` - type: PATH.
@@ -556,6 +564,12 @@ Can be created as an extra.
 	- `0 0` - automatically size so text fits on one line (expanding horizontally).
 	- `w 0` - automatically wrap text so it doesn't go beyond `w` (expanding vertically).
 	- `w h` - works like a "text box."  If `h` is non-zero and `h` <= `fontSize` (implying it should be a single line of text), text that goes beyond `w` will be truncated with an elipses (...).
+* `origin` - type: NORMALIZED_PAIR.
+	- Where on the component `pos` refers to.  For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the component exactly in the middle of the screen.  If the "POSITION" and "SIZE" attributes are themable, "ORIGIN" is implied.
+* `rotation` - type: FLOAT.
+	- angle in degrees that the text should be rotated.  Positive values will rotate clockwise, negative values will rotate counterclockwise.
+* `rotationOrigin` - type: NORMALIZED_PAIR.
+	- Point around which the text will be rotated. Defaults to `0.5 0.5`.
 * `text` - type: STRING.
 * `color` - type: COLOR.
 * `backgroundColor` - type: COLOR;
@@ -574,6 +588,8 @@ Can be created as an extra.
 
 * `pos` - type: NORMALIZED_PAIR.
 * `size` - type: NORMALIZED_PAIR.
+* `origin` - type: NORMALIZED_PAIR.
+	- Where on the component `pos` refers to.  For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the component exactly in the middle of the screen.  If the "POSITION" and "SIZE" attributes are themable, "ORIGIN" is implied.
 * `selectorColor` - type: COLOR.
 	- Color of the "selector bar."
 * `selectorImagePath` - type: PATH.
@@ -618,6 +634,12 @@ EmulationStation borrows the concept of "nine patches" from Android (or "9-Slice
 * `pos` - type: NORMALIZED_PAIR.
 * `size` - type: NORMALIZED_PAIR.
 	- Only one value is actually used. The other value should be zero.  (e.g. specify width OR height, but not both.  This is done to maintain the aspect ratio.)
+* `origin` - type: NORMALIZED_PAIR.
+	- Where on the component `pos` refers to.  For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the component exactly in the middle of the screen.  If the "POSITION" and "SIZE" attributes are themable, "ORIGIN" is implied.
+* `rotation` - type: FLOAT.
+	- angle in degrees that the rating should be rotated.  Positive values will rotate clockwise, negative values will rotate counterclockwise.
+* `rotationOrigin` - type: NORMALIZED_PAIR.
+	- Point around which the rating will be rotated. Defaults to `0.5 0.5`.
 * `filledPath` - type: PATH.
 	- Path to the "filled star" image.  Image must be square (width equals height).
 * `unfilledPath` - type: PATH.

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -78,7 +78,7 @@ void DetailedGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& them
 	BasicGameListView::onThemeChanged(theme);
 
 	using namespace ThemeFlags;
-	mImage.applyTheme(theme, getName(), "md_image", POSITION | ThemeFlags::SIZE | Z_INDEX);
+	mImage.applyTheme(theme, getName(), "md_image", POSITION | ThemeFlags::SIZE | Z_INDEX | ROTATION);
 
 	initMDLabels();
 	std::vector<TextComponent*> labels = getMDLabels();
@@ -109,7 +109,7 @@ void DetailedGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& them
 
 	mDescContainer.applyTheme(theme, getName(), "md_description", POSITION | ThemeFlags::SIZE | Z_INDEX);
 	mDescription.setSize(mDescContainer.getSize().x(), 0);
-	mDescription.applyTheme(theme, getName(), "md_description", ALL ^ (POSITION | ThemeFlags::SIZE | TEXT));
+	mDescription.applyTheme(theme, getName(), "md_description", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
 
 	sortChildren();
 }

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -114,9 +114,9 @@ void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 	BasicGameListView::onThemeChanged(theme);
 
 	using namespace ThemeFlags;
-	mMarquee.applyTheme(theme, getName(), "md_marquee", POSITION | ThemeFlags::SIZE | Z_INDEX);
-	mImage.applyTheme(theme, getName(), "md_image", POSITION | ThemeFlags::SIZE | Z_INDEX);
-	mVideo->applyTheme(theme, getName(), "md_video", POSITION | ThemeFlags::SIZE | ThemeFlags::DELAY | Z_INDEX);
+	mMarquee.applyTheme(theme, getName(), "md_marquee", POSITION | ThemeFlags::SIZE | Z_INDEX | ROTATION);
+	mImage.applyTheme(theme, getName(), "md_image", POSITION | ThemeFlags::SIZE | Z_INDEX | ROTATION);
+	mVideo->applyTheme(theme, getName(), "md_video", POSITION | ThemeFlags::SIZE | ThemeFlags::DELAY | Z_INDEX | ROTATION);
 
 	initMDLabels();
 	std::vector<TextComponent*> labels = getMDLabels();
@@ -147,7 +147,7 @@ void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 
 	mDescContainer.applyTheme(theme, getName(), "md_description", POSITION | ThemeFlags::SIZE | Z_INDEX);
 	mDescription.setSize(mDescContainer.getSize().x(), 0);
-	mDescription.applyTheme(theme, getName(), "md_description", ALL ^ (POSITION | ThemeFlags::SIZE | TEXT));
+	mDescription.applyTheme(theme, getName(), "md_description", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
 
 	sortChildren();
 }

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -37,20 +37,41 @@ public:
 	virtual void render(const Eigen::Affine3f& parentTrans);
 
 	Eigen::Vector3f getPosition() const;
-	void setPosition(const Eigen::Vector3f& offset);
+	inline void setPosition(const Eigen::Vector3f& offset) { setPosition(offset.x(), offset.y(), offset.z()); }
 	void setPosition(float x, float y, float z = 0.0f);
 	virtual void onPositionChanged() {};
 
+	//Sets the origin as a percentage of this image (e.g. (0, 0) is top left, (0.5, 0.5) is the center)
+	Eigen::Vector2f getOrigin() const;
+	void setOrigin(float originX, float originY);
+	inline void setOrigin(Eigen::Vector2f origin) { setOrigin(origin.x(), origin.y()); }
+	virtual void onOriginChanged() {};
+
+	//Sets the rotation origin as a percentage of this image (e.g. (0, 0) is top left, (0.5, 0.5) is the center)
+	Eigen::Vector2f getRotationOrigin() const;
+	void setRotationOrigin(float originX, float originY);
+	inline void setRotationOrigin(Eigen::Vector2f origin) { setRotationOrigin(origin.x(), origin.y()); }
+
 	Eigen::Vector2f getSize() const;
-    void setSize(const Eigen::Vector2f& size);
+    inline void setSize(const Eigen::Vector2f& size) { setSize(size.x(), size.y()); }
     void setSize(float w, float h);
     virtual void onSizeChanged() {};
+
+	float getRotation() const;
+	void setRotation(float rotation);
+	inline void setRotationDegrees(float rotation) { setRotation(rotation * M_PI / 180); }
+
+	float getScale() const;
+	void setScale(float scale);
 
     float getZIndex() const;
     void setZIndex(float zIndex);
 
     float getDefaultZIndex() const;
     void setDefaultZIndex(float zIndex);
+
+	// Returns the center point of the image (takes origin into account).
+	Eigen::Vector2f getCenter() const;
 
 	void setParent(GuiComponent* parent);
 	GuiComponent* getParent() const;
@@ -119,7 +140,12 @@ protected:
 	std::vector<GuiComponent*> mChildren;
 
 	Eigen::Vector3f mPosition;
+	Eigen::Vector2f mOrigin;
+	Eigen::Vector2f mRotationOrigin;
 	Eigen::Vector2f mSize;
+
+	float mRotation = 0.0;
+	float mScale = 1.0;
 
 	float mDefaultZIndex = 0;
 	float mZIndex = 0;

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -33,6 +33,8 @@ std::map< std::string, ElementMapType > ThemeData::sElementMap = boost::assign::
 		("size", NORMALIZED_PAIR)
 		("maxSize", NORMALIZED_PAIR)
 		("origin", NORMALIZED_PAIR)
+	 	("rotation", FLOAT)
+		("rotationOrigin", NORMALIZED_PAIR)
 		("path", PATH)
 		("tile", BOOLEAN)
 		("color", COLOR)
@@ -40,6 +42,9 @@ std::map< std::string, ElementMapType > ThemeData::sElementMap = boost::assign::
 	("text", makeMap(boost::assign::map_list_of
 		("pos", NORMALIZED_PAIR)
 		("size", NORMALIZED_PAIR)
+		("origin", NORMALIZED_PAIR)
+		("rotation", FLOAT)
+		("rotationOrigin", NORMALIZED_PAIR)
 		("text", STRING)
 		("backgroundColor", COLOR)
 		("fontPath", PATH)
@@ -53,6 +58,7 @@ std::map< std::string, ElementMapType > ThemeData::sElementMap = boost::assign::
 	("textlist", makeMap(boost::assign::map_list_of
 		("pos", NORMALIZED_PAIR)
 		("size", NORMALIZED_PAIR)
+		("origin", NORMALIZED_PAIR)
 		("selectorHeight", FLOAT)
 		("selectorOffsetY", FLOAT)
 		("selectorColor", COLOR)
@@ -72,6 +78,7 @@ std::map< std::string, ElementMapType > ThemeData::sElementMap = boost::assign::
 	("container", makeMap(boost::assign::map_list_of
 		("pos", NORMALIZED_PAIR)
 		("size", NORMALIZED_PAIR)
+	 	("origin", NORMALIZED_PAIR)
 		("zIndex", FLOAT)))
 	("ninepatch", makeMap(boost::assign::map_list_of
 		("pos", NORMALIZED_PAIR)
@@ -89,6 +96,9 @@ std::map< std::string, ElementMapType > ThemeData::sElementMap = boost::assign::
 	("rating", makeMap(boost::assign::map_list_of
 		("pos", NORMALIZED_PAIR)
 		("size", NORMALIZED_PAIR)
+		("origin", NORMALIZED_PAIR)
+		("rotation", FLOAT)
+		("rotationOrigin", NORMALIZED_PAIR)
 		("color", COLOR)
 		("filledPath", PATH)
 		("unfilledPath", PATH)
@@ -106,6 +116,8 @@ std::map< std::string, ElementMapType > ThemeData::sElementMap = boost::assign::
 		("size", NORMALIZED_PAIR)
 		("maxSize", NORMALIZED_PAIR)
 		("origin", NORMALIZED_PAIR)
+		("rotation", FLOAT)
+		("rotationOrigin", NORMALIZED_PAIR)
 		("default", PATH)
 		("delay", FLOAT)
 		("zIndex", FLOAT)

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -40,7 +40,7 @@ namespace ThemeFlags
 		LINE_SPACING = 2048,
 		DELAY = 4096,
 		Z_INDEX = 8192,
-
+		ROTATION = 16384,
 		ALL = 0xFFFFFFFF
 	};
 }

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -25,10 +25,6 @@ public:
 	void onSizeChanged() override;
 	void setOpacity(unsigned char opacity) override;
 
-	//Sets the origin as a percentage of this image (e.g. (0, 0) is top left, (0.5, 0.5) is the center)
-	void setOrigin(float originX, float originY);
-	inline void setOrigin(Eigen::Vector2f origin) { setOrigin(origin.x(), origin.y()); }
-
 	// Resize the image to fit this size. If one axis is zero, scale that axis to maintain aspect ratio.
 	// If both are non-zero, potentially break the aspect ratio.  If both are zero, no resizing.
 	// Can be set before or after an image is loaded.
@@ -51,9 +47,6 @@ public:
 	// Returns the size of the current texture, or (0, 0) if none is loaded.  May be different than drawn size (use getSize() for that).
 	Eigen::Vector2i getTextureSize() const;
 
-	// Returns the center point of the image (takes origin into account).
-	Eigen::Vector2f getCenter() const;
-
 	bool hasImage();
 
 	void render(const Eigen::Affine3f& parentTrans) override;
@@ -63,7 +56,6 @@ public:
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 private:
 	Eigen::Vector2f mTargetSize;
-	Eigen::Vector2f mOrigin;
 
 	bool mFlipX, mFlipY, mTargetIsMax;
 

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -60,7 +60,6 @@ VideoComponent::VideoComponent(Window* window) :
 	mDisable(false),
 	mScreensaverMode(false),
 	mTargetIsMax(false),
-	mOrigin(0, 0),
 	mTargetSize(0, 0)
 {
 	// Setup the default configuration
@@ -84,18 +83,10 @@ VideoComponent::~VideoComponent()
 	remove(getTitlePath().c_str());
 }
 
-void VideoComponent::setOrigin(float originX, float originY)
+void VideoComponent::onOriginChanged()
 {
-	mOrigin << originX, originY;
-
 	// Update the embeded static image
-	mStaticImage.setOrigin(originX, originY);
-}
-
-Eigen::Vector2f VideoComponent::getCenter() const
-{
-	return Eigen::Vector2f(mPosition.x() - (getSize().x() * mOrigin.x()) + getSize().x() / 2,
-		mPosition.y() - (getSize().y() * mOrigin.y()) + getSize().y() / 2);
+	mStaticImage.setOrigin(mOrigin);
 }
 
 void VideoComponent::onSizeChanged()
@@ -220,6 +211,13 @@ void VideoComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 
 	if (elem->has("showSnapshotDelay"))
 		mConfig.showSnapshotDelay = elem->get<bool>("showSnapshotDelay");
+
+	if(properties & ThemeFlags::ROTATION) {
+		if(elem->has("rotation"))
+			setRotationDegrees(elem->get<float>("rotation"));
+		if(elem->has("rotationOrigin"))
+			setRotationOrigin(elem->get<Eigen::Vector2f>("rotationOrigin"));
+	}
 
 	if(properties & ThemeFlags::Z_INDEX && elem->has("zIndex"))
 		setZIndex(elem->get<float>("zIndex"));

--- a/es-core/src/components/VideoComponent.h
+++ b/es-core/src/components/VideoComponent.h
@@ -48,10 +48,7 @@ public:
 	virtual void onScreenSaverDeactivate() override;
 	virtual void topWindow(bool isTop) override;
 
-	//Sets the origin as a percentage of this image (e.g. (0, 0) is top left, (0.5, 0.5) is the center)
-	void setOrigin(float originX, float originY);
-	inline void setOrigin(Eigen::Vector2f origin) { setOrigin(origin.x(), origin.y()); }
-
+	void onOriginChanged() override;
 	void onSizeChanged() override;
 	void setOpacity(unsigned char opacity) override;
 
@@ -61,9 +58,6 @@ public:
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
-
-	// Returns the center point of the video (takes origin into account).
-	Eigen::Vector2f getCenter() const;
 
 	virtual void update(int deltaTime);
 
@@ -100,7 +94,6 @@ private:
 protected:
 	unsigned						mVideoWidth;
 	unsigned						mVideoHeight;
-	Eigen::Vector2f 				mOrigin;
 	Eigen::Vector2f					mTargetSize;
 	std::shared_ptr<TextureResource> mTexture;
 	float							mFadeIn;

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -141,10 +141,10 @@ void VideoVlcComponent::render(const Eigen::Affine3f& parentTrans)
 		float x2;
 		float y2;
 
-		x = -(float)mSize.x() * mOrigin.x();
-		y = -(float)mSize.y() * mOrigin.y();
-		x2 = x+mSize.x();
-		y2 = y+mSize.y();
+		x = 0.0;
+		y = 0.0;
+		x2 = mSize.x();
+		y2 = mSize.y();
 
 		// Define a structure to contain the data for each vertex
 		struct Vertex


### PR DESCRIPTION
added origin and rotation support to guicomponent, exposed as theme options for several components.

Origin support exposed to themes for TextComponent, ScrollableContainer, RatingComponent and TextListComponent.

Rotation support exposed to themes for ImageComponent, TextComponent, and RatingComponent.

@pjft rotation in theory should work for VideoComponent, but I didn't expose it at this time since I am assuming that OMX player probably can't be rotated.