### PR TITLE
Power Saving enhancements

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -199,7 +199,6 @@ void FileData::launchGame(Window* window)
 
 	window->init();
 	VolumeControl::getInstance()->init();
-	AudioManager::getInstance()->init();
 	window->normalizeNextUpdate();
 
 	//update number of times the game has been launched

--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -76,13 +76,11 @@ public:
 	inline void setSelectorOffsetY(float selectorOffsetY) { mSelectorOffsetY = selectorOffsetY; }
 	inline void setSelectorColor(unsigned int color) { mSelectorColor = color; }
 	inline void setSelectedColor(unsigned int color) { mSelectedColor = color; }
-	inline void setScrollSound(const std::shared_ptr<Sound>& sound) { mScrollSound = sound; }
 	inline void setColor(unsigned int id, unsigned int color) { mColors[id] = color; }
-	inline void setSound(const std::shared_ptr<Sound>& sound) { mScrollSound = sound; }
 	inline void setLineSpacing(float lineSpacing) { mLineSpacing = lineSpacing; }
 
 protected:
-	virtual void onScroll(int amt) { if(mScrollSound) mScrollSound->play(); }
+	virtual void onScroll(int amt) { if(!mScrollSound.empty()) Sound::get(mScrollSound)->play(); }
 	virtual void onCursorChanged(const CursorState& state);
 
 private:
@@ -105,7 +103,7 @@ private:
 	float mSelectorOffsetY;
 	unsigned int mSelectorColor;
 	unsigned int mSelectedColor;
-	std::shared_ptr<Sound> mScrollSound;
+	std::string mScrollSound;
 	static const unsigned int COLOR_ID_COUNT = 2;
 	unsigned int mColors[COLOR_ID_COUNT];
 
