### PR TITLE
UI modes part 2: Kid mode (File Filtering and system hiding)

### DIFF
--- a/es-app/src/FileFilterIndex.h
+++ b/es-app/src/FileFilterIndex.h
@@ -14,7 +14,9 @@ enum FilterIndexType
 	PLAYER_FILTER,
 	PUBDEV_FILTER,
 	RATINGS_FILTER,
-	FAVORITES_FILTER
+	FAVORITES_FILTER,
+	HIDDEN_FILTER,
+	KIDGAME_FILTER
 };
 
 struct FilterDataDecl
@@ -40,12 +42,15 @@ public:
 	void clearAllFilters();
 	void debugPrintIndexes();
 	bool showFile(FileData* game);
-	bool isFiltered() { return (filterByGenre || filterByPlayers || filterByPubDev || filterByRatings || filterByFavorites); };
+	bool isFiltered() { return (filterByGenre || filterByPlayers || filterByPubDev || filterByRatings || filterByFavorites || filterByHidden || filterByKidGame); };
 	bool isKeyBeingFilteredBy(std::string key, FilterIndexType type);
 	std::vector<FilterDataDecl>& getFilterDataDecls();
 
 	void importIndex(FileFilterIndex* indexToImport);
 	void resetIndex();
+	void resetFilters();
+	void setUIModeFilters();
+
 private:
 	std::vector<FilterDataDecl> filterDataDecl;
 	std::string getIndexableKey(FileData* game, FilterIndexType type, bool getSecondary);
@@ -55,6 +60,8 @@ private:
 	void managePubDevEntryInIndex(FileData* game, bool remove = false);
 	void manageRatingsEntryInIndex(FileData* game, bool remove = false);
 	void manageFavoritesEntryInIndex(FileData* game, bool remove = false);
+	void manageHiddenEntryInIndex(FileData* game, bool remove = false);
+	void manageKidGameEntryInIndex(FileData* game, bool remove = false);
 
 	void manageIndexEntry(std::map<std::string, int>* index, std::string key, bool remove);
 
@@ -65,18 +72,24 @@ private:
 	bool filterByPubDev;
 	bool filterByRatings;
 	bool filterByFavorites;
+	bool filterByHidden;
+	bool filterByKidGame;
 
 	std::map<std::string, int> genreIndexAllKeys;
 	std::map<std::string, int> playersIndexAllKeys;
 	std::map<std::string, int> pubDevIndexAllKeys;
 	std::map<std::string, int> ratingsIndexAllKeys;
 	std::map<std::string, int> favoritesIndexAllKeys;
+	std::map<std::string, int> hiddenIndexAllKeys;
+	std::map<std::string, int> kidGameIndexAllKeys;
 
 	std::vector<std::string> genreIndexFilteredKeys;
 	std::vector<std::string> playersIndexFilteredKeys;
 	std::vector<std::string> pubDevIndexFilteredKeys;
 	std::vector<std::string> ratingsIndexFilteredKeys;
 	std::vector<std::string> favoritesIndexFilteredKeys;
+	std::vector<std::string> hiddenIndexFilteredKeys;
+	std::vector<std::string> kidGameIndexFilteredKeys;
 
 	FileData* mRootFolder;
 

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -21,6 +21,8 @@ MetaDataDecl gameDecls[] = {
 	{"genre",       MD_STRING,              "unknown",          false,      "genre",                "enter game genre"},
 	{"players",     MD_INT,                 "1",                false,      "players",              "enter number of players"},
 	{"favorite",    MD_BOOL,                "false",            false,      "favorite",             "enter favorite off/on"},
+	{"hidden",      MD_BOOL,                "false",            false,      "hidden",               "enter hidden off/on" },
+	{"kidgame",     MD_BOOL,                "false",            false,      "kidgame",              "enter kidgame off/on" },
 	{"playcount",   MD_INT,                 "0",                true,       "play count",           "enter number of times played"},
 	{"lastplayed",  MD_TIME,                "0",                true,       "last played",          "enter last played date"}
 };

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -340,6 +340,33 @@ std::string SystemData::getConfigPath(bool forWrite)
 	return "/etc/emulationstation/es_systems.cfg";
 }
 
