### PR TITLE
PowerSaver Updates

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -4,6 +4,7 @@
 #endif
 #include "components/VideoVlcComponent.h"
 #include "platform.h"
+#include "PowerSaver.h"
 #include "Renderer.h"
 #include "Settings.h"
 #include "SystemData.h"
@@ -100,6 +101,7 @@ void SystemScreenSaver::startScreenSaver()
 			mVideoScreensaver->setVideo(path);
 			mVideoScreensaver->setScreensaverMode(true);
 			mVideoScreensaver->onShow();
+			PowerSaver::runningScreenSaver(true);
 			mTimer = 0;
 			return;
 		}
@@ -114,6 +116,7 @@ void SystemScreenSaver::stopScreenSaver()
 	delete mVideoScreensaver;
 	mVideoScreensaver = NULL;
 	mState = STATE_INACTIVE;
+	PowerSaver::runningScreenSaver(false);
 }
 
 void SystemScreenSaver::renderScreenSaver()

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -45,5 +45,5 @@ private:
 	int				mTimer;
 	FileData*		mCurrentGame;
 	std::string		mGameName;
-	std::string		mSystemName;	
+	std::string		mSystemName;
 };

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -54,7 +54,7 @@ bool parseArgs(int argc, char* argv[], unsigned int* width, unsigned int* height
 #ifndef WIN32
 		}else if(strcmp(argv[i], "--show-hidden-files") == 0)
 		{
-			Settings::getInstance()->setBool("ShowHiddenFiles", true);			
+			Settings::getInstance()->setBool("ShowHiddenFiles", true);
 #endif
 		}else if(strcmp(argv[i], "--draw-framerate") == 0)
 		{
@@ -95,7 +95,7 @@ bool parseArgs(int argc, char* argv[], unsigned int* width, unsigned int* height
 			AttachConsole(ATTACH_PARENT_PROCESS);
 			freopen("CONOUT$", "wb", stdout);
 #endif
-			std::cout << 
+			std::cout <<
 				"EmulationStation, a graphical front-end for ROM browsing.\n"
 				"Written by Alec \"Aloshi\" Lofquist.\n"
 				"Version " << PROGRAM_VERSION_STRING << ", built " << PROGRAM_BUILT_STRING << "\n\n"
@@ -139,7 +139,7 @@ bool verifyHomeFolderExists()
 	return true;
 }
 
-// Returns true if everything is OK, 
+// Returns true if everything is OK,
 bool loadSystemConfigFile(const char** errorString)
 {
 	*errorString = NULL;
@@ -187,8 +187,8 @@ int main(int argc, char* argv[])
 	// only show the console on Windows if HideConsole is false
 #ifdef WIN32
 	// MSVC has a "SubSystem" option, with two primary options: "WINDOWS" and "CONSOLE".
-	// In "WINDOWS" mode, no console is automatically created for us.  This is good, 
-	// because we can choose to only create the console window if the user explicitly 
+	// In "WINDOWS" mode, no console is automatically created for us.  This is good,
+	// because we can choose to only create the console window if the user explicitly
 	// asks for it, preventing it from flashing open and then closing.
 	// In "CONSOLE" mode, a console is always automatically created for us before we
 	// enter main. In this case, we can only hide the console after the fact, which
@@ -210,7 +210,7 @@ int main(int argc, char* argv[])
 	}else{
 		// we want to hide the console
 		// if we're compiled with the "WINDOWS" subsystem, this is already done.
-		// if we're compiled with the "CONSOLE" subsystem, a console is already created; 
+		// if we're compiled with the "CONSOLE" subsystem, a console is already created;
 		// it'll flash open, but we hide it nearly immediately
 		if(GetConsoleWindow()) // should only pass in "CONSOLE" mode
 			ShowWindow(GetConsoleWindow(), SW_HIDE);
@@ -266,7 +266,7 @@ int main(int argc, char* argv[])
 		// we can't handle es_systems.cfg file problems inside ES itself, so display the error message then quit
 		window.pushGui(new GuiMsgBox(&window,
 			errorMsg,
-			"QUIT", [] { 
+			"QUIT", [] {
 				SDL_Event* quit = new SDL_Event();
 				quit->type = SDL_QUIT;
 				SDL_PushEvent(quit);
@@ -302,19 +302,16 @@ int main(int argc, char* argv[])
 
 	int lastTime = SDL_GetTicks();
 	int ps_time = SDL_GetTicks();
-	
+
 	bool running = true;
 	bool ps_standby = false;
-
-	// assuming screensaver timeout is not updated regularly.
-	int timeout = (unsigned int) Settings::getInstance()->getInt("ScreenSaverTime");
 
 	while(running)
 	{
 		SDL_Event event;
-		bool ps_standby = PowerSaver::getState() && SDL_GetTicks() - ps_time > PowerSaver::getTimeout();
-		
-		if(ps_standby ? SDL_WaitEventTimeout(&event, timeout - 100) : SDL_PollEvent(&event))
+		bool ps_standby = PowerSaver::getState() && SDL_GetTicks() - ps_time > PowerSaver::getMode();
+
+		if(ps_standby ? SDL_WaitEventTimeout(&event, PowerSaver::getTimeout()) : SDL_PollEvent(&event))
 		{
 			do
 			{
@@ -337,12 +334,12 @@ int main(int argc, char* argv[])
 						break;
 				}
 			} while(SDL_PollEvent(&event));
-			
+
 			// triggered if exiting from SDL_WaitEvent
 			if (ps_standby)
 				// show as if continuing from last event
 				lastTime = SDL_GetTicks();
-			
+
 			// reset counter
 			ps_time = SDL_GetTicks();
 		}
@@ -359,7 +356,7 @@ int main(int argc, char* argv[])
 		lastTime = curTime;
 
 		// cap deltaTime
-		if(deltaTime > timeout || deltaTime < 0)
+		if((deltaTime > PowerSaver::getTimeout() && PowerSaver::getTimeout() > 0) || deltaTime < 0)
 			deltaTime = 1000;
 
 		window.update(deltaTime);

--- a/es-core/src/PowerSaver.cpp
+++ b/es-core/src/PowerSaver.cpp
@@ -2,32 +2,49 @@
 #include "Settings.h"
 #include <string.h>
 
-bool PowerSaver::mState = true;
-int PowerSaver::mTimeout = PowerSaver::ps_default;
+bool PowerSaver::mState = false;
+bool PowerSaver::mRunningScreenSaver = false;
 
-void PowerSaver::init(bool state)
+int PowerSaver::mPlayNextTimeout = -1;
+int PowerSaver::mScreenSaverTimeout = -1;
+PowerSaver::mode PowerSaver::mMode = PowerSaver::DISABLED;
+
+void PowerSaver::init()
 {
 	setState(true);
-	updateTimeout();
+	updateTimeouts();
+	updateMode();
 }
 
 int PowerSaver::getTimeout()
 {
-	return mTimeout;
+	return mRunningScreenSaver ? mPlayNextTimeout : mScreenSaverTimeout;
 }
 
-void PowerSaver::updateTimeout()
+void PowerSaver::updateTimeouts()
+{
+	mScreenSaverTimeout = (unsigned int) Settings::getInstance()->getInt("ScreenSaverTime");
+	mScreenSaverTimeout = mScreenSaverTimeout > 0 ? mScreenSaverTimeout - 100 : -1;
+	mPlayNextTimeout = 30000;
+}
+
+PowerSaver::mode PowerSaver::getMode()
+{
+	return mMode;
+}
+
+void PowerSaver::updateMode()
 {
 	std::string mode = Settings::getInstance()->getString("PowerSaverMode");
-	
+
 	if (mode == "disabled") {
-		mTimeout = ps_disabled;
+		mMode = DISABLED;
 	} else if (mode == "instant") {
-		mTimeout = ps_instant;
+		mMode = INSTANT;
 	} else if (mode == "enhanced") {
-		mTimeout = ps_enhanced;
-	} else { // default
-		mTimeout = ps_default;
+		mMode = ENHANCED;
+	} else {
+		mMode = DEFAULT;
 	}
 }
 
@@ -42,3 +59,7 @@ void PowerSaver::setState(bool state)
 	mState = ps_enabled && state;
 }
 
+void PowerSaver::runningScreenSaver(bool state)
+{
+	mRunningScreenSaver = state;
+}

--- a/es-core/src/PowerSaver.h
+++ b/es-core/src/PowerSaver.h
@@ -1,17 +1,26 @@
 class PowerSaver
 {
 public:
-	enum ps_state : int { ps_disabled = -1, ps_instant = 200, ps_enhanced = 3000, ps_default = 10000 };
-	
-	static void init(bool state = true);
-	
+	enum mode : int { DISABLED = -1, INSTANT = 200, ENHANCED = 3000, DEFAULT = 10000 };
+
+	static void init();
+
 	static int getTimeout();
-	static void updateTimeout();
+	static void updateTimeouts();
+
+	static mode getMode();
+	static void updateMode();
 
 	static bool getState();
 	static void setState(bool state);
-	
+
+	static void runningScreenSaver(bool state);
+
 private:
 	static bool mState;
-	static int mTimeout;
+	static bool mRunningScreenSaver;
+
+	static mode mMode;
+	static int mPlayNextTimeout;
+	static int mScreenSaverTimeout;
 };


### PR DESCRIPTION
- Removed warning while enabling Instant mode
- Fixes #198  Instant mode setting not being saved
- Fixes #200 Fast animations when Screensaver is disabled by setting timeout to 0
- Added methods to support changing screensaver videos after timeout
while using OMX.
- Added methods to support changing Screensaver play next video timeout
- Minor fixes