### PR TITLE
Fix build warnings (mostly adding explicit type casting)

### DIFF
--- a/es-app/src/FileFilterIndex.cpp
+++ b/es-app/src/FileFilterIndex.cpp
@@ -131,7 +131,7 @@ std::string FileFilterIndex::getIndexableKey(FileData* game, FilterIndexType typ
 					}
 					catch (int e)
 					{
-						LOG(LogError) << "Error parsing Rating (invalid value, expected decimal): " << ratingString;
+						LOG(LogError) << "Error parsing Rating (invalid value, exception nr.): " << ratingString << ", " << e;
 					}
 				}
 			}

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -151,7 +151,7 @@ bool MetaDataList::isDefault()
 {
 	const std::vector<MetaDataDecl>& mdd = getMDD();
 
-	for (int i = 1; i < mMap.size(); i++) {
+	for (unsigned int i = 1; i < mMap.size(); i++) {
 		if (mMap.at(mdd[i].key) != mdd[i].defaultValue) return false;
 	}
 

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -405,7 +405,7 @@ SystemData* SystemData::getRandomSystem()
 	}
 
 	// get random number in range
-	int target = std::round(((double)std::rand() / (double)RAND_MAX) * (total - 1));
+	int target = (int) std::round(((double)std::rand() / (double)RAND_MAX) * (total - 1));
 	for (auto it = sSystemVector.begin(); it != sSystemVector.end(); it++)
 	{
 		if ((*it)->isGameSystem())
@@ -420,6 +420,9 @@ SystemData* SystemData::getRandomSystem()
 			}
 		}
 	}
+
+	// if we end up here, there is no valid system
+	return NULL;
 }
 
 FileData* SystemData::getRandomGame()
@@ -430,7 +433,7 @@ FileData* SystemData::getRandomGame()
 	// get random number in range
 	if (total == 0)
 		return NULL;
-	target = std::round(((double)std::rand() / (double)RAND_MAX) * (total - 1));
+	target = (int) std::round(((double)std::rand() / (double)RAND_MAX) * (total - 1));
 	return list.at(target);
 }
 

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -99,7 +99,7 @@ void SystemScreenSaver::startScreenSaver()
 #endif
 
 			mVideoScreensaver->setOrigin(0.5f, 0.5f);
