### PR TITLE
carousel enhancements

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -673,17 +673,32 @@ EmulationStation borrows the concept of "nine patches" from Android (or "9-Slice
 #### carousel
 
 * `type` - type: STRING.
-	- Accepted values are "horizontal" or "vertical".  Sets the scoll direction of the carousel.
- 	- Default is "horizontal".
+	- Sets the scoll direction of the carousel.
+	- Accepted values are "horizontal", "vertical" or "vertical_wheel".
+	- Default is "horizontal".
 * `size` - type: NORMALIZED_PAIR. Default is "1 0.2325"
 * `pos` - type: NORMALIZED_PAIR.  Default is "0 0.38375".
+* `origin` - type: NORMALIZED_PAIR.
+	- Where on the carousel `pos` refers to.  For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the carousel exactly in the middle of the screen.  If the "POSITION" and "SIZE" attributes are themable, "ORIGIN" is implied.
 * `color` - type: COLOR.
 	- Controls the color of the carousel background.
 	- Default is FFFFFFD8
 * `logoSize` - type: NORMALIZED_PAIR.  Default is "0.25 0.155"
 * `logoScale` - type: FLOAT.
- * Selected logo is increased in size by this scale
- * Default is 1.2
+	- Selected logo is increased in size by this scale
+	- Default is 1.2
+* `logoRotation` - type: FLOAT.
+	- Angle in degrees that the logos should be rotated.  Value should be positive.
+	- Default is 7.5
+	- This property only applies when `type` is "vertical_wheel".
+* `logoRotationOrigin` - type: NORMALIZED_PAIR.
+	- Point around which the logos will be rotated. Defaults to `-5 0.5`.
+	- This property only applies when `type` is "vertical_wheel".
+* `logoAlignment` - type: STRING.
+	- Sets the alignment of the logos relative to the carousel.
+	- Accepted values are "top", "bottom" or "center" when `type` is "horizontal".
+	- Accepted values are "left", "right" or "center" when `type` is "vertical" or "vertical_wheel".
+	- Default is "center"
 * `maxLogoCount` - type: FLOAT.
 	- Sets the number of logos to display in the carousel.
 	- Default is 3

--- a/es-app/src/guis/GuiFastSelect.cpp
+++ b/es-app/src/guis/GuiFastSelect.cpp
@@ -19,14 +19,14 @@ GuiFastSelect::GuiFastSelect(Window* window, IGameListView* gamelist) : GuiCompo
 	addChild(&mBackground);
 
 	mLetterText.setSize(mSize.x(), mSize.y() * 0.75f);
-	mLetterText.setAlignment(ALIGN_CENTER);
+	mLetterText.setHorizontalAlignment(ALIGN_CENTER);
 	mLetterText.applyTheme(theme, "fastSelect", "letter", FONT_PATH | COLOR);
 	// TODO - set font size
 	addChild(&mLetterText);
 
 	mSortText.setPosition(0, mSize.y() * 0.75f);
 	mSortText.setSize(mSize.x(), mSize.y() * 0.25f);
-	mSortText.setAlignment(ALIGN_CENTER);
+	mSortText.setHorizontalAlignment(ALIGN_CENTER);
 	mSortText.applyTheme(theme, "fastSelect", "subtext", FONT_PATH | COLOR);
 	// TODO - set font size
 	addChild(&mSortText);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -418,7 +418,7 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 	mVersion.setFont(Font::get(FONT_SIZE_SMALL));
 	mVersion.setColor(0x5E5E5EFF);
 	mVersion.setText("EMULATIONSTATION V" + strToUpper(PROGRAM_VERSION_STRING));
-	mVersion.setAlignment(ALIGN_CENTER);
+	mVersion.setHorizontalAlignment(ALIGN_CENTER);
 
 	addChild(&mMenu);
 	addChild(&mVersion);

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -13,13 +13,13 @@ class AnimatedImageComponent;
 enum CarouselType : unsigned int
 {
 	HORIZONTAL = 0,
-	VERTICAL = 1
+	VERTICAL = 1,
+	VERTICAL_WHEEL = 2
 };
 
 struct SystemViewData
 {
 	std::shared_ptr<GuiComponent> logo;
-	std::shared_ptr<GuiComponent> logoSelected;
 	std::vector<GuiComponent*> backgroundExtras;
 };
 
@@ -28,8 +28,11 @@ struct SystemViewCarousel
 	CarouselType type;
 	Eigen::Vector2f pos;
 	Eigen::Vector2f size;
+	Eigen::Vector2f origin;
 	float logoScale;
-	Eigen::Vector2f logoSpacing;
+	float logoRotation;
+	Eigen::Vector2f logoRotationOrigin;
+	Alignment logoAlignment;
 	unsigned int color;
 	int maxLogoCount; // number of logos shown on the carousel
 	Eigen::Vector2f logoSize;
@@ -40,6 +43,9 @@ class SystemView : public IList<SystemViewData, SystemData*>
 {
 public:
 	SystemView(Window* window);
+
+	virtual void onShow() override;
+	virtual void onHide() override;
 
 	void goToSystem(SystemData* system, bool animate);
 
@@ -76,4 +82,5 @@ private:
 	float mExtrasFadeOpacity;
 
 	bool mViewNeedsReload;
+	bool mShowing;
 };

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -72,6 +72,7 @@ void ViewController::goToSystemView(SystemData* system)
 
 	systemList->goToSystem(system, false);
 	mCurrentView = systemList;
+	mCurrentView->onShow();
 	PowerSaver::setState(true);
 
 	playViewTransition();

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -13,7 +13,7 @@ ISimpleGameListView::ISimpleGameListView(Window* window, FileData* root) : IGame
 	mHeaderText.setText("Logo Text");
 	mHeaderText.setSize(mSize.x(), 0);
 	mHeaderText.setPosition(0, 0);
-	mHeaderText.setAlignment(ALIGN_CENTER);
+	mHeaderText.setHorizontalAlignment(ALIGN_CENTER);
 	mHeaderText.setDefaultZIndex(50);
 	
 	mHeaderImage.setResize(0, mSize.y() * 0.185f);

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -132,7 +132,6 @@ float GuiComponent::getScale() const
 void GuiComponent::setScale(float scale)
 {
 	mScale = scale;
-	onSizeChanged();
 }
 
 float GuiComponent::getZIndex() const

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -127,9 +127,13 @@ std::map< std::string, ElementMapType > ThemeData::sElementMap = boost::assign::
 		("type", STRING)
 		("size", NORMALIZED_PAIR)
 		("pos", NORMALIZED_PAIR)
+		("origin", NORMALIZED_PAIR)
 		("color", COLOR)
 		("logoScale", FLOAT)
+		("logoRotation", FLOAT)
+		("logoRotationOrigin", NORMALIZED_PAIR)
 		("logoSize", NORMALIZED_PAIR)
+		("logoAlignment", STRING)
 		("maxLogoCount", FLOAT)
 		("zIndex", FLOAT)));
 