+SystemData* SystemData::getNext() const
+{
+	std::vector<SystemData*>::const_iterator it = getIterator();
+
+	do {
+		it++;
+		if (it == sSystemVector.end())
+			it = sSystemVector.begin();
+	} while ((*it)->getDisplayedGameCount() == 0); 
+	// as we are starting in a valid gamelistview, this will always succeed, even if we have to come full circle.
+
+	return *it;
+}
+
+SystemData* SystemData::getPrev() const
+{
+	auto it = getRevIterator();
+	do {
+		it++;
+		if (it == sSystemVector.rend())
+			it = sSystemVector.rbegin();
+	} while ((*it)->getDisplayedGameCount() == 0);
+	// as we are starting in a valid gamelistview, this will always succeed, even if we have to come full circle.
+
+	return *it;
+}
+
 std::string SystemData::getGamelistPath(bool forWrite) const
 {
 	fs::path filePath;

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -56,22 +56,9 @@ public:
 	inline std::vector<SystemData*>::const_reverse_iterator getRevIterator() const { return std::find(sSystemVector.rbegin(), sSystemVector.rend(), this); };
 	inline bool isCollection() { return mIsCollectionSystem; };
 	inline bool isGameSystem() { return mIsGameSystem; }
-	inline SystemData* getNext() const
-	{
-		auto it = getIterator();
-		it++;
-		if(it == sSystemVector.end()) it = sSystemVector.begin();
-		return *it;
-	}
-
-	inline SystemData* getPrev() const
-	{
-		auto it = getRevIterator();
-		it++;
-		if(it == sSystemVector.rend()) it = sSystemVector.rbegin();
-		return *it;
-	}
-
+	
+	SystemData* getNext() const;
+	SystemData* getPrev() const;
 	static SystemData* getRandomSystem();
 	FileData* getRandomGame();
 

--- a/es-app/src/guis/GuiGamelistFilter.cpp
+++ b/es-app/src/guis/GuiGamelistFilter.cpp
@@ -1,6 +1,7 @@
 #include "guis/GuiGamelistFilter.h"
 
 #include "components/OptionListComponent.h"
+#include "views/ViewController.h"
 #include "SystemData.h"
 
 GuiGamelistFilter::GuiGamelistFilter(Window* window, SystemData* system) : GuiComponent(window), mMenu(window, "FILTER GAMELIST BY"), mSystem(system)
@@ -34,7 +35,7 @@ void GuiGamelistFilter::initializeMenu()
 
 void GuiGamelistFilter::resetAllFilters()
 {
-	mFilterIndex->clearAllFilters();
+	mFilterIndex->resetFilters();
 	for (std::map<FilterIndexType, std::shared_ptr< OptionListComponent<std::string> >>::iterator it = mFilterOptions.begin(); it != mFilterOptions.end(); ++it ) {
 		std::shared_ptr< OptionListComponent<std::string> > optionList = it->second;
 		optionList->selectNone();
@@ -49,7 +50,14 @@ GuiGamelistFilter::~GuiGamelistFilter()
 void GuiGamelistFilter::addFiltersToMenu()
 {
 	std::vector<FilterDataDecl> decls = mFilterIndex->getFilterDataDecls();
-	for (std::vector<FilterDataDecl>::iterator it = decls.begin(); it != decls.end(); ++it ) {
+	
+	int skip = 0;
+	if (!ViewController::get()->isUIModeFull())
+		skip = 1;
+	if (ViewController::get()->isUIModeKid())
+		skip = 2;
+
+	for (std::vector<FilterDataDecl>::iterator it = decls.begin(); it != decls.end()-skip; ++it ) {
 
 		FilterIndexType type = (*it).type; // type of filter
 		std::map<std::string, int>* allKeys = (*it).allIndexKeys; // all possible filters for this type

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -38,7 +38,8 @@ GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MEN
 	if (isFullUI)
 		addEntry("CONFIGURE INPUT", 0x777777FF, true, [this] { openConfigInput(); });
 
-	addEntry("QUIT", 0x777777FF, true, [this] {openQuitMenu(); });
+	if (!(ViewController::get()->isUIModeKid() && Settings::getInstance()->getBool("hideQuitMenuOnKidUI")))
+		addEntry("QUIT", 0x777777FF, true, [this] {openQuitMenu(); });
 
 	addChild(&mMenu);
 	addVersionInfo();
@@ -422,12 +423,11 @@ void GuiMenu::openQuitMenu()
 			s->addRow(row);
 		}
 	}
-
 	row.elements.clear();
 	row.makeAcceptInputHandler([window] {
 		window->pushGui(new GuiMsgBox(window, "REALLY RESTART?", "YES",
 			[] {
-			if(quitES("/tmp/es-sysrestart") != 0)
+			if (quitES("/tmp/es-sysrestart") != 0)
 				LOG(LogWarning) << "Restart terminated with non-zero result!";
 		}, "NO", nullptr));
 	});
@@ -455,7 +455,6 @@ void GuiMenu::addVersionInfo()
 	mVersion.setText("EMULATIONSTATION V" + strToUpper(PROGRAM_VERSION_STRING));
 	mVersion.setHorizontalAlignment(ALIGN_CENTER);
 	addChild(&mVersion);
-
 }
 
 void GuiMenu::openScreensaverOptions() {

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -86,7 +86,12 @@ bool parseArgs(int argc, char* argv[], unsigned int* width, unsigned int* height
 		else if (strcmp(argv[i], "--force-kiosk") == 0)
 		{
 			Settings::getInstance()->setBool("ForceKiosk", true);
-		}else if(strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0)
+		}
+		else if (strcmp(argv[i], "--force-kid") == 0)
+		{
+			Settings::getInstance()->setBool("ForceKid", true);
+		}
+		else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0)
 		{
 #ifdef WIN32
 			// This is a bit of a hack, but otherwise output will go to nowhere

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -1,6 +1,7 @@
 #include "views/SystemView.h"
 
 #include "animations/LambdaAnimation.h"
+#include "guis/GuiMsgBox.h"
 #include "views/ViewController.h"
 #include "Log.h"
 #include "Renderer.h"
@@ -35,78 +36,88 @@ void SystemView::populate()
 		if(mViewNeedsReload)
 			getViewElements(theme);
 
-		Entry e;
-		e.name = (*it)->getName();
-		e.object = *it;
-
-		// make logo
-		const ThemeData::ThemeElement* logoElem = theme->getElement("system", "logo", "image");
-		if(logoElem)
+		if((*it)->getDisplayedGameCount() > 0)
 		{
-			std::string path = logoElem->get<std::string>("path");
-			std::string defaultPath = logoElem->has("default") ? logoElem->get<std::string>("default") : "";
-			if((!path.empty() && ResourceManager::getInstance()->fileExists(path))
-			   || (!defaultPath.empty() && ResourceManager::getInstance()->fileExists(defaultPath)))
+			Entry e;
+			e.name = (*it)->getName();
+			e.object = *it;
+
+			// make logo
+			const ThemeData::ThemeElement* logoElem = theme->getElement("system", "logo", "image");
+			if(logoElem)
 			{
-				ImageComponent* logo = new ImageComponent(mWindow, false, false);
-				logo->setMaxSize(mCarousel.logoSize * mCarousel.logoScale);
-				logo->applyTheme(theme, "system", "logo", ThemeFlags::PATH | ThemeFlags::COLOR);
-
-				e.data.logo = std::shared_ptr<GuiComponent>(logo);
+				std::string path = logoElem->get<std::string>("path");
+				std::string defaultPath = logoElem->has("default") ? logoElem->get<std::string>("default") : "";
+				if((!path.empty() && ResourceManager::getInstance()->fileExists(path))
+				   || (!defaultPath.empty() && ResourceManager::getInstance()->fileExists(defaultPath)))
+				{
+					ImageComponent* logo = new ImageComponent(mWindow, false, false);
+					logo->setMaxSize(mCarousel.logoSize * mCarousel.logoScale);
+					logo->applyTheme(theme, "system", "logo", ThemeFlags::PATH | ThemeFlags::COLOR);
+					e.data.logo = std::shared_ptr<GuiComponent>(logo);
+				}
 			}
-		}
-		if (!e.data.logo)
-		{
-			// no logo in theme; use text
-			TextComponent* text = new TextComponent(mWindow,
-				(*it)->getName(),
-				Font::get(FONT_SIZE_LARGE),
-				0x000000FF,
-				ALIGN_CENTER);
-			text->setSize(mCarousel.logoSize * mCarousel.logoScale);
-			text->applyTheme((*it)->getTheme(), "system", "logoText", ThemeFlags::FONT_PATH | ThemeFlags::FONT_SIZE | ThemeFlags::COLOR | ThemeFlags::FORCE_UPPERCASE);
-			e.data.logo = std::shared_ptr<GuiComponent>(text);
+			if (!e.data.logo)
+			{
+				// no logo in theme; use text
+				TextComponent* text = new TextComponent(mWindow,
+					(*it)->getName(),
+					Font::get(FONT_SIZE_LARGE),
+					0x000000FF,
+					ALIGN_CENTER);
+				text->setSize(mCarousel.logoSize * mCarousel.logoScale);
+				text->applyTheme((*it)->getTheme(), "system", "logoText", ThemeFlags::FONT_PATH | ThemeFlags::FONT_SIZE | ThemeFlags::COLOR | ThemeFlags::FORCE_UPPERCASE);
+				e.data.logo = std::shared_ptr<GuiComponent>(text);
+
+				if (mCarousel.type == VERTICAL || mCarousel.type == VERTICAL_WHEEL)
+					text->setHorizontalAlignment(mCarousel.logoAlignment);
+				else
+					text->setVerticalAlignment(mCarousel.logoAlignment);
+			}
 
 			if (mCarousel.type == VERTICAL || mCarousel.type == VERTICAL_WHEEL)
-				text->setHorizontalAlignment(mCarousel.logoAlignment);
-			else
-				text->setVerticalAlignment(mCarousel.logoAlignment);
-		}
+			{
+				if (mCarousel.logoAlignment == ALIGN_LEFT)
+					e.data.logo->setOrigin(0, 0.5);
+				else if (mCarousel.logoAlignment == ALIGN_RIGHT)
+					e.data.logo->setOrigin(1.0, 0.5);
+				else
+					e.data.logo->setOrigin(0.5, 0.5);
+			} else {
+				if (mCarousel.logoAlignment == ALIGN_TOP)
+					e.data.logo->setOrigin(0.5, 0);
+				else if (mCarousel.logoAlignment == ALIGN_BOTTOM)
+					e.data.logo->setOrigin(0.5, 1);
+				else
+					e.data.logo->setOrigin(0.5, 0.5);
+			}
 
-		if (mCarousel.type == VERTICAL || mCarousel.type == VERTICAL_WHEEL)
+			Vector2f denormalized = mCarousel.logoSize * e.data.logo->getOrigin();
+			e.data.logo->setPosition(denormalized.x(), denormalized.y(), 0.0);
+			// delete any existing extras
+			for (auto extra : e.data.backgroundExtras)
+				delete extra;
+			e.data.backgroundExtras.clear();
+
+			// make background extras
+			e.data.backgroundExtras = ThemeData::makeExtras((*it)->getTheme(), "system", mWindow);
+
+			// sort the extras by z-index
+			std::stable_sort(e.data.backgroundExtras.begin(), e.data.backgroundExtras.end(),  [](GuiComponent* a, GuiComponent* b) {
+				return b->getZIndex() > a->getZIndex();
+			});
+
+			this->add(e);
+		}
+	}
+	if (mEntries.size() == 0)
+	{
+		// Something is wrong, there is not a single system to show, check if UI mode is not full
+		if (!ViewController::get()->isUIModeFull())
 		{
-			if (mCarousel.logoAlignment == ALIGN_LEFT)
-				e.data.logo->setOrigin(0, 0.5);
-			else if (mCarousel.logoAlignment == ALIGN_RIGHT)
-				e.data.logo->setOrigin(1.0, 0.5);
-			else
-				e.data.logo->setOrigin(0.5, 0.5);
-		} else {
-			if (mCarousel.logoAlignment == ALIGN_TOP)
-				e.data.logo->setOrigin(0.5, 0);
-			else if (mCarousel.logoAlignment == ALIGN_BOTTOM)
-				e.data.logo->setOrigin(0.5, 1);
-			else
-				e.data.logo->setOrigin(0.5, 0.5);
+			Settings::getInstance()->setString("UIMode", "Full");
+			mWindow->pushGui(new GuiMsgBox(mWindow, "The selected UI mode has nothing to show,\n returning to UI mode: FULL", "OK", nullptr));
 		}
-
-		Vector2f denormalized = mCarousel.logoSize * e.data.logo->getOrigin();
-		e.data.logo->setPosition(denormalized.x(), denormalized.y(), 0.0);
-
-		// delete any existing extras
-		for (auto extra : e.data.backgroundExtras)
-			delete extra;
-		e.data.backgroundExtras.clear();
-
-		// make background extras
-		e.data.backgroundExtras = ThemeData::makeExtras((*it)->getTheme(), "system", mWindow);
-
-		// sort the extras by z-index
-		std::stable_sort(e.data.backgroundExtras.begin(), e.data.backgroundExtras.end(),  [](GuiComponent* a, GuiComponent* b) {
-			return b->getZIndex() > a->getZIndex();
-		});
-
-		this->add(e);
 	}
 }
 

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -11,7 +11,7 @@ class IGameListView;
 class SystemData;
 class SystemView;
 
-const std::vector<std::string> UIModes = { "Full", "Kiosk" };
+const std::vector<std::string> UIModes = { "Full", "Kiosk", "Kid" };
 
 // Used to smoothly transition the camera between multiple views (e.g. from system to system, from gamelist to gamelist).
 class ViewController : public GuiComponent
@@ -33,8 +33,9 @@ public:
 	void reloadAll(); // Reload everything with a theme.  Used when the "ThemeSet" setting changes.
 
 	void monitorUIMode();
-	bool isUIModeFull();
 	inline std::vector<std::string> getUIModes() { return UIModes; };
+	bool isUIModeFull();
+	bool isUIModeKid();
 
 	// Navigation.
 	void goToNextGameList();

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -141,7 +141,7 @@ std::vector<HelpPrompt> BasicGameListView::getHelpPrompts()
 	prompts.push_back(HelpPrompt("b", "back"));
 	prompts.push_back(HelpPrompt("select", "options"));
 	prompts.push_back(HelpPrompt("x", "random"));
-	if(mRoot->getSystem()->isGameSystem())
+	if(mRoot->getSystem()->isGameSystem() && !ViewController::get()->isUIModeKid())
 	{
 		std::string prompt = CollectionSystemManager::get()->getEditingCollection();
 		prompts.push_back(HelpPrompt("y", prompt));

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -142,7 +142,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 				setCursor(randomGame);
 			}
 			return true;
-		}else if (config->isMappedTo("y", input))
+		}else if (config->isMappedTo("y", input) && !(ViewController::get()->isUIModeKid()))
 		{
 			if(mRoot->getSystem()->isGameSystem())
 			{

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -14,6 +14,7 @@ std::vector<const char*> settings_dont_save = boost::assign::list_of
 	("Debug")
 	("DebugGrid")
 	("DebugText")
+	("ForceKid")
 	("ForceKiosk")
 	("IgnoreGamelist")
 	("HideConsole")
@@ -124,6 +125,8 @@ void Settings::setDefaults()
 	mStringMap["UIMode"] = "Full";
 	mStringMap["UIMode_passkey"] = "uuddlrlrba";
 	mBoolMap["ForceKiosk"] = false;
+	mBoolMap["ForceKid"] = false;
+	mBoolMap["hideQuitMenuOnKidUI"] = false;
 }
 
 template <typename K, typename V>


### PR DESCRIPTION
This is the second part of the UI modes delivery.
It build on part one (shielding ES menus), by employing the filter mechanism in order to hide items that are unwanted.
Two modi operandi are introduced here:
1. Kiosk, where only specific items are hidden, and all else is shown.
2. Kid, where only specific items are shown, and all else is hidden.

This filtering is based on two new metadata values for these items `hidden` and `kidgame`, both of type boolean.

This brings the total number of UI modes to three: Full, Kiosk and Kid.

Final cleanup of automatic whitespace shifts and such will be done once everyone has had a chance to have a look at this.