### PR TITLE
Add image slideshow screensaver mode

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -26,6 +26,9 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiGameScraper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiGamelistOptions.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiScreensaverOptions.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiGeneralScreensaverOptions.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiVideoScreensaverOptions.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiSlideshowScreensaverOptions.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiMenu.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiSettings.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiScraperMulti.h
@@ -79,6 +82,9 @@ set(ES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiGameScraper.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiGamelistOptions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiScreensaverOptions.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiGeneralScreensaverOptions.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiVideoScreensaverOptions.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiSlideshowScreensaverOptions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiMenu.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiSettings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiScraperMulti.cpp

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -3,6 +3,8 @@
 #include "Window.h"
 
 class VideoComponent;
+class ImageComponent;
+class Sound;
 
 // Screensaver implementation for main window
 class SystemScreenSaver : public Window::ScreenSaver
@@ -23,8 +25,13 @@ public:
 	virtual void launchGame();
 
 private:
-	void	countVideos();
-	void	pickRandomVideo(std::string& path);
+	unsigned long	countGameListNodes(const char *nodeName);
+	void			countVideos();
+	void			countImages();
+	void			pickGameListNode(unsigned long index, const char *nodeName, std::string& path);
+	void			pickRandomVideo(std::string& path);
+	void			pickRandomGameListImage(std::string& path);
+	void			pickRandomCustomImage(std::string& path);
 
 	void input(InputConfig* config, Input input);
 
@@ -36,14 +43,19 @@ private:
 	};
 
 private:
-	bool			mCounted;
-	unsigned long	mVideoCount;
-	VideoComponent* mVideoScreensaver;
-	Window*			mWindow;
-	STATE			mState;
-	float			mOpacity;
-	int				mTimer;
-	FileData*		mCurrentGame;
-	std::string		mGameName;
-	std::string		mSystemName;
+	bool					mVideosCounted;
+	unsigned long			mVideoCount;
+	VideoComponent*			mVideoScreensaver;
+	bool					mImagesCounted;
+	unsigned long			mImageCount;
+	ImageComponent*			mImageScreensaver;
+	Window*					mWindow;
+	STATE					mState;
+	float					mOpacity;
+	int						mTimer;
+	FileData*				mCurrentGame;
+	std::string				mGameName;
+	std::string				mSystemName;
+	std::shared_ptr<Sound>	mBackgroundAudio;
+	bool					mStopBackgroundAudio;
 };

--- a/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
@@ -1,6 +1,7 @@
 #include "guis/GuiGeneralScreensaverOptions.h"
 #include "Window.h"
 #include "Settings.h"
+#include "PowerSaver.h"
 #include "views/ViewController.h"
 
 #include "components/ButtonComponent.h"

