### PR TITLE
add sortname to gamelist.xml to sort by a different name

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -82,6 +82,14 @@ const std::string& FileData::getName()
 	return metadata.get("name");
 }
 
+const std::string& FileData::getSortName()
+{
+	if (metadata.get("sortname").empty())
+		return metadata.get("name");
+	else
+		return metadata.get("sortname");
+}
+
 const std::vector<FileData*>& FileData::getChildrenListToDisplay() {
 
 	FileFilterIndex* idx = CollectionSystemManager::get()->getSystemToView(mSystem)->getIndex();

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -37,6 +37,7 @@ public:
 	virtual ~FileData();
 
 	virtual const std::string& getName();
+	virtual const std::string& getSortName();
 	inline FileType getType() const { return mType; }
 	inline const std::string& getPath() const { return mPath; }
 	inline FileData* getParent() const { return mParent; }

--- a/es-app/src/FileSorts.cpp
+++ b/es-app/src/FileSorts.cpp
@@ -42,8 +42,14 @@ namespace FileSorts
 	bool compareName(const FileData* file1, const FileData* file2)
 	{
 		// we compare the actual metadata name, as collection files have the system appended which messes up the order
-		std::string name1 = Utils::String::toUpper(file1->metadata.get("name"));
-		std::string name2 = Utils::String::toUpper(file2->metadata.get("name"));
+		std::string name1 = Utils::String::toUpper(file1->metadata.get("sortname"));
+		std::string name2 = Utils::String::toUpper(file2->metadata.get("sortname"));
+		if(name1.empty()){
+			name1 = Utils::String::toUpper(file1->metadata.get("name"));
+		}
+		if(name2.empty()){
+			name2 = Utils::String::toUpper(file2->metadata.get("name"));
+		}
 		return name1.compare(name2) < 0;
 	}
 

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -7,6 +7,7 @@
 MetaDataDecl gameDecls[] = {
 	// key,         type,                   default,            statistic,  name in GuiMetaDataEd,  prompt in GuiMetaDataEd
 	{"name",        MD_STRING,              "",                 false,      "name",                 "enter game name"},
+	{"sortname",    MD_STRING,              "",                 false,      "sortname",             "enter game sort name"},
 	{"desc",        MD_MULTILINE_STRING,    "",                 false,      "description",          "enter description"},
 	{"image",       MD_PATH,                "",                 false,      "image",                "enter path to image"},
 	{"video",       MD_PATH     ,           "",                 false,      "video",                "enter path to video"},
@@ -28,6 +29,7 @@ const std::vector<MetaDataDecl> gameMDD(gameDecls, gameDecls + sizeof(gameDecls)
 
 MetaDataDecl folderDecls[] = {
 	{"name",        MD_STRING,              "",                 false,      "name",                 "enter game name"},
+	{"sortname",    MD_STRING,              "",                 false,      "sortname",             "enter game sort name"},
 	{"desc",        MD_MULTILINE_STRING,    "",                 false,      "description",          "enter description"},
 	{"image",       MD_PATH,                "",                 false,      "image",                "enter path to image"},
 	{"thumbnail",   MD_PATH,                "",                 false,      "thumbnail",            "enter path to thumbnail"},

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -30,7 +30,7 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 		char startChar = '!';
 		char endChar = '_';
 
-		char curChar = (char)toupper(getGamelist()->getCursor()->getName()[0]);
+		char curChar = (char)toupper(getGamelist()->getCursor()->getSortName()[0]);
 		if(curChar < startChar || curChar > endChar)
 			curChar = startChar;
 
@@ -41,7 +41,7 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 			const std::vector<FileData*>& files = getGamelist()->getCursor()->getParent()->getChildrenListToDisplay();
 			for (auto file : files)
 			{
-				char candidate = (char)toupper(file->getName()[0]);
+				char candidate = (char)toupper(file->getSortName()[0]);
 				if (c == candidate)
 				{
 					mJumpToLetterList->add(std::string(1, c), c, c == curChar);
@@ -218,11 +218,11 @@ void GuiGamelistOptions::jumpToLetter()
 		if(files.at(mid)->getName().empty())
 			continue;
 
-		char checkLetter = (char)toupper(files.at(mid)->getName()[0]);
+		char checkLetter = (char)toupper(files.at(mid)->getSortName()[0]);
 
 		if(checkLetter < letter)
 			min = mid + 1;
-		else if(checkLetter > letter || (mid > 0 && (letter == toupper(files.at(mid - 1)->getName()[0]))))
+		else if(checkLetter > letter || (mid > 0 && (letter == toupper(files.at(mid - 1)->getSortName()[0]))))
 			max = mid - 1;
 		else
 			break; //exact match found


### PR DESCRIPTION
This is in response to people wanting to sort "The Legend of Zelda" as "Legend of Zelda" alphabetically without dropping the "The" in the displayed name.  It also allows sorting Final Fantasy VII and IX, as "7" and "9" without changing the displayed title.