### PR TITLE
CMake: use correct Raspberry Pi library names & fix generic GLES support

### DIFF
--- a/CMake/Packages/FindOpenGLES.cmake
+++ b/CMake/Packages/FindOpenGLES.cmake
@@ -42,21 +42,33 @@ ELSE (WIN32)
 
   ELSE(APPLE)
 
-    FIND_PATH(OPENGLES_INCLUDE_DIR GLES/gl.h
-      /usr/openwin/share/include
-      /opt/graphics/OpenGL/include /usr/X11R6/include
-      /usr/include
-      /opt/vc/include
-    )
+    IF (DEFINED BCMHOST)
+      FIND_PATH(OPENGLES_INCLUDE_DIR GLES/gl.h
+        /opt/vc/include
+        NO_DEFAULT_PATH
+      )
 
-    FIND_LIBRARY(OPENGLES_gl_LIBRARY
-      NAMES GLES_CM GLESv1_CM
-      PATHS /opt/graphics/OpenGL/lib
-            /usr/openwin/lib
-            /usr/shlib /usr/X11R6/lib
-            /usr/lib
-            /opt/vc/lib
-    )
+      FIND_LIBRARY(OPENGLES_gl_LIBRARY
+        NAMES brcmGLESv2
+        PATHS /opt/vc/lib
+      )
+
+    ELSE (DEFINED BCMHOST)
+
+      FIND_PATH(OPENGLES_INCLUDE_DIR GLES/gl.h
+        /usr/openwin/share/include
+        /opt/graphics/OpenGL/include /usr/X11R6/include
+        /usr/include
+      )
+
+      FIND_LIBRARY(OPENGLES_gl_LIBRARY
+        NAMES GLES_CM GLESv1_CM
+        PATHS /opt/graphics/OpenGL/lib
+              /usr/openwin/lib
+              /usr/shlib /usr/X11R6/lib
+              /usr/lib
+      )
+    ENDIF (DEFINED BCMHOST)
 
     # On Unix OpenGL most certainly always requires X11.
     # Feel free to tighten up these conditions if you don't 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ endif()
 if(DEFINED BCMHOST)
     LIST(APPEND COMMON_LIBRARIES
         bcm_host
-        EGL
+        brcmEGL
         ${OPENGLES_LIBRARIES}
     )
 else()


### PR DESCRIPTION
* For BCMHOST build, use brcmEGL / brcmGLESv2 libraries, and don't look at
  Mesa includes (so libraspberrypi-dev and libgles*-mesa-dev can coexist).
* If overridden via -DGLES=On, don't present vendor includes to build to
  make absolutely sure that the Mesa includes are used.

Fixes stretch vendor library building & generic Mesa GLES compatibility.