-			mVideoScreensaver->setPosition(Renderer::getScreenWidth()/2, Renderer::getScreenHeight()/2);
+			mVideoScreensaver->setPosition(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f);
 
 			if (Settings::getInstance()->getBool("StretchVideoOnScreenSaver"))
 			{
@@ -148,7 +148,7 @@ void SystemScreenSaver::startScreenSaver()
 
 		mImageScreensaver->setImage(path);
 		mImageScreensaver->setOrigin(0.5f, 0.5f);
-		mImageScreensaver->setPosition(Renderer::getScreenWidth()/2, Renderer::getScreenHeight()/2);
+		mImageScreensaver->setPosition(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f);
 
 		if (Settings::getInstance()->getBool("SlideshowScreenSaverStretch"))
 		{
@@ -230,7 +230,7 @@ void SystemScreenSaver::renderScreenSaver()
 		{
 			if (mImageScreensaver->hasImage())
 			{
-				mImageScreensaver->setOpacity(255-mOpacity);
+				mImageScreensaver->setOpacity(255- (unsigned char) (mOpacity * 255));
 
 				Eigen::Affine3f transform = Eigen::Affine3f::Identity();
 				mImageScreensaver->render(transform);

--- a/es-app/src/guis/GuiInfoPopup.cpp
+++ b/es-app/src/guis/GuiInfoPopup.cpp
@@ -32,8 +32,8 @@ GuiInfoPopup::GuiInfoPopup(Window* window, std::string message, int duration) :
 	}
 
 	// add a padding to the box
-	int paddingX = Renderer::getScreenWidth() * 0.03f;
-	int paddingY = Renderer::getScreenHeight() * 0.02f;
+	int paddingX = (int) (Renderer::getScreenWidth() * 0.03f);
+	int paddingY = (int) (Renderer::getScreenHeight() * 0.02f);
 	mSize[0] = mSize.x() + paddingX;
 	mSize[1] = mSize.y() + paddingY;
 

--- a/es-app/src/guis/GuiMetaDataEd.cpp
+++ b/es-app/src/guis/GuiMetaDataEd.cpp
@@ -152,8 +152,8 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 	mButtons = makeButtonGrid(mWindow, buttons);
 	mGrid.setEntry(mButtons, Vector2i(0, 2), true, false);
 
-	// resize + center
-	float width = std::min(Renderer::getScreenHeight(), (unsigned int) (Renderer::getScreenWidth() * 0.90f));
+	// resize + center	
+	float width = (float) std::min(Renderer::getScreenHeight(), (unsigned int) (Renderer::getScreenWidth() * 0.90f));
 	setSize(width, Renderer::getScreenHeight() * 0.82f);
 	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
 }

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -314,7 +314,7 @@ int main(int argc, char* argv[])
 	while(running)
 	{
 		SDL_Event event;
-		bool ps_standby = PowerSaver::getState() && SDL_GetTicks() - ps_time > PowerSaver::getMode();
+		bool ps_standby = PowerSaver::getState() && (int) SDL_GetTicks() - ps_time > PowerSaver::getMode();
 
 		if(ps_standby ? SDL_WaitEventTimeout(&event, PowerSaver::getTimeout()) : SDL_PollEvent(&event))
 		{

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -172,7 +172,6 @@ bool SystemView::input(InputConfig* config, Input input)
 			// get random system
 			// go to system
 			setCursor(SystemData::getRandomSystem());
-			//ViewController::get()->goToRandomGame();
 			return true;
 		}
 	}else{
@@ -430,36 +429,36 @@ void SystemView::renderCarousel(const Eigen::Affine3f& trans)
 	switch (mCarousel.type)
 	{
 		case VERTICAL_WHEEL:
-			yOff = (mCarousel.size.y() - mCarousel.logoSize.y()) / 2 - (mCamOffset * logoSpacing[1]);
+			yOff = (mCarousel.size.y() - mCarousel.logoSize.y()) / 2.f - (mCamOffset * logoSpacing[1]);
 			if (mCarousel.logoAlignment == ALIGN_LEFT)
-				xOff = mCarousel.logoSize.x() / 10;
+				xOff = mCarousel.logoSize.x() / 10.f;
 			else if (mCarousel.logoAlignment == ALIGN_RIGHT)
-				xOff = mCarousel.size.x() - (mCarousel.logoSize.x() * 1.1);
+				xOff = mCarousel.size.x() - (mCarousel.logoSize.x() * 1.1f);
 			else
-				xOff = (mCarousel.size.x() - mCarousel.logoSize.x()) / 2;
+				xOff = (mCarousel.size.x() - mCarousel.logoSize.x()) / 2.f;
 			break;
 		case VERTICAL:
 			logoSpacing[1] = ((mCarousel.size.y() - (mCarousel.logoSize.y() * mCarousel.maxLogoCount)) / (mCarousel.maxLogoCount)) + mCarousel.logoSize.y();
-			yOff = (mCarousel.size.y() - mCarousel.logoSize.y()) / 2 - (mCamOffset * logoSpacing[1]);
+			yOff = (mCarousel.size.y() - mCarousel.logoSize.y()) / 2.f - (mCamOffset * logoSpacing[1]);
 
 			if (mCarousel.logoAlignment == ALIGN_LEFT)
-				xOff = mCarousel.logoSize.x() / 10;
+				xOff = mCarousel.logoSize.x() / 10.f;
 			else if (mCarousel.logoAlignment == ALIGN_RIGHT)
-				xOff = mCarousel.size.x() - (mCarousel.logoSize.x() * 1.1);
+				xOff = mCarousel.size.x() - (mCarousel.logoSize.x() * 1.1f);
 			else
 				xOff = (mCarousel.size.x() - mCarousel.logoSize.x()) / 2;
 			break;
 		case HORIZONTAL:
 		default:
 			logoSpacing[0] = ((mCarousel.size.x() - (mCarousel.logoSize.x() * mCarousel.maxLogoCount)) / (mCarousel.maxLogoCount)) + mCarousel.logoSize.x();
-			xOff = (mCarousel.size.x() - mCarousel.logoSize.x()) / 2 - (mCamOffset * logoSpacing[0]);
+			xOff = (mCarousel.size.x() - mCarousel.logoSize.x()) / 2.f - (mCamOffset * logoSpacing[0]);
 
 			if (mCarousel.logoAlignment == ALIGN_TOP)
-				yOff = mCarousel.logoSize.y() / 10;
+				yOff = mCarousel.logoSize.y() / 10.f;
 			else if (mCarousel.logoAlignment == ALIGN_BOTTOM)
-				yOff = mCarousel.size.y() - (mCarousel.logoSize.y() * 1.1);
+				yOff = mCarousel.size.y() - (mCarousel.logoSize.y() * 1.1f);
 			else
-				yOff = (mCarousel.size.y() - mCarousel.logoSize.y()) / 2;
+				yOff = (mCarousel.size.y() - mCarousel.logoSize.y()) / 2.f;
 			break;
 	}
 
@@ -489,11 +488,11 @@ void SystemView::renderCarousel(const Eigen::Affine3f& trans)
 
 		float distance = i - mCamOffset;
 
-		float scale = 1.0 + ((mCarousel.logoScale - 1.0) * (1 - fabs(distance)));
+		float scale = 1.0f + ((mCarousel.logoScale - 1.0f) * (1.0f - fabs(distance)));
 		scale = std::min(mCarousel.logoScale, std::max(1.0f, scale));
 		scale /= mCarousel.logoScale;
 
-		int opacity = round(0x80 + ((0xFF - 0x80) * (1 - fabs(distance))));
+		int opacity = (int) round(0x80 + ((0xFF - 0x80) * (1.0f - fabs(distance))));
 		opacity = std::max((int) 0x80, opacity);
 
 		const std::shared_ptr<GuiComponent> &comp = mEntries.at(index).data.logo;
@@ -623,7 +622,7 @@ void SystemView::getCarouselFromTheme(const ThemeData::ThemeElement* elem)
 	if (elem->has("logoSize"))
 		mCarousel.logoSize = elem->get<Eigen::Vector2f>("logoSize").cwiseProduct(mSize);
 	if (elem->has("maxLogoCount"))
-		mCarousel.maxLogoCount = std::round(elem->get<float>("maxLogoCount"));
+		mCarousel.maxLogoCount = (int) std::round(elem->get<float>("maxLogoCount"));
 	if (elem->has("zIndex"))
 		mCarousel.zIndex = elem->get<float>("zIndex");
 	if (elem->has("logoRotation"))

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -119,37 +119,6 @@ void ViewController::goToGameList(SystemData* system)
 	playViewTransition();
 }
 
-void ViewController::goToRandomGame()
-{
-	unsigned int total = 0;
-	for(auto it = SystemData::sSystemVector.begin(); it != SystemData::sSystemVector.end(); it++)
-	{
-		if ((*it)->isGameSystem())
-			total += (*it)->getDisplayedGameCount();
-	}
-
-	// get random number in range
-	int target = std::round(((double)std::rand() / (double)RAND_MAX) * total);
-
-	for (auto it = SystemData::sSystemVector.begin(); it != SystemData::sSystemVector.end(); it++)
-	{
-		if ((*it)->isGameSystem())
-		{
-			if ((target - (int)(*it)->getDisplayedGameCount()) >= 0)
-			{
-				target -= (int)(*it)->getDisplayedGameCount();
-			}
-			else
-			{
-				goToGameList(*it);
-				std::vector<FileData*> list = (*it)->getRootFolder()->getFilesRecursive(GAME, true);
-				getGameListView(*it)->setCursor(list.at(target));
-				return;
-			}
-		}
-	}
-}
-
 void ViewController::playViewTransition()
 {
 	Eigen::Vector3f target(Eigen::Vector3f::Identity());

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -36,7 +36,6 @@ public:
 	void goToGameList(SystemData* system);
 	void goToSystemView(SystemData* system);
 	void goToStart();
-	void goToRandomGame();
 
 	void onFileChanged(FileData* file, FileChangeType change);
 

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -111,7 +111,7 @@ void BasicGameListView::remove(FileData *game, bool deleteFile)
 	{
 		std::vector<FileData*> siblings = parent->getChildrenListToDisplay();
 		auto gameIter = std::find(siblings.begin(), siblings.end(), game);
-		auto gamePos = std::distance(siblings.begin(), gameIter);
+		unsigned int gamePos = std::distance(siblings.begin(), gameIter);
 		if (gameIter != siblings.end())
 		{
 			if ((gamePos + 1) < siblings.size())

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -320,8 +320,8 @@ void VideoGameListView::updateInfoPanel()
 
 void VideoGameListView::launch(FileData* game)
 {
-	float screenWidth = Renderer::getScreenWidth();
-	float screenHeight = Renderer::getScreenHeight();
+	float screenWidth = (float) Renderer::getScreenWidth();
+	float screenHeight = (float) Renderer::getScreenHeight();
 
 	Eigen::Vector3f target(screenWidth / 2.0f, screenHeight / 2.0f, 0);
 

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -200,7 +200,7 @@ void GuiComponent::clearChildren()
 
 void GuiComponent::sortChildren()
 {
-	std:stable_sort(mChildren.begin(), mChildren.end(),  [](GuiComponent* a, GuiComponent* b) {
+	std::stable_sort(mChildren.begin(), mChildren.end(),  [](GuiComponent* a, GuiComponent* b) {
 		return b->getZIndex() > a->getZIndex();
 	});
 }

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -60,7 +60,7 @@ public:
 
 	float getRotation() const;
 	void setRotation(float rotation);
-	inline void setRotationDegrees(float rotation) { setRotation(rotation * M_PI / 180); }
+	inline void setRotationDegrees(float rotation) { setRotation((float) (rotation * M_PI / 180)); }
 
 	float getScale() const;
 	void setScale(float scale);

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -17,7 +17,7 @@ Eigen::Vector2i ImageComponent::getTextureSize() const
 
 ImageComponent::ImageComponent(Window* window, bool forceLoad, bool dynamic) : GuiComponent(window),
 	mTargetIsMax(false), mFlipX(false), mFlipY(false), mTargetSize(0, 0), mColorShift(0xFFFFFFFF),
-	mForceLoad(forceLoad), mDynamic(dynamic), mFadeOpacity(0.0f), mFading(false)
+	mForceLoad(forceLoad), mDynamic(dynamic), mFadeOpacity(0), mFading(false)
 {
 	updateColors();
 }

--- a/es-core/src/components/MenuComponent.cpp
+++ b/es-core/src/components/MenuComponent.cpp
@@ -63,7 +63,7 @@ void MenuComponent::updateSize()
 		}
 	}
 
-	float width = std::min(Renderer::getScreenHeight(), (unsigned int) (Renderer::getScreenWidth() * 0.90f));
+	float width = (float) std::min(Renderer::getScreenHeight(), (unsigned int) (Renderer::getScreenWidth() * 0.90f));
 	setSize(width, height);
 }
 

--- a/es-core/src/components/TextEditComponent.h
+++ b/es-core/src/components/TextEditComponent.h
@@ -49,7 +49,7 @@ private:
 	std::string mText;
 	bool mFocused;
 	bool mEditing;
-	int mCursor; // cursor position in characters
+	unsigned int mCursor; // cursor position in characters
 
 	int mCursorRepeatTimer;
 	int mCursorRepeatDir;

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -155,8 +155,6 @@ void VideoComponent::setOpacity(unsigned char opacity)
 
 void VideoComponent::render(const Eigen::Affine3f& parentTrans)
 {
-	float x, y;
-
 	Eigen::Affine3f trans = parentTrans * getTransform();
 	GuiComponent::renderChildren(trans);
 

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -319,14 +319,14 @@ void VideoVlcComponent::startVideo()
 
 							if(resizeScale.x() < resizeScale.y())
 							{
-								mVideoWidth *= resizeScale.x();
-								mVideoHeight *= resizeScale.x();
+								mVideoWidth = (unsigned int) (mVideoWidth * resizeScale.x());
+								mVideoHeight = (unsigned int) (mVideoHeight * resizeScale.x());
 							}else{
-								mVideoWidth *= resizeScale.y();
-								mVideoHeight *= resizeScale.y();
+								mVideoWidth = (unsigned int) (mVideoWidth * resizeScale.y());
+								mVideoHeight = (unsigned int) (mVideoHeight * resizeScale.y());
 							}
-							mVideoHeight = round(mVideoHeight);
-							mVideoWidth = round(mVideoWidth);
+							mVideoHeight = (unsigned int) round(mVideoHeight);
+							mVideoWidth = (unsigned int) round(mVideoWidth);
 						}
 					}
 #endif

--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -105,8 +105,8 @@ bool TextureData::initImageFromMemory(const unsigned char* fileData, size_t leng
 		return false;
 	}
 
-	mSourceWidth = width;
-	mSourceHeight = height;
+	mSourceWidth = (float) width;
+	mSourceHeight = (float) height;
 	mScalable = false;
 
 	return initFromRGBA(imageRGBA.data(), width, height);


### PR DESCRIPTION
This is a cleanup pr, fixing some build warnings that pop up during compilation in VS2015.
These concern mostly adding explicit type casting that have no functional difference.
I've also removed a method in ViewController.cpp that was no longer used (goToRandomGame() RIP), and removed some unused variables.