### PR TITLE
Setting VRAM default at 80 for the Pi

### DIFF
--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -71,7 +71,11 @@ void Settings::setDefaults()
 	mIntMap["ScreenSaverTime"] = 5*60*1000; // 5 minutes
 	mIntMap["ScraperResizeWidth"] = 400;
 	mIntMap["ScraperResizeHeight"] = 0;
-	mIntMap["MaxVRAM"] = 100;
+	#ifdef _RPI_
+		mIntMap["MaxVRAM"] = 80;
+	#else
+		mIntMap["MaxVRAM"] = 100;
+	#endif
 
 	mStringMap["TransitionStyle"] = "fade";
 	mStringMap["ThemeSet"] = "";


### PR DESCRIPTION
More often than not users are running into glGetErrors 505 (running out of video memory) when using heavy themes with the default 100 VRAM setting.

The advice of setting it to 80 is often the solution.

Until we have a proper/better GPU management solution, this is probably a better default.

**Disclaimer: I have not compiled this (lacking hardware access at the moment).** 