### PR TITLE
Use new Raspberry Pi EGL/GLES library names

### DIFF
--- a/CMake/Packages/FindOpenGLES.cmake
+++ b/CMake/Packages/FindOpenGLES.cmake
@@ -50,7 +50,7 @@ ELSE (WIN32)
     )
 
     FIND_LIBRARY(OPENGLES_gl_LIBRARY
-      NAMES GLES_CM GLESv1_CM
+      NAMES brcmGLESv2 GLES_CM GLESv1_CM
       PATHS /opt/graphics/OpenGL/lib
             /usr/openwin/lib
             /usr/shlib /usr/X11R6/lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ endif()
 if(DEFINED BCMHOST)
     LIST(APPEND COMMON_LIBRARIES
         bcm_host
-        EGL
+        brcmEGL
         ${OPENGLES_LIBRARIES}
     )
 else()


### PR DESCRIPTION
Will not break compatibility with jessie, as recent firmware packages also have these files.