### PR TITLE
Second stab at normalizing volume scale for OMX Player

### DIFF
--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -116,7 +116,7 @@ void VideoPlayerComponent::startVideo()
 				else
 				{
 					float percentVolume = (float)VolumeControl::getInstance()->getVolume();
-					int OMXVolume = (int)(log(percentVolume/100)*2000);
+					int OMXVolume = (int)((percentVolume-98)*105);
 					argv[8] = std::to_string(OMXVolume).c_str();
 				}
 


### PR DESCRIPTION
This commit aims to make the OMX Player volume as close to the ALSA/VLC one as possible, as the ES Sound Settings slider goes lower. The previous formula, found online, didn't seem to match what was intended, so after experimenting with the several levels and what sounded similar, this is a better approximation.