### PR TITLE
Adding slider for video screensaver timeout

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -11,10 +11,10 @@
 #include "Log.h"
 #include "views/ViewController.h"
 #include "views/gamelist/IGameListView.h"
+#include "PowerSaver.h"
 #include <stdio.h>
 
 #define FADE_TIME 			300
-#define SWAP_VIDEO_TIMEOUT	30000
 
 SystemScreenSaver::SystemScreenSaver(Window* window) :
 	mVideoScreensaver(NULL),
@@ -33,6 +33,7 @@ SystemScreenSaver::SystemScreenSaver(Window* window) :
 	if(!boost::filesystem::exists(path))
 		boost::filesystem::create_directory(path);
 	srand((unsigned int)time(NULL));
+	mVideoChangeTime = 30000;
 }
 
 SystemScreenSaver::~SystemScreenSaver()
@@ -58,6 +59,9 @@ void SystemScreenSaver::startScreenSaver()
 {
 	if (!mVideoScreensaver && (Settings::getInstance()->getString("ScreenSaverBehavior") == "random video"))
 	{
+		mVideoChangeTime = Settings::getInstance()->getInt("ScreenSaverSwapVideoTimeout");
+		// we need this to loop through different videos
+		PowerSaver::setState(false);
 		// Configure to fade out the windows
 		mState = STATE_FADE_OUT_WINDOW;
 		mOpacity = 0.0f;
@@ -113,6 +117,8 @@ void SystemScreenSaver::stopScreenSaver()
 {
 	delete mVideoScreensaver;
 	mVideoScreensaver = NULL;
+	// we need this to loop through different videos
+	PowerSaver::setState(true);
 	mState = STATE_INACTIVE;
 }
 
@@ -286,7 +292,7 @@ void SystemScreenSaver::update(int deltaTime)
 	{
 		// Update the timer that swaps the videos
 		mTimer += deltaTime;
-		if (mTimer > SWAP_VIDEO_TIMEOUT)
+		if (mTimer > mVideoChangeTime)
 		{
 			nextVideo();
 		}

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -45,5 +45,6 @@ private:
 	int				mTimer;
 	FileData*		mCurrentGame;
 	std::string		mGameName;
-	std::string		mSystemName;	
+	std::string		mSystemName;
+	int 			mVideoChangeTime;
 };

--- a/es-app/src/guis/GuiScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiScreensaverOptions.cpp
@@ -15,6 +15,12 @@ GuiScreensaverOptions::GuiScreensaverOptions(Window* window, const char* title) 
 {
 	addChild(&mMenu);
 
+	// timeout to swap videos
+	auto swap = std::make_shared<SliderComponent>(mWindow, 10.f, 1000.f, 1.f, "s");
+	swap->setValue((float)(Settings::getInstance()->getInt("ScreenSaverSwapVideoTimeout") / (1000)));
+	addWithLabel("SWAP VIDEO AFTER (SECS)", swap);
+	addSaveFunc([swap] { Settings::getInstance()->setInt("ScreenSaverSwapVideoTimeout", (int)round(swap->getValue()) * (1000)); });
+
 #ifdef _RPI_
 	auto ss_omx = std::make_shared<SwitchComponent>(mWindow);
 	ss_omx->setState(Settings::getInstance()->getBool("ScreenSaverOmxPlayer"));

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -306,14 +306,14 @@ int main(int argc, char* argv[])
 	bool ps_standby = false;
 
 	// assuming screensaver timeout is not updated regularly.
-	int timeout = (unsigned int) Settings::getInstance()->getInt("ScreenSaverTime");
+	int timeout = (unsigned int) Settings::getInstance()->getInt("ScreenSaverTime") - PowerSaver::getTimeout();
 
 	while(running)
 	{
 		SDL_Event event;
 		bool ps_standby = PowerSaver::getState() && SDL_GetTicks() - ps_time > PowerSaver::getTimeout();
-		
-		if(ps_standby ? SDL_WaitEventTimeout(&event, timeout - 100) : SDL_PollEvent(&event))
+
+		if(ps_standby ? SDL_WaitEventTimeout(&event, timeout) : SDL_PollEvent(&event))
 		{
 			do
 			{
@@ -358,7 +358,7 @@ int main(int argc, char* argv[])
 		lastTime = curTime;
 
 		// cap deltaTime
-		if(deltaTime > timeout || deltaTime < 0)
+		if((!ps_standby && ((deltaTime > timeout && timeout > 0) || deltaTime > 1000)) || deltaTime < 0)
 			deltaTime = 1000;
 
 		window.update(deltaTime);

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -94,6 +94,8 @@ void Settings::setDefaults()
 		mBoolMap["ScreenSaverOmxPlayer"] = false;
 	#endif
 
+	mIntMap["ScreenSaverSwapVideoTimeout"] = 30000;
+
 	mBoolMap["VideoAudio"] = true;
 	mBoolMap["CaptionsCompatibility"] = true;
 	// Audio out device for Video playback using OMX player.

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -1,6 +1,7 @@
 #include "components/VideoComponent.h"
 #include "Renderer.h"
 #include "ThemeData.h"
+#include "Settings.h"
 #include "Util.h"
 #include "Window.h"
 #ifdef WIN32
@@ -22,8 +23,11 @@ std::string getTitleFolder() {
 void writeSubtitle(const char* gameName, const char* systemName, bool always)
 {
 	FILE* file = fopen(getTitlePath().c_str(), "w");
+	int end = (int)(Settings::getInstance()->getInt("ScreenSaverSwapVideoTimeout") / (1000));
 	if (always) {
-		fprintf(file, "1\n00:00:01,000 --> 00:00:30,000\n");
+		fprintf(file, "1\n00:00:01,000 --> 00:00:");
+		fprintf(file, std::to_string(end).c_str());
+		fprintf(file, ",000\n");
 	}
 	else
 	{
@@ -33,9 +37,16 @@ void writeSubtitle(const char* gameName, const char* systemName, bool always)
 	fprintf(file, "<i>%s</i>\n\n", systemName);
 
 	if (!always) {
-		fprintf(file, "2\n00:00:26,000 --> 00:00:30,000\n");
-		fprintf(file, "%s\n", gameName);
-		fprintf(file, "<i>%s</i>\n", systemName);
+		if (end > 12)
+		{
+			fprintf(file, "2\n00:00:");
+			fprintf(file, std::to_string(end - 4).c_str());
+			fprintf(file, ",000 --> 00:00:");
+			fprintf(file, std::to_string(end).c_str());
+			fprintf(file, ",000\n");
+			fprintf(file, "%s\n", gameName);
+			fprintf(file, "<i>%s</i>\n", systemName);
+		}
 	}
 
 	fflush(file);


### PR DESCRIPTION
And addressing PowerSaver not allowing videos to change after the expected time.

@hex007 - could you confirm that what I did is the right way to go about it?

Ideally I wouldn't want to disable power saver, but it seems that if I don't the timer will stop refreshing after a bit, causing the videos not to swap during the screensaver. 

I'm happy to submit a separate PR later for that should there be a more elegant way to do it, but for now this seems to be the correct approach in the current setup.