### PR TITLE
fix delete-after-use issue with temporary string

### DIFF
--- a/es-app/src/CollectionSystemManager.h
+++ b/es-app/src/CollectionSystemManager.h
@@ -70,7 +70,7 @@ public:
 	void setEditMode(std::string collectionName);
 	void exitEditMode();
 	inline bool isEditing() { return mIsEditingCustom; };
-	inline std::string getEditingCollection() { std::string res = mEditingCollection; return res; };
+	inline std::string getEditingCollection() { return mEditingCollection; };
 	bool toggleGameInCollection(FileData* file);
 
 	SystemData* getSystemToView(SystemData* sys);

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -144,7 +144,8 @@ std::vector<HelpPrompt> BasicGameListView::getHelpPrompts()
 	prompts.push_back(HelpPrompt("x", "random"));
 	if(mRoot->getSystem()->isGameSystem())
 	{
-		prompts.push_back(HelpPrompt("y", "toggle"));
+		std::string prompt = CollectionSystemManager::get()->getEditingCollection();
+		prompts.push_back(HelpPrompt("y", prompt));
 	}
 	return prompts;
 }

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -2,6 +2,7 @@
 
 #include "InputConfig.h"
 #include <memory>
+#include <string>
 #include <Eigen/Dense>
 #include "HelpStyle.h"
 
@@ -11,7 +12,7 @@ class AnimationController;
 class ThemeData;
 class Font;
 
-typedef std::pair<const char*, const char*> HelpPrompt;
+typedef std::pair<std::string, std::string> HelpPrompt;
 
 class GuiComponent
 {

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -331,7 +331,7 @@ void Window::setHelpPrompts(const std::vector<HelpPrompt>& prompts, const HelpSt
 	for(auto it = prompts.begin(); it != prompts.end(); it++)
 	{
 		// only add it if the same icon hasn't already been added
-		if(inputSeenMap.insert(std::make_pair<std::string, bool>(it->first, true)).second)
+		if(inputSeenMap.emplace(it->first, true).second)
 		{
 			// this symbol hasn't been seen yet, what about the action name?
 			auto mappedTo = mappedToSeenMap.find(it->second);
@@ -340,8 +340,8 @@ void Window::setHelpPrompts(const std::vector<HelpPrompt>& prompts, const HelpSt
 				// yes, it has!
 
 				// can we combine? (dpad only)
-				if((strcmp(it->first, "up/down") == 0 && strcmp(addPrompts.at(mappedTo->second).first, "left/right")) ||
-					(strcmp(it->first, "left/right") == 0 && strcmp(addPrompts.at(mappedTo->second).first, "up/down")))
+				if((it->first == "up/down" && addPrompts.at(mappedTo->second).first != "left/right") ||
+					(it->first == "left/right" && addPrompts.at(mappedTo->second).first != "up/down"))
 				{
 					// yes!
 					addPrompts.at(mappedTo->second).first = "up/down/left/right";
@@ -352,7 +352,7 @@ void Window::setHelpPrompts(const std::vector<HelpPrompt>& prompts, const HelpSt
 				}
 			}else{
 				// no, it hasn't!
-				mappedToSeenMap.insert(std::pair<std::string, int>(it->second, addPrompts.size()));
+				mappedToSeenMap.emplace(it->second, addPrompts.size());
 				addPrompts.push_back(*it);
 			}
 		}

--- a/es-core/src/components/ComponentGrid.cpp
+++ b/es-core/src/components/ComponentGrid.cpp
@@ -430,15 +430,15 @@ std::vector<HelpPrompt> ComponentGrid::getHelpPrompts()
 	bool canScrollHoriz = mGridSize.x() > 1;
 	for(auto it = prompts.begin(); it != prompts.end(); it++)
 	{
-		if(strcmp(it->first, "up/down/left/right") == 0)
+		if(it->first == "up/down/left/right")
 		{
 			canScrollHoriz = false;
 			canScrollVert = false;
 			break;
-		}else if(strcmp(it->first, "up/down") == 0)
+		}else if(it->first == "up/down")
 		{
 			canScrollVert = false;
-		}else if(strcmp(it->first, "left/right") == 0)
+		}else if(it->first == "left/right")
 		{
 			canScrollHoriz = false;
 		}

--- a/es-core/src/components/ComponentList.cpp
+++ b/es-core/src/components/ComponentList.cpp
@@ -319,7 +319,7 @@ std::vector<HelpPrompt> ComponentList::getHelpPrompts()
 		bool addMovePrompt = true;
 		for(auto it = prompts.begin(); it != prompts.end(); it++)
 		{
-			if(strcmp(it->first, "up/down") == 0 || strcmp(it->first, "up/down/left/right") == 0)
+			if(it->first == "up/down" || it->first == "up/down/left/right")
 			{
 				addMovePrompt = false;
 				break;

--- a/es-core/src/components/HelpComponent.cpp
+++ b/es-core/src/components/HelpComponent.cpp
@@ -72,7 +72,7 @@ void HelpComponent::updateGrid()
 	for(auto it = mPrompts.begin(); it != mPrompts.end(); it++)
 	{
 		auto icon = std::make_shared<ImageComponent>(mWindow);
-		icon->setImage(getIconTexture(it->first));
+		icon->setImage(getIconTexture(it->first.c_str()));
 		icon->setColorShift(mStyle.iconColor);
 		icon->setResize(0, height);
 		icons.push_back(icon);


### PR DESCRIPTION
I've built EmulationStation on Ubuntu 17.04 and it always triggers an assert() because of invalid utf-8 codepoints when I open a game system view.

After some debugging I saw that it uses a char pointer from a temporary std::string object, and when that pointer reaches the assert() the string was already overwritten by something else.

I would guess that this issue might not occur with older GCC versions or with the old C++ ABI settings because the old ref-counted std::string would have meant that the string would not have been deleted with the temporary object.