### PR TITLE
Achievements Metadata Support

### DIFF
--- a/es-app/src/FileFilterIndex.h
+++ b/es-app/src/FileFilterIndex.h
@@ -16,7 +16,8 @@ enum FilterIndexType
 	PLAYER_FILTER,
 	PUBDEV_FILTER,
 	RATINGS_FILTER,
-	FAVORITES_FILTER
+	FAVORITES_FILTER,
+	ACHIEVEMENTS_FILTER
 };
 
 struct FilterDataDecl
@@ -42,7 +43,7 @@ public:
 	void clearAllFilters();
 	void debugPrintIndexes();
 	bool showFile(FileData* game);
-	bool isFiltered() { return (filterByGenre || filterByPlayers || filterByPubDev || filterByRatings || filterByFavorites); };
+	bool isFiltered() { return (filterByGenre || filterByPlayers || filterByPubDev || filterByRatings || filterByFavorites || filterByAchievements); };
 	bool isKeyBeingFilteredBy(std::string key, FilterIndexType type);
 	std::vector<FilterDataDecl>& getFilterDataDecls();
 
@@ -57,6 +58,7 @@ private:
 	void managePubDevEntryInIndex(FileData* game, bool remove = false);
 	void manageRatingsEntryInIndex(FileData* game, bool remove = false);
 	void manageFavoritesEntryInIndex(FileData* game, bool remove = false);
+	void manageAchievementsEntryInIndex(FileData* game, bool remove = false);
 
 	void manageIndexEntry(std::map<std::string, int>* index, std::string key, bool remove);
 
@@ -67,18 +69,21 @@ private:
 	bool filterByPubDev;
 	bool filterByRatings;
 	bool filterByFavorites;
+	bool filterByAchievements;
 
 	std::map<std::string, int> genreIndexAllKeys;
 	std::map<std::string, int> playersIndexAllKeys;
 	std::map<std::string, int> pubDevIndexAllKeys;
 	std::map<std::string, int> ratingsIndexAllKeys;
 	std::map<std::string, int> favoritesIndexAllKeys;
+	std::map<std::string, int> achievementsIndexAllKeys;
 
 	std::vector<std::string> genreIndexFilteredKeys;
 	std::vector<std::string> playersIndexFilteredKeys;
 	std::vector<std::string> pubDevIndexFilteredKeys;
 	std::vector<std::string> ratingsIndexFilteredKeys;
 	std::vector<std::string> favoritesIndexFilteredKeys;
+    std::vector<std::string> achievementsIndexFilteredKeys;
 
 	FileData* mRootFolder;
 

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -6,22 +6,23 @@
 namespace fs = boost::filesystem;
 
 MetaDataDecl gameDecls[] = {
-	// key,         type,                   default,            statistic,  name in GuiMetaDataEd,  prompt in GuiMetaDataEd
-	{"name",        MD_STRING,              "",                 false,      "name",                 "enter game name"},
-	{"desc",        MD_MULTILINE_STRING,    "",                 false,      "description",          "enter description"},
-	{"image",       MD_PATH,                "",                 false,      "image",                "enter path to image"},
-	{"video",       MD_PATH     ,           "",                 false,      "video",                "enter path to video"},
-	{"marquee",     MD_PATH,                "",                 false,      "marquee",              "enter path to marquee"},
-	{"thumbnail",   MD_PATH,                "",                 false,      "thumbnail",            "enter path to thumbnail"},
-	{"rating",      MD_RATING,              "0.000000",         false,      "rating",               "enter rating"},
-	{"releasedate", MD_DATE,                "not-a-date-time",  false,      "release date",         "enter release date"},
-	{"developer",   MD_STRING,              "unknown",          false,      "developer",            "enter game developer"},
-	{"publisher",   MD_STRING,              "unknown",          false,      "publisher",            "enter game publisher"},
-	{"genre",       MD_STRING,              "unknown",          false,      "genre",                "enter game genre"},
-	{"players",     MD_INT,                 "1",                false,      "players",              "enter number of players"},
-	{"favorite",    MD_BOOL,                "false",            false,      "favorite",             "enter favorite off/on"},
-	{"playcount",   MD_INT,                 "0",                true,       "play count",           "enter number of times played"},
-	{"lastplayed",  MD_TIME,                "0",                true,       "last played",          "enter last played date"}
+	// key,          type,                   default,            statistic,  name in GuiMetaDataEd,  prompt in GuiMetaDataEd
+	{"name",         MD_STRING,              "",                 false,      "name",                 "enter game name"},
+	{"desc",         MD_MULTILINE_STRING,    "",                 false,      "description",          "enter description"},
+	{"image",        MD_PATH,                "",                 false,      "image",                "enter path to image"},
+	{"video",        MD_PATH     ,           "",                 false,      "video",                "enter path to video"},
+	{"marquee",      MD_PATH,                "",                 false,      "marquee",              "enter path to marquee"},
+	{"thumbnail",    MD_PATH,                "",                 false,      "thumbnail",            "enter path to thumbnail"},
+	{"rating",       MD_RATING,              "0.000000",         false,      "rating",               "enter rating"},
+	{"releasedate",  MD_DATE,                "not-a-date-time",  false,      "release date",         "enter release date"},
+	{"developer",    MD_STRING,              "unknown",          false,      "developer",            "enter game developer"},
+	{"publisher",    MD_STRING,              "unknown",          false,      "publisher",            "enter game publisher"},
+	{"genre",        MD_STRING,              "unknown",          false,      "genre",                "enter game genre"},
+	{"players",      MD_INT,                 "1",                false,      "players",              "enter number of players"},
+	{"favorite",     MD_BOOL,                "false",            false,      "favorite",             "enter favorite off/on"},
+	{"achievements", MD_BOOL,                "false",            false,      "achievements",         "enter achievement support off/on"},
+	{"playcount",    MD_INT,                 "0",                true,       "play count",           "enter number of times played"},
+	{"lastplayed",   MD_TIME,                "0",                true,       "last played",          "enter last played date"}
 };
 const std::vector<MetaDataDecl> gameMDD(gameDecls, gameDecls + sizeof(gameDecls) / sizeof(gameDecls[0]));
 


### PR DESCRIPTION
This adds "Achievements" metadata support in ES, per requests and discussions here:

https://retropie.org.uk/forum/topic/11859/what-about-adding-a-cheevos-flag-in-gamelist-xml

It has been tested by @meleu at least, but as always further testing is always appreciated.

Thanks.