--- a/es-core/src/components/MenuComponent.cpp
+++ b/es-core/src/components/MenuComponent.cpp
@@ -18,7 +18,7 @@ MenuComponent::MenuComponent(Window* window, const char* title, const std::share
 
 	// set up title
 	mTitle = std::make_shared<TextComponent>(mWindow);
-	mTitle->setAlignment(ALIGN_CENTER);
+	mTitle->setHorizontalAlignment(ALIGN_CENTER);
 	mTitle->setColor(0x555555FF);
 	setTitle(title, titleFont);
 	mGrid.setEntry(mTitle, Vector2i(0, 0), false);

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -144,7 +144,7 @@ public:
 		auto font = Font::get(FONT_SIZE_MEDIUM, FONT_PATH_LIGHT);
 		mText.setFont(font);
 		mText.setColor(0x777777FF);
-		mText.setAlignment(ALIGN_CENTER);
+		mText.setHorizontalAlignment(ALIGN_CENTER);
 		addChild(&mText);
 
 		if(mMultiSelect)

--- a/es-core/src/components/TextComponent.h
+++ b/es-core/src/components/TextComponent.h
@@ -23,7 +23,8 @@ public:
 	void onSizeChanged() override;
 	void setText(const std::string& text);
 	void setColor(unsigned int color);
-	void setAlignment(Alignment align);
+	void setHorizontalAlignment(Alignment align);
+	void setVerticalAlignment(Alignment align);
 	void setLineSpacing(float spacing);
 	void setBackgroundColor(unsigned int color);
 	void setRenderBackground(bool render);
@@ -57,7 +58,8 @@ private:
 	Eigen::Matrix<bool, 1, 2> mAutoCalcExtent;
 	std::string mText;
 	std::shared_ptr<TextCache> mTextCache;
-	Alignment mAlignment;
+	Alignment mHorizontalAlignment;
+	Alignment mVerticalAlignment;
 	float mLineSpacing;
 };
 

--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -25,7 +25,9 @@ enum Alignment
 {
 	ALIGN_LEFT,
 	ALIGN_CENTER, // centers both horizontally and vertically
-	ALIGN_RIGHT
+	ALIGN_RIGHT,
+	ALIGN_TOP,
+	ALIGN_BOTTOM
 };
 
 //A TrueType Font renderer that uses FreeType and OpenGL.


### PR DESCRIPTION
* The scaling of the logos will now animate properly and they will grow and shrink gradually as they become selected/unselected. This has added benefit of simplifying some of the code. Previously, we created 2 images for each logo, a normal and a selected image. With this change we are now only creating one.
* Opacity change of logos is also animated properly.
* Text logos now increase is size properly. This should reduce/eliminated the `...` that are seen sometimes now with carbon when using the new game collections feature.
* Origin supported for setting carousel position.
* Fixed a bug where background extras would bleed into gamelists when using vertical carousel.
* Alignment options for the logos.
* New vertical wheel carousel type.