--- a/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiGeneralScreensaverOptions.cpp
@@ -1,0 +1,75 @@
+#include "guis/GuiGeneralScreensaverOptions.h"
+#include "Window.h"
+#include "Settings.h"
+#include "views/ViewController.h"
+
+#include "components/ButtonComponent.h"
+#include "components/SwitchComponent.h"
+#include "components/SliderComponent.h"
+#include "components/TextComponent.h"
+//#include "components/TextEditComponent.h"
+#include "components/OptionListComponent.h"
+#include "components/MenuComponent.h"
+#include "guis/GuiMsgBox.h"
+#include "guis/GuiVideoScreensaverOptions.h"
+#include "guis/GuiSlideshowScreensaverOptions.h"
+
+GuiGeneralScreensaverOptions::GuiGeneralScreensaverOptions(Window* window, const char* title) : GuiScreensaverOptions(window, title)
+{
+	// screensaver time
+	auto screensaver_time = std::make_shared<SliderComponent>(mWindow, 0.f, 30.f, 1.f, "m");
+	screensaver_time->setValue((float)(Settings::getInstance()->getInt("ScreenSaverTime") / (1000 * 60)));
+	addWithLabel("SCREENSAVER AFTER", screensaver_time);
+	addSaveFunc([screensaver_time] {
+	    Settings::getInstance()->setInt("ScreenSaverTime", (int)round(screensaver_time->getValue()) * (1000 * 60));
+	    PowerSaver::updateTimeouts();
+	});
+
+	// screensaver behavior
+	auto screensaver_behavior = std::make_shared< OptionListComponent<std::string> >(mWindow, "SCREENSAVER BEHAVIOR", false);
+	std::vector<std::string> screensavers;
+	screensavers.push_back("dim");
+	screensavers.push_back("black");
+	screensavers.push_back("random video");
+	screensavers.push_back("slideshow");
+	for(auto it = screensavers.begin(); it != screensavers.end(); it++)
+		screensaver_behavior->add(*it, *it, Settings::getInstance()->getString("ScreenSaverBehavior") == *it);
+	addWithLabel("SCREENSAVER BEHAVIOR", screensaver_behavior);
+	addSaveFunc([this, screensaver_behavior] {
+		if (Settings::getInstance()->getString("ScreenSaverBehavior") != "random video" && screensaver_behavior->getSelected() == "random video") {
+			// if before it wasn't risky but now there's a risk of problems, show warning
+			mWindow->pushGui(new GuiMsgBox(mWindow,
+			"The \"Random Video\" screensaver shows videos from your gamelist.\n\nIf you do not have videos, or if in several consecutive attempts the games it selects don't have videos it will default to black.\n\nMore options in the \"UI Settings\" > \"Video Screensaver\" menu.",
+				"OK", [] { return; }));
+		}
+		Settings::getInstance()->setString("ScreenSaverBehavior", screensaver_behavior->getSelected());
+	});
+
+	ComponentListRow row;
+
+	// show filtered menu
+	row.elements.clear();
+	row.addElement(std::make_shared<TextComponent>(mWindow, "VIDEO SCREENSAVER SETTINGS", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+	row.addElement(makeArrow(mWindow), false);
+	row.makeAcceptInputHandler(std::bind(&GuiGeneralScreensaverOptions::openVideoScreensaverOptions, this));
+	addRow(row);
+
+	row.elements.clear();
+	row.addElement(std::make_shared<TextComponent>(mWindow, "SLIDESHOW SCREENSAVER SETTINGS", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+	row.addElement(makeArrow(mWindow), false);
+	row.makeAcceptInputHandler(std::bind(&GuiGeneralScreensaverOptions::openSlideshowScreensaverOptions, this));
+	addRow(row);
+}
+
+GuiGeneralScreensaverOptions::~GuiGeneralScreensaverOptions()
+{
+}
+
+void GuiGeneralScreensaverOptions::openVideoScreensaverOptions() {
+	mWindow->pushGui(new GuiVideoScreensaverOptions(mWindow, "VIDEO SCREENSAVER"));
+}
+
+void GuiGeneralScreensaverOptions::openSlideshowScreensaverOptions() {
+    mWindow->pushGui(new GuiSlideshowScreensaverOptions(mWindow, "SLIDESHOW SCREENSAVER"));
+}
+

--- a/es-app/src/guis/GuiGeneralScreensaverOptions.h
+++ b/es-app/src/guis/GuiGeneralScreensaverOptions.h
@@ -1,0 +1,18 @@
+#ifndef _GUI_GENERAL_SCREENSAVER_OPTIONS_H_
+#define _GUI_GENERAL_SCREENSAVER_OPTIONS_H_
+
+#include "components/MenuComponent.h"
+#include "GuiScreensaverOptions.h"
+
+class GuiGeneralScreensaverOptions : public GuiScreensaverOptions
+{
+public:
+	GuiGeneralScreensaverOptions(Window* window, const char* title);
+	virtual ~GuiGeneralScreensaverOptions();
+
+private:
+	void openVideoScreensaverOptions();
+	void openSlideshowScreensaverOptions();
+};
+
+#endif // _GUI_GENERAL_SCREENSAVER_OPTIONS_H_

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -7,7 +7,7 @@
 #include "PowerSaver.h"
 #include "guis/GuiMsgBox.h"
 #include "guis/GuiSettings.h"
-#include "guis/GuiScreensaverOptions.h"
+#include "guis/GuiGeneralScreensaverOptions.h"
 #include "guis/GuiCollectionSystemsOptions.h"
 #include "guis/GuiScraperStart.h"
 #include "guis/GuiDetectDevice.h"
@@ -132,42 +132,12 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 		[this] {
 			auto s = new GuiSettings(mWindow, "UI SETTINGS");
 
-			// screensaver time
-			auto screensaver_time = std::make_shared<SliderComponent>(mWindow, 0.f, 30.f, 1.f, "m");
-			screensaver_time->setValue((float)(Settings::getInstance()->getInt("ScreenSaverTime") / (1000 * 60)));
-			s->addWithLabel("SCREENSAVER AFTER", screensaver_time);
-			s->addSaveFunc([screensaver_time] {
-				Settings::getInstance()->setInt("ScreenSaverTime", (int)round(screensaver_time->getValue()) * (1000 * 60));
-				PowerSaver::updateTimeouts();
-			});
-
-			// screensaver behavior
-			auto screensaver_behavior = std::make_shared< OptionListComponent<std::string> >(mWindow, "SCREENSAVER BEHAVIOR", false);
-			std::vector<std::string> screensavers;
-			screensavers.push_back("dim");
-			screensavers.push_back("black");
-			screensavers.push_back("random video");
-			for(auto it = screensavers.begin(); it != screensavers.end(); it++)
-				screensaver_behavior->add(*it, *it, Settings::getInstance()->getString("ScreenSaverBehavior") == *it);
-			s->addWithLabel("SCREENSAVER BEHAVIOR", screensaver_behavior);
-			s->addSaveFunc([this, screensaver_behavior] {
-				if (Settings::getInstance()->getString("ScreenSaverBehavior") != "random video" && screensaver_behavior->getSelected() == "random video") {
-					// if before it wasn't risky but now there's a risk of problems, show warning
-					mWindow->pushGui(new GuiMsgBox(mWindow,
-					"The \"Random Video\" screensaver shows videos from your gamelist.\n\nIf you do not have videos, or if in several consecutive attempts the games it selects don't have videos it will default to black.\n\nMore options in the \"UI Settings\" > \"Video Screensaver\" menu.",
-						"OK", [] { return; }));
-				}
-				Settings::getInstance()->setString("ScreenSaverBehavior", screensaver_behavior->getSelected());
-			});
-
-			ComponentListRow row;
-
-			// show filtered menu
-			row.elements.clear();
-			row.addElement(std::make_shared<TextComponent>(mWindow, "VIDEO SCREENSAVER SETTINGS", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
-			row.addElement(makeArrow(mWindow), false);
-			row.makeAcceptInputHandler(std::bind(&GuiMenu::openScreensaverOptions, this));
-			s->addRow(row);
+			ComponentListRow screensaver_row;
+			screensaver_row.elements.clear();
+			screensaver_row.addElement(std::make_shared<TextComponent>(mWindow, "SCREENSAVER SETTINGS", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+			screensaver_row.addElement(makeArrow(mWindow), false);
+			screensaver_row.makeAcceptInputHandler(std::bind(&GuiMenu::openScreensaverOptions, this));
+			s->addRow(screensaver_row);
 
 			// quick system select (left/right in game list view)
 			auto quick_sys_select = std::make_shared<SwitchComponent>(mWindow);
@@ -428,7 +398,7 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 }
 
 void GuiMenu::openScreensaverOptions() {
-	mWindow->pushGui(new GuiScreensaverOptions(mWindow, "VIDEO SCREENSAVER"));
+	mWindow->pushGui(new GuiGeneralScreensaverOptions(mWindow, "SCREENSAVER SETTINGS"));
 }
 
 void GuiMenu::openCollectionSystemSettings() {

--- a/es-app/src/guis/GuiScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiScreensaverOptions.cpp
@@ -15,42 +15,6 @@ GuiScreensaverOptions::GuiScreensaverOptions(Window* window, const char* title) 
 {
 	addChild(&mMenu);
 
-#ifdef _RPI_
-	auto ss_omx = std::make_shared<SwitchComponent>(mWindow);
-	ss_omx->setState(Settings::getInstance()->getBool("ScreenSaverOmxPlayer"));
-	addWithLabel("USE OMX PLAYER FOR SCREENSAVER", ss_omx);
-	addSaveFunc([ss_omx, this] { Settings::getInstance()->setBool("ScreenSaverOmxPlayer", ss_omx->getState()); });
-#endif
-
-	// Allow ScreenSaver Controls - ScreenSaverControls
-	auto ss_controls = std::make_shared<SwitchComponent>(mWindow);
-	ss_controls->setState(Settings::getInstance()->getBool("ScreenSaverControls"));
-	addWithLabel("SCREENSAVER CONTROLS", ss_controls);
-	addSaveFunc([ss_controls] { Settings::getInstance()->setBool("ScreenSaverControls", ss_controls->getState()); });
-
-	// Render Video Game Name as subtitles
-	auto ss_info = std::make_shared< OptionListComponent<std::string> >(mWindow, "SHOW GAME INFO", false);
-	std::vector<std::string> info_type;
-	info_type.push_back("always");
-	info_type.push_back("start & end");
-	info_type.push_back("never");
-	for(auto it = info_type.begin(); it != info_type.end(); it++)
-		ss_info->add(*it, *it, Settings::getInstance()->getString("ScreenSaverGameInfo") == *it);
-	addWithLabel("SHOW GAME INFO ON SCREENSAVER", ss_info);
-	addSaveFunc([ss_info, this] { Settings::getInstance()->setString("ScreenSaverGameInfo", ss_info->getSelected()); });
-
-#ifndef _RPI_
-	auto captions_compatibility = std::make_shared<SwitchComponent>(mWindow);
-	captions_compatibility->setState(Settings::getInstance()->getBool("CaptionsCompatibility"));
-	addWithLabel("USE COMPATIBLE LOW RESOLUTION FOR CAPTIONS", captions_compatibility);
-	addSaveFunc([captions_compatibility] { Settings::getInstance()->setBool("CaptionsCompatibility", captions_compatibility->getState()); });
-#endif
-
-	auto stretch_screensaver = std::make_shared<SwitchComponent>(mWindow);
-	stretch_screensaver->setState(Settings::getInstance()->getBool("StretchVideoOnScreenSaver"));
-	addWithLabel("STRETCH VIDEO ON SCREENSAVER", stretch_screensaver);
-	addSaveFunc([stretch_screensaver] { Settings::getInstance()->setBool("StretchVideoOnScreenSaver", stretch_screensaver->getState()); });
-
 	mMenu.addButton("BACK", "go back", [this] { delete this; });
 
 	setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
@@ -67,24 +31,10 @@ void GuiScreensaverOptions::save()
 	if(!mSaveFuncs.size())
 		return;
 
-#ifdef _RPI_
-	bool startingStatusNotRisky = (Settings::getInstance()->getString("ScreenSaverGameInfo") == "never" || !Settings::getInstance()->getBool("ScreenSaverOmxPlayer"));
-#endif
-
 	for(auto it = mSaveFuncs.begin(); it != mSaveFuncs.end(); it++)
 		(*it)();
 
 	Settings::getInstance()->saveFile();
-
-#ifdef _RPI_
-	bool endStatusRisky = (Settings::getInstance()->getString("ScreenSaverGameInfo") != "never" && Settings::getInstance()->getBool("ScreenSaverOmxPlayer"));
-	if (startingStatusNotRisky && endStatusRisky) {
-		// if before it wasn't risky but now there's a risk of problems, show warning
-		mWindow->pushGui(new GuiMsgBox(mWindow,
-		"Using OMX Player and displaying Game Info may result in the video flickering in some TV modes. If that happens, consider:\n\n• Disabling the \"Show Game Info\" option;\n• Disabling \"Overscan\" on the Pi configuration menu might help:\nRetroPie > Raspi-Config > Advanced Options > Overscan > \"No\".\n• Disabling the use of OMX Player for the screensaver.",
-			"GOT IT!", [] { return; }));
-	}
-#endif
 }
 
 bool GuiScreensaverOptions::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiScreensaverOptions.h
+++ b/es-app/src/guis/GuiScreensaverOptions.h
@@ -1,3 +1,6 @@
+#ifndef _GUI_SCREENSAVER_OPTIONS_H_
+#define _GUI_SCREENSAVER_OPTIONS_H_
+
 #include "GuiComponent.h"
 #include "components/MenuComponent.h"
 #include "SystemData.h"
@@ -9,7 +12,7 @@ public:
 	GuiScreensaverOptions(Window* window, const char* title);
 	virtual ~GuiScreensaverOptions(); // just calls save();
 
-	void save();
+	virtual void save();
 	inline void addRow(const ComponentListRow& row) { mMenu.addRow(row); };
 	inline void addWithLabel(const std::string& label, const std::shared_ptr<GuiComponent>& comp) { mMenu.addWithLabel(label, comp); };
 	inline void addSaveFunc(const std::function<void()>& func) { mSaveFuncs.push_back(func); };
@@ -18,7 +21,9 @@ public:
 	std::vector<HelpPrompt> getHelpPrompts() override;
 	HelpStyle getHelpStyle() override;
 
-private:
+protected:
 	MenuComponent mMenu;
 	std::vector< std::function<void()> > mSaveFuncs;
 };
+
+#endif // _GUI_SCREENSAVER_OPTIONS_H_

--- a/es-app/src/guis/GuiSlideshowScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiSlideshowScreensaverOptions.cpp
@@ -1,0 +1,119 @@
+#include "guis/GuiSlideshowScreensaverOptions.h"
+#include "Window.h"
+#include "Settings.h"
+#include "views/ViewController.h"
+
+#include "components/SwitchComponent.h"
+#include "components/SliderComponent.h"
+#include "components/TextComponent.h"
+#include "components/OptionListComponent.h"
+#include "components/MenuComponent.h"
+#include "guis/GuiMsgBox.h"
+#include "guis/GuiTextEditPopup.h"
+
+GuiSlideshowScreensaverOptions::GuiSlideshowScreensaverOptions(Window* window, const char* title) : GuiScreensaverOptions(window, title)
+{
+	ComponentListRow row;
+
+	// image duration (seconds)
+	auto sss_image_sec = std::make_shared<SliderComponent>(mWindow, 5.0f, 45.0f, 1.0f, "s");
+	sss_image_sec->setValue(Settings::getInstance()->getFloat("SlideshowScreenSaverImageSec"));
+	addWithLabel(row, "IMAGE TIME (SEC)", sss_image_sec);
+	addSaveFunc([sss_image_sec] {
+	    Settings::getInstance()->setFloat("SlideshowScreenSaverImageSec", sss_image_sec->getValue());
+	  });
+
+	// stretch
+	auto sss_stretch = std::make_shared<SwitchComponent>(mWindow);
+	sss_stretch->setState(Settings::getInstance()->getBool("SlideshowScreenSaverStretch"));
+	addWithLabel(row, "STRETCH IMAGES", sss_stretch);
+	addSaveFunc([sss_stretch] {
+	    Settings::getInstance()->setBool("SlideshowScreenSaverStretch", sss_stretch->getState());
+	  });
+
+	// background audio file
+	auto sss_bg_audio_file = std::make_shared<TextComponent>(mWindow);
+	addEditableTextComponent(row, "BACKGROUND AUDIO", sss_bg_audio_file, Settings::getInstance()->getString("SlideshowScreenSaverBackgroundAudioFile"));
+	addSaveFunc([sss_bg_audio_file] {
+	    Settings::getInstance()->setString("SlideshowScreenSaverBackgroundAudioFile", sss_bg_audio_file->getValue());
+	  });
+
+	// image source
+	auto sss_source = std::make_shared< OptionListComponent<std::string> >(mWindow, "IMAGE SOURCE", false);
+	std::vector<std::string> image_sources;
+	image_sources.push_back("game list");
+	image_sources.push_back("custom");
+	for(auto it = image_sources.begin(); it != image_sources.end(); it++)
+		sss_source->add(*it, *it, Settings::getInstance()->getString("SlideshowScreenSaverImageSource") == *it);
+	addWithLabel(row, "IMAGE SOURCE", sss_source);
+	addSaveFunc([this, sss_source] {
+		Settings::getInstance()->setString("SlideshowScreenSaverImageSource", sss_source->getSelected());
+	});
+
+	// custom image directory
+	auto sss_image_dir = std::make_shared<TextComponent>(mWindow);
+	addEditableTextComponent(row, "CUSTOM IMAGE DIR", sss_image_dir, Settings::getInstance()->getString("SlideshowScreenSaverImageDir"));
+	addSaveFunc([sss_image_dir] {
+	    Settings::getInstance()->setString("SlideshowScreenSaverImageDir", sss_image_dir->getValue());
+	  });
+
+	// recurse custom image directory
+	auto sss_recurse = std::make_shared<SwitchComponent>(mWindow);
+	sss_recurse->setState(Settings::getInstance()->getBool("SlideshowScreenSaverRecurse"));
+	addWithLabel(row, "CUSTOM IMAGE DIR RECURSIVE", sss_recurse);
+	addSaveFunc([sss_recurse] {
+	    Settings::getInstance()->setBool("SlideshowScreenSaverRecurse", sss_recurse->getState());
+	  });
+
+	// custom image filter
+	auto sss_image_filter = std::make_shared<TextComponent>(mWindow);
+	addEditableTextComponent(row, "CUSTOM IMAGE FILTER", sss_image_filter, Settings::getInstance()->getString("SlideshowScreenSaverImageFilter"));
+	addSaveFunc([sss_image_filter] {
+	    Settings::getInstance()->setString("SlideshowScreenSaverImageFilter", sss_image_filter->getValue());
+	  });
+}
+
+GuiSlideshowScreensaverOptions::~GuiSlideshowScreensaverOptions()
+{
+}
+
+void GuiSlideshowScreensaverOptions::addWithLabel(ComponentListRow row, const std::string label, std::shared_ptr<GuiComponent> component)
+{
+	row.elements.clear();
+
+	auto lbl = std::make_shared<TextComponent>(mWindow, strToUpper(label), Font::get(FONT_SIZE_SMALL), 0x777777FF);
+	row.addElement(lbl, true); // label
+
+	row.addElement(component, false, true);
+
+	addRow(row);
+}
+
+void GuiSlideshowScreensaverOptions::addEditableTextComponent(ComponentListRow row, const std::string label, std::shared_ptr<GuiComponent> ed, std::string value)
+{
+	row.elements.clear();
+
+	auto lbl = std::make_shared<TextComponent>(mWindow, strToUpper(label), Font::get(FONT_SIZE_SMALL), 0x777777FF);
+	row.addElement(lbl, true); // label
+
+	//std::shared_ptr<GuiComponent> ed = std::make_shared<TextComponent>(window, "", Font::get(FONT_SIZE_SMALL, FONT_PATH_LIGHT), 0x777777FF, ALIGN_RIGHT);
+	row.addElement(ed, true);
+
+	auto spacer = std::make_shared<GuiComponent>(mWindow);
+	spacer->setSize(Renderer::getScreenWidth() * 0.005f, 0);
+	row.addElement(spacer, false);
+
+	auto bracket = std::make_shared<ImageComponent>(mWindow);
+	bracket->setImage(":/arrow.svg");
+	bracket->setResize(Eigen::Vector2f(0, lbl->getFont()->getLetterHeight()));
+	row.addElement(bracket, false);
+
+	auto updateVal = [ed](const std::string& newVal) { ed->setValue(newVal); }; // ok callback (apply new value to ed)
+	row.makeAcceptInputHandler([this, label, ed, updateVal] {
+		mWindow->pushGui(new GuiTextEditPopup(mWindow, label, ed->getValue(), updateVal, false));
+	});
+
+	assert(ed);
+	addRow(row);
+	ed->setValue(value);
+}

--- a/es-app/src/guis/GuiSlideshowScreensaverOptions.h
+++ b/es-app/src/guis/GuiSlideshowScreensaverOptions.h
@@ -1,0 +1,18 @@
+#ifndef _GUI_SLIDESHOW_SCREENSAVER_OPTIONS_H_
+#define _GUI_SLIDESHOW_SCREENSAVER_OPTIONS_H_
+
+#include "components/MenuComponent.h"
+#include "GuiScreensaverOptions.h"
+
+class GuiSlideshowScreensaverOptions : public GuiScreensaverOptions
+{
+public:
+	GuiSlideshowScreensaverOptions(Window* window, const char* title);
+	virtual ~GuiSlideshowScreensaverOptions();
+
+private:
+	void addWithLabel(ComponentListRow row, const std::string label, std::shared_ptr<GuiComponent> component);
+	void addEditableTextComponent(ComponentListRow row, const std::string label, std::shared_ptr<GuiComponent> ed, std::string value);
+};
+
+#endif // _GUI_SLIDESHOW_SCREENSAVER_OPTIONS_H_

--- a/es-app/src/guis/GuiVideoScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiVideoScreensaverOptions.cpp
@@ -1,0 +1,71 @@
+#include "guis/GuiVideoScreensaverOptions.h"
+#include "Window.h"
+#include "Settings.h"
+#include "views/ViewController.h"
+
+#include "components/SwitchComponent.h"
+#include "components/OptionListComponent.h"
+#include "components/MenuComponent.h"
+#include "guis/GuiMsgBox.h"
+
+GuiVideoScreensaverOptions::GuiVideoScreensaverOptions(Window* window, const char* title) : GuiScreensaverOptions(window, title)
+{
+#ifdef _RPI_
+	auto ss_omx = std::make_shared<SwitchComponent>(mWindow);
+	ss_omx->setState(Settings::getInstance()->getBool("ScreenSaverOmxPlayer"));
+	addWithLabel("USE OMX PLAYER FOR SCREENSAVER", ss_omx);
+	addSaveFunc([ss_omx, this] { Settings::getInstance()->setBool("ScreenSaverOmxPlayer", ss_omx->getState()); });
+#endif
+
+	// Allow ScreenSaver Controls - ScreenSaverControls
+	auto ss_controls = std::make_shared<SwitchComponent>(mWindow);
+	ss_controls->setState(Settings::getInstance()->getBool("ScreenSaverControls"));
+	addWithLabel("SCREENSAVER CONTROLS", ss_controls);
+	addSaveFunc([ss_controls] { Settings::getInstance()->setBool("ScreenSaverControls", ss_controls->getState()); });
+
+	// Render Video Game Name as subtitles
+	auto ss_info = std::make_shared< OptionListComponent<std::string> >(mWindow, "SHOW GAME INFO", false);
+	std::vector<std::string> info_type;
+	info_type.push_back("always");
+	info_type.push_back("start & end");
+	info_type.push_back("never");
+	for(auto it = info_type.begin(); it != info_type.end(); it++)
+		ss_info->add(*it, *it, Settings::getInstance()->getString("ScreenSaverGameInfo") == *it);
+	addWithLabel("SHOW GAME INFO ON SCREENSAVER", ss_info);
+	addSaveFunc([ss_info, this] { Settings::getInstance()->setString("ScreenSaverGameInfo", ss_info->getSelected()); });
+
+#ifndef _RPI_
+	auto captions_compatibility = std::make_shared<SwitchComponent>(mWindow);
+	captions_compatibility->setState(Settings::getInstance()->getBool("CaptionsCompatibility"));
+	addWithLabel("USE COMPATIBLE LOW RESOLUTION FOR CAPTIONS", captions_compatibility);
+	addSaveFunc([captions_compatibility] { Settings::getInstance()->setBool("CaptionsCompatibility", captions_compatibility->getState()); });
+#endif
+
+	auto stretch_screensaver = std::make_shared<SwitchComponent>(mWindow);
+	stretch_screensaver->setState(Settings::getInstance()->getBool("StretchVideoOnScreenSaver"));
+	addWithLabel("STRETCH VIDEO ON SCREENSAVER", stretch_screensaver);
+	addSaveFunc([stretch_screensaver] { Settings::getInstance()->setBool("StretchVideoOnScreenSaver", stretch_screensaver->getState()); });
+
+}
+
+GuiVideoScreensaverOptions::~GuiVideoScreensaverOptions()
+{
+}
+
+void GuiVideoScreensaverOptions::save()
+{
+#ifdef _RPI_
+	bool startingStatusNotRisky = (Settings::getInstance()->getString("ScreenSaverGameInfo") == "never" || !Settings::getInstance()->getBool("ScreenSaverOmxPlayer"));
+#endif
+	GuiScreensaverOptions::save();
+
+#ifdef _RPI_
+	bool endStatusRisky = (Settings::getInstance()->getString("ScreenSaverGameInfo") != "never" && Settings::getInstance()->getBool("ScreenSaverOmxPlayer"));
+	if (startingStatusNotRisky && endStatusRisky) {
+		// if before it wasn't risky but now there's a risk of problems, show warning
+		mWindow->pushGui(new GuiMsgBox(mWindow,
+		"Using OMX Player and displaying Game Info may result in the video flickering in some TV modes. If that happens, consider:\n\n• Disabling the \"Show Game Info\" option;\n• Disabling \"Overscan\" on the Pi configuration menu might help:\nRetroPie > Raspi-Config > Advanced Options > Overscan > \"No\".\n• Disabling the use of OMX Player for the screensaver.",
+			"GOT IT!", [] { return; }));
+	}
+#endif
+}

--- a/es-app/src/guis/GuiVideoScreensaverOptions.h
+++ b/es-app/src/guis/GuiVideoScreensaverOptions.h
@@ -1,0 +1,16 @@
+#ifndef _GUI_VIDEO_SCREENSAVER_OPTIONS_H_
+#define _GUI_VIDEO_SCREENSAVER_OPTIONS_H_
+
+#include "components/MenuComponent.h"
+#include "GuiScreensaverOptions.h"
+
+class GuiVideoScreensaverOptions : public GuiScreensaverOptions
+{
+public:
+	GuiVideoScreensaverOptions(Window* window, const char* title);
+	virtual ~GuiVideoScreensaverOptions();
+
+	void save() override;
+};
+
+#endif // _GUI_VIDEO_SCREENSAVER_OPTIONS_H_

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -84,6 +84,14 @@ void Settings::setDefaults()
 	mBoolMap["StretchVideoOnScreenSaver"] = false;
 	mStringMap["PowerSaverMode"] = "default";
 
+	mFloatMap["SlideshowScreenSaverImageSec"] = 10.0f;
+	mBoolMap["SlideshowScreenSaverStretch"] = false;
+	mStringMap["SlideshowScreenSaverBackgroundAudioFile"] = getHomePath() + "/.emulationstation/slideshow/audio/slideshow_bg.wav";
+	mStringMap["SlideshowScreenSaverImageSource"] = "game list";
+	mStringMap["SlideshowScreenSaverImageDir"] = getHomePath() + "/.emulationstation/slideshow/image";
+	mStringMap["SlideshowScreenSaverImageFilter"] = ".png,.jpg";
+	mBoolMap["SlideshowScreenSaverRecurse"] = false;
+
 	// This setting only applies to raspberry pi but set it for all platforms so
 	// we don't get a warning if we encounter it on a different platform
 	mBoolMap["VideoOmxPlayer"] = false;


### PR DESCRIPTION
This change adds an image slideshow screensaver mode with optional
background audio.  The existing menu and video screensaver have been
refactored to include this new mode.

By default, the slideshow screensaver will show images from the
game list, but it can be configured in the menu to use a custom
directory instead.