@@ -354,7 +352,7 @@ void TextListComponent<T>::applyTheme(const std::shared_ptr<ThemeData>& theme, c
 	setSelectorHeight(selectorHeight);
 
 	if(properties & SOUND && elem->has("scrollSound"))
-		setSound(Sound::get(elem->get<std::string>("scrollSound")));
+		mScrollSound = elem->get<std::string>("scrollSound");
 
 	if(properties & ALIGNMENT)
 	{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -119,7 +119,16 @@ void GuiMenu::openSoundSettings()
 		auto sounds_enabled = std::make_shared<SwitchComponent>(mWindow);
 		sounds_enabled->setState(Settings::getInstance()->getBool("EnableSounds"));
 		s->addWithLabel("ENABLE NAVIGATION SOUNDS", sounds_enabled);
-		s->addSaveFunc([sounds_enabled] { Settings::getInstance()->setBool("EnableSounds", sounds_enabled->getState()); });
+		s->addSaveFunc([sounds_enabled] {
+			if (sounds_enabled->getState()
+				&& !Settings::getInstance()->getBool("EnableSounds")
+				&& PowerSaver::getMode() == PowerSaver::INSTANT)
+			{
+				Settings::getInstance()->setString("PowerSaverMode", "default");
+				PowerSaver::init();
+			}
+			Settings::getInstance()->setBool("EnableSounds", sounds_enabled->getState());
+		});
 
 		auto video_audio = std::make_shared<SwitchComponent>(mWindow);
 		video_audio->setState(Settings::getInstance()->getBool("VideoAudio"));
@@ -300,6 +309,7 @@ void GuiMenu::openOtherSettings()
 		if (Settings::getInstance()->getString("PowerSaverMode") != "instant" && power_saver->getSelected() == "instant") {
 			Settings::getInstance()->setString("TransitionStyle", "instant");
 			Settings::getInstance()->setBool("MoveCarousel", false);
+			Settings::getInstance()->setBool("EnableSounds", false);
 		}
 		Settings::getInstance()->setString("PowerSaverMode", power_saver->getSelected());
 		PowerSaver::init();

--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -1,4 +1,5 @@
 #include "AudioManager.h"
+#include "Settings.h"
 
 #include <SDL.h>
 #include "Log.h"
@@ -62,7 +63,7 @@ AudioManager::~AudioManager()
 std::shared_ptr<AudioManager> & AudioManager::getInstance()
 {
 	//check if an AudioManager instance is already created, if not create one
-	if (sInstance == nullptr) {
+	if (sInstance == nullptr && Settings::getInstance()->getBool("EnableSounds")) {
 		sInstance = std::shared_ptr<AudioManager>(new AudioManager);
 	}
 	return sInstance;

--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -106,6 +106,7 @@ void AudioManager::deinit()
 	//completely tear down SDL audio. else SDL hogs audio resources and emulators might fail to start...
 	SDL_CloseAudio();
 	SDL_QuitSubSystem(SDL_INIT_AUDIO);
+	sInstance = NULL;
 }
 
 void AudioManager::registerSound(std::shared_ptr<Sound> & sound)

--- a/es-core/src/PowerSaver.cpp
+++ b/es-core/src/PowerSaver.cpp
@@ -1,4 +1,5 @@
 #include "PowerSaver.h"
+#include "AudioManager.h"
 #include "Settings.h"
 #include <string.h>
 
@@ -17,6 +18,9 @@ void PowerSaver::init()
 
 int PowerSaver::getTimeout()
 {
+	if (SDL_GetAudioStatus() == SDL_AUDIO_PAUSED)
+		AudioManager::getInstance()->deinit();
+
 	// Used only for SDL_WaitEventTimeout. Use `getMode()` for modes.
 	return mRunningScreenSaver ? mWakeupTimeout : mScreenSaverTimeout;
 }

--- a/es-core/src/Sound.cpp
+++ b/es-core/src/Sound.cpp
@@ -114,6 +114,8 @@ void Sound::play()
 	if(!Settings::getInstance()->getBool("EnableSounds"))
 		return;
 
+	AudioManager::getInstance();
+
 	SDL_LockAudio();
 	if (playing)
 	{

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -191,11 +191,6 @@ void VideoPlayerComponent::stopVideo()
 		int status;
 		kill(mPlayerPid, SIGKILL);
 		waitpid(mPlayerPid, &status, WNOHANG);
-		// Restart AudioManager
-		if (boost::starts_with(Settings::getInstance()->getString("OMXAudioDev").c_str(), "alsa"))
-		{
-			AudioManager::getInstance()->init();
-		}
 		mPlayerPid = -1;
 	}
 }


### PR DESCRIPTION
I figured out the issue with constant 2-3% CPU usage. When the audio driver is opened via SDL_OpenAudio, there will be a constant stream of failing ioctls from the ALSA driver, even when there's no active playback.

**strace -f -p $(pidof emulationstation)** will show this spammed constantly, even during idle & no background audio running: 

```
4326  ioctl(4, SNDRV_PCM_IOCTL_WRITEI_FRAMES, 0x76f2edc0) = -1 EAGAIN (Resource temporarily unavailable)
4326  ioctl(4, SNDRV_PCM_IOCTL_WRITEI_FRAMES, 0x76f2edc0) = -1 EAGAIN (Resource temporarily unavailable)
4326  ioctl(4, SNDRV_PCM_IOCTL_WRITEI_FRAMES, 0x76f2edc0) = -1 EAGAIN (Resource temporarily unavailable)
4326  ioctl(4, SNDRV_PCM_IOCTL_WRITEI_FRAMES, 0x76f2edc0) = -1 EAGAIN (Resource temporarily unavailable)
4326  ioctl(4, SNDRV_PCM_IOCTL_WRITEI_FRAMES, 0x76f2edc0) = -1 EAGAIN (Resource temporarily unavailable)
4326  ioctl(4, SNDRV_PCM_IOCTL_WRITEI_FRAMES, 0x76f2edc0) = -1 EAGAIN (Resource temporarily unavailable)
4326  ioctl(4, SNDRV_PCM_IOCTL_WRITEI_FRAMES, 0x76f2edc0) = -1 EAGAIN (Resource temporarily unavailable)
4326  ioctl(4, SNDRV_PCM_IOCTL_WRITEI_FRAMES, 0x76f2edc0) = -1 EAGAIN (Resource temporarily unavailable)
4326  ioctl(4, SNDRV_PCM_IOCTL_WRITEI_FRAMES, 0x76f2edc0) = 0
4326  ioctl(4, SNDRV_PCM_IOCTL_SYNC_PTR, 0x2ee8f8) = 0
```
As I noted before, certain themes seem immune to the problem *until* after launching something. The reason is now clear:

- if a theme has a "scrollSound" element (such as Carbon), the ViewController::get()->preload() function that's called during early startup will cause the the audio device to open: https://github.com/RetroPie/EmulationStation/blob/master/es-app/src/components/TextListComponent.h#L357. Anything that calls AudioManager::getInstance() or AudioManager's init() directly will trigger the bug. 
- if a theme has no "scrollSound" element, the preload function will never trigger a call to Sound::get(x), so the audio device will not be opened until ES returns from launching an item, here: https://github.com/RetroPie/EmulationStation/blob/master/es-app/src/FileData.cpp#L202. This means that a theme with no scrollSound will not exhibit the extra CPU usage upon program start, but the CPU usage will occur after returning from a launched item due to the AudioManager instance being unnecessarily inited.

With this PS, the new behaviour is:

- ViewController::preload() will no longer trigger audio initialization on startup. Instead, onScroll will trigger audio init only when  playback is really needed.
- Audio is not explicitly re-initialized when returning from a launched item. Instead, I've made changes to ensure that when audio has been de-initialized, the re-initialization will trigger automatically for anything calling AudioManager::getInstance().
- Add an additional check in AudioManager::getInstance() so that audio init will not be triggered if navigation sounds are disabled. This will ensure that the audio device is never opened unnecessarily.
- The audio device will be closed during power saving mode (but only if no playback is detected as occurring).
- Force-disable audio in INSTANT PowerSaver mode. This is necessary to avoid lag introduced by constant deinit/reinit due to the 200ms delay between user input ending and audio deinit being triggered. 

The combined result is that idle CPU (with PS active) usage now goes down to 0.3%. Aside from CPU, keeping the audio device closed may possibly reduce power draw/heat, but that's only if the hardware audio codec powers down the chip (I've no idea about this, and don't have any means to test USB current draw).
