### PR TITLE
display info without waiting for cursor change

### DIFF
--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -142,7 +142,11 @@ void TextListComponent<T>::render(const Eigen::Affine3f& parentTrans)
 
 	if(size() == 0)
 		return;
-
+	
+        /* force update info before we render if cursor is on first element */
+  	if(mCursor == 0)
+                stopScrolling();
+	
 	const float entrySize = std::max(font->getHeight(1.0), (float)font->getSize()) * mLineSpacing;
 
 	int startEntry = 0;


### PR DESCRIPTION
When roms are in their own folders you enter the folder and the boxart and descriptions are blank until you scroll within the list, that could be either up/down or left/right. The same behaviour may also be observed in other contexts but this was the first I noted.

Calls stopScrolling(); if cursor is on first element, effecting a redraw event