### PR TITLE
Replace Eigen with inhouse vector and matrix classes

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -209,20 +209,20 @@ void SystemScreenSaver::renderScreenSaver()
 	if (mVideoScreensaver && screensaver_behavior == "random video")
 	{
 		// Render black background
-		Renderer::setMatrix(Affine3f::Identity());
+		Renderer::setMatrix(Matrix4x4f::Identity());
 		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), (unsigned char)(255));
 
 		// Only render the video if the state requires it
 		if ((int)mState >= STATE_FADE_IN_VIDEO)
 		{
-			Affine3f transform = Affine3f::Identity();
+			Matrix4x4f transform = Matrix4x4f::Identity();
 			mVideoScreensaver->render(transform);
 		}
 	}
 	else if (mImageScreensaver && screensaver_behavior == "slideshow")
 	{
 		// Render black background
-		Renderer::setMatrix(Affine3f::Identity());
+		Renderer::setMatrix(Matrix4x4f::Identity());
 		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), (unsigned char)(255));
 
 		// Only render the video if the state requires it
@@ -232,7 +232,7 @@ void SystemScreenSaver::renderScreenSaver()
 			{
 				mImageScreensaver->setOpacity(255-mOpacity);
 
-				Affine3f transform = Affine3f::Identity();
+				Matrix4x4f transform = Matrix4x4f::Identity();
 				mImageScreensaver->render(transform);
 			}
 		}
@@ -248,7 +248,7 @@ void SystemScreenSaver::renderScreenSaver()
 	}
 	else if (mState != STATE_INACTIVE)
 	{
-		Renderer::setMatrix(Affine3f::Identity());
+		Renderer::setMatrix(Matrix4x4f::Identity());
 		unsigned char opacity = screensaver_behavior == "dim" ? 0xA0 : 0xFF;
 		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), 0x00000000 | opacity);
 	}

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -209,20 +209,20 @@ void SystemScreenSaver::renderScreenSaver()
 	if (mVideoScreensaver && screensaver_behavior == "random video")
 	{
 		// Render black background
-		Renderer::setMatrix(Eigen::Affine3f::Identity());
+		Renderer::setMatrix(Affine3f::Identity());
 		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), (unsigned char)(255));
 
 		// Only render the video if the state requires it
 		if ((int)mState >= STATE_FADE_IN_VIDEO)
 		{
-			Eigen::Affine3f transform = Eigen::Affine3f::Identity();
+			Affine3f transform = Affine3f::Identity();
 			mVideoScreensaver->render(transform);
 		}
 	}
 	else if (mImageScreensaver && screensaver_behavior == "slideshow")
 	{
 		// Render black background
-		Renderer::setMatrix(Eigen::Affine3f::Identity());
+		Renderer::setMatrix(Affine3f::Identity());
 		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), (unsigned char)(255));
 
 		// Only render the video if the state requires it
@@ -232,7 +232,7 @@ void SystemScreenSaver::renderScreenSaver()
 			{
 				mImageScreensaver->setOpacity(255-mOpacity);
 
-				Eigen::Affine3f transform = Eigen::Affine3f::Identity();
+				Affine3f transform = Affine3f::Identity();
 				mImageScreensaver->render(transform);
 			}
 		}
@@ -248,7 +248,7 @@ void SystemScreenSaver::renderScreenSaver()
 	}
 	else if (mState != STATE_INACTIVE)
 	{
-		Renderer::setMatrix(Eigen::Affine3f::Identity());
+		Renderer::setMatrix(Affine3f::Identity());
 		unsigned char opacity = screensaver_behavior == "dim" ? 0xA0 : 0xFF;
 		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), 0x00000000 | opacity);
 	}

--- a/es-app/src/animations/LaunchAnimation.h
+++ b/es-app/src/animations/LaunchAnimation.h
@@ -31,14 +31,14 @@ class LaunchAnimation : public Animation
 {
 public:
 	//Target is a centerpoint
-	LaunchAnimation(Affine3f& camera, float& fade, const Vector3f& target, int duration) : 
+	LaunchAnimation(Matrix4x4f& camera, float& fade, const Vector3f& target, int duration) : 
 	  mCameraStart(camera), mTarget(target), mDuration(duration), cameraOut(camera), fadeOut(fade) {}
 
 	int getDuration() const override { return mDuration; }
 
 	void apply(float t) override
 	{
-		cameraOut = Affine3f::Identity();
+		cameraOut = Matrix4x4f::Identity();
 
 		float zoom = lerp<float>(1.0, 4.25f, t*t);
 		cameraOut.scale(Vector3f(zoom, zoom, 1));
@@ -55,10 +55,10 @@ public:
 	}
 
 private:
-	Affine3f mCameraStart;
+	Matrix4x4f mCameraStart;
 	Vector3f mTarget;
 	int mDuration;
 
-	Affine3f& cameraOut;
+	Matrix4x4f& cameraOut;
 	float& fadeOut;
 };

--- a/es-app/src/animations/LaunchAnimation.h
+++ b/es-app/src/animations/LaunchAnimation.h
@@ -31,34 +31,34 @@ class LaunchAnimation : public Animation
 {
 public:
 	//Target is a centerpoint
-	LaunchAnimation(Eigen::Affine3f& camera, float& fade, const Eigen::Vector3f& target, int duration) : 
+	LaunchAnimation(Affine3f& camera, float& fade, const Vector3f& target, int duration) : 
 	  mCameraStart(camera), mTarget(target), mDuration(duration), cameraOut(camera), fadeOut(fade) {}
 
 	int getDuration() const override { return mDuration; }
 
 	void apply(float t) override
 	{
-		cameraOut = Eigen::Affine3f::Identity();
+		cameraOut = Affine3f::Identity();
 
 		float zoom = lerp<float>(1.0, 4.25f, t*t);
-		cameraOut.scale(Eigen::Vector3f(zoom, zoom, 1));
+		cameraOut.scale(Vector3f(zoom, zoom, 1));
 
 		const float sw = (float)Renderer::getScreenWidth() / zoom;
 		const float sh = (float)Renderer::getScreenHeight() / zoom;
 
-		Eigen::Vector3f centerPoint = lerp<Eigen::Vector3f>(-mCameraStart.translation() + Eigen::Vector3f(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f, 0), 
+		Vector3f centerPoint = lerp<Vector3f>(-mCameraStart.translation() + Vector3f(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f, 0), 
 			mTarget, smoothStep(0.0, 1.0, t));
 
-		cameraOut.translate(Eigen::Vector3f((sw / 2) - centerPoint.x(), (sh / 2) - centerPoint.y(), 0));
+		cameraOut.translate(Vector3f((sw / 2) - centerPoint.x(), (sh / 2) - centerPoint.y(), 0));
 		
 		fadeOut = lerp<float>(0.0, 1.0, t*t);
 	}
 
 private:
-	Eigen::Affine3f mCameraStart;
-	Eigen::Vector3f mTarget;
+	Affine3f mCameraStart;
+	Vector3f mTarget;
 	int mDuration;
 
-	Eigen::Affine3f& cameraOut;
+	Affine3f& cameraOut;
 	float& fadeOut;
 };

--- a/es-app/src/animations/MoveCameraAnimation.h
+++ b/es-app/src/animations/MoveCameraAnimation.h
@@ -5,7 +5,7 @@
 class MoveCameraAnimation : public Animation
 {
 public:
-	MoveCameraAnimation(Affine3f& camera, const Vector3f& target) : mCameraStart(camera), mTarget(target), cameraOut(camera) {}
+	MoveCameraAnimation(Matrix4x4f& camera, const Vector3f& target) : mCameraStart(camera), mTarget(target), cameraOut(camera) {}
 
 	int getDuration() const override { return 400; }
 
@@ -17,8 +17,8 @@ public:
 	}
 
 private:
-	Affine3f mCameraStart;
+	Matrix4x4f mCameraStart;
 	Vector3f mTarget;
 
-	Affine3f& cameraOut;
+	Matrix4x4f& cameraOut;
 };

--- a/es-app/src/animations/MoveCameraAnimation.h
+++ b/es-app/src/animations/MoveCameraAnimation.h
@@ -5,7 +5,7 @@
 class MoveCameraAnimation : public Animation
 {
 public:
-	MoveCameraAnimation(Eigen::Affine3f& camera, const Eigen::Vector3f& target) : mCameraStart(camera), mTarget(target), cameraOut(camera) {}
+	MoveCameraAnimation(Affine3f& camera, const Vector3f& target) : mCameraStart(camera), mTarget(target), cameraOut(camera) {}
 
 	int getDuration() const override { return 400; }
 
@@ -13,12 +13,12 @@ public:
 	{
 		// cubic ease out
 		t -= 1;
-		cameraOut.translation() = -lerp<Eigen::Vector3f>(-mCameraStart.translation(), mTarget, t*t*t + 1);
+		cameraOut.translation() = -lerp<Vector3f>(-mCameraStart.translation(), mTarget, t*t*t + 1);
 	}
 
 private:
-	Eigen::Affine3f mCameraStart;
-	Eigen::Vector3f mTarget;
+	Affine3f mCameraStart;
+	Vector3f mTarget;
 
-	Eigen::Affine3f& cameraOut;
+	Affine3f& cameraOut;
 };

--- a/es-app/src/components/AsyncReqComponent.cpp
+++ b/es-app/src/components/AsyncReqComponent.cpp
@@ -33,13 +33,13 @@ void AsyncReqComponent::update(int deltaTime)
 	mTime += deltaTime;
 }
 
-void AsyncReqComponent::render(const Eigen::Affine3f& parentTrans)
+void AsyncReqComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = Eigen::Affine3f::Identity();
-	trans = trans.translate(Eigen::Vector3f(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f, 0));
+	Affine3f trans = Affine3f::Identity();
+	trans = trans.translate(Vector3f(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f, 0));
 	Renderer::setMatrix(trans);
 
-	Eigen::Vector3f point(cos(mTime * 0.01f) * 12, sin(mTime * 0.01f) * 12, 0);
+	Vector3f point(cos(mTime * 0.01f) * 12, sin(mTime * 0.01f) * 12, 0);
 	Renderer::drawRect((int)point.x(), (int)point.y(), 8, 8, 0x0000FFFF);
 }
 

--- a/es-app/src/components/AsyncReqComponent.cpp
+++ b/es-app/src/components/AsyncReqComponent.cpp
@@ -33,9 +33,9 @@ void AsyncReqComponent::update(int deltaTime)
 	mTime += deltaTime;
 }
 
-void AsyncReqComponent::render(const Affine3f& parentTrans)
+void AsyncReqComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = Affine3f::Identity();
+	Matrix4x4f trans = Matrix4x4f::Identity();
 	trans = trans.translate(Vector3f(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f, 0));
 	Renderer::setMatrix(trans);
 

--- a/es-app/src/components/AsyncReqComponent.h
+++ b/es-app/src/components/AsyncReqComponent.h
@@ -33,7 +33,7 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 private:

--- a/es-app/src/components/AsyncReqComponent.h
+++ b/es-app/src/components/AsyncReqComponent.h
@@ -33,7 +33,7 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 private:

--- a/es-app/src/components/RatingComponent.cpp
+++ b/es-app/src/components/RatingComponent.cpp
@@ -109,9 +109,9 @@ void RatingComponent::updateColors()
 	Renderer::buildGLColorArray(mColors, mColorShift, 12);
 }
 
-void RatingComponent::render(const Eigen::Affine3f& parentTrans)
+void RatingComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = roundMatrix(parentTrans * getTransform());
+	Affine3f trans = roundMatrix(parentTrans * getTransform());
 	Renderer::setMatrix(trans);
 
 	glEnable(GL_TEXTURE_2D);

--- a/es-app/src/components/RatingComponent.cpp
+++ b/es-app/src/components/RatingComponent.cpp
@@ -109,9 +109,9 @@ void RatingComponent::updateColors()
 	Renderer::buildGLColorArray(mColors, mColorShift, 12);
 }
 
-void RatingComponent::render(const Affine3f& parentTrans)
+void RatingComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = roundMatrix(parentTrans * getTransform());
+	Matrix4x4f trans = roundMatrix(parentTrans * getTransform());
 	Renderer::setMatrix(trans);
 
 	glEnable(GL_TEXTURE_2D);

--- a/es-app/src/components/RatingComponent.h
+++ b/es-app/src/components/RatingComponent.h
@@ -19,7 +19,7 @@ public:
 	void setValue(const std::string& value) override; // Should be a normalized float (in the range [0..1]) - if it's not, it will be clamped.
 
 	bool input(InputConfig* config, Input input) override;
-	void render(const Eigen::Affine3f& parentTrans);
+	void render(const Affine3f& parentTrans);
 
 	void onSizeChanged() override;
 
@@ -40,8 +40,8 @@ private:
 
 	struct Vertex
 	{
-		Eigen::Vector2f pos;
-		Eigen::Vector2f tex;
+		Vector2f pos;
+		Vector2f tex;
 	} mVertices[12];
 
 

--- a/es-app/src/components/RatingComponent.h
+++ b/es-app/src/components/RatingComponent.h
@@ -19,7 +19,7 @@ public:
 	void setValue(const std::string& value) override; // Should be a normalized float (in the range [0..1]) - if it's not, it will be clamped.
 
 	bool input(InputConfig* config, Input input) override;
-	void render(const Affine3f& parentTrans);
+	void render(const Matrix4x4f& parentTrans);
 
 	void onSizeChanged() override;
 

--- a/es-app/src/components/ScraperSearchComponent.cpp
+++ b/es-app/src/components/ScraperSearchComponent.cpp
@@ -15,7 +15,7 @@
 #include "guis/GuiTextEditPopup.h"
 
 ScraperSearchComponent::ScraperSearchComponent(Window* window, SearchType type) : GuiComponent(window),
-	mGrid(window, Eigen::Vector2i(4, 3)), mBusyAnim(window), 
+	mGrid(window, Vector2i(4, 3)), mBusyAnim(window), 
 	mSearchType(type)
 {
 	addChild(&mGrid);
@@ -23,14 +23,14 @@ ScraperSearchComponent::ScraperSearchComponent(Window* window, SearchType type) 
 	mBlockAccept = false;
 
 	// left spacer (empty component, needed for borders)
-	mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Eigen::Vector2i(0, 0), false, false, Eigen::Vector2i(1, 3), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
+	mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Vector2i(0, 0), false, false, Vector2i(1, 3), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
 
 	// selected result name
 	mResultName = std::make_shared<TextComponent>(mWindow, "Result name", Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
 
 	// selected result thumbnail
 	mResultThumbnail = std::make_shared<ImageComponent>(mWindow);
-	mGrid.setEntry(mResultThumbnail, Eigen::Vector2i(1, 1), false, false, Eigen::Vector2i(1, 1));
+	mGrid.setEntry(mResultThumbnail, Vector2i(1, 1), false, false, Vector2i(1, 1));
 
 	// selected result desc + container
 	mDescContainer = std::make_shared<ScrollableContainer>(mWindow);
@@ -57,16 +57,16 @@ ScraperSearchComponent::ScraperSearchComponent(Window* window, SearchType type) 
 	mMD_Pairs.push_back(MetaDataPair(std::make_shared<TextComponent>(mWindow, "GENRE:", font, mdLblColor), mMD_Genre));
 	mMD_Pairs.push_back(MetaDataPair(std::make_shared<TextComponent>(mWindow, "PLAYERS:", font, mdLblColor), mMD_Players));
 
-	mMD_Grid = std::make_shared<ComponentGrid>(mWindow, Eigen::Vector2i(2, mMD_Pairs.size()*2 - 1));
+	mMD_Grid = std::make_shared<ComponentGrid>(mWindow, Vector2i(2, mMD_Pairs.size()*2 - 1));
 	unsigned int i = 0;
 	for(auto it = mMD_Pairs.begin(); it != mMD_Pairs.end(); it++)
 	{
-		mMD_Grid->setEntry(it->first, Eigen::Vector2i(0, i), false, true);
-		mMD_Grid->setEntry(it->second, Eigen::Vector2i(1, i), false, it->resize);
+		mMD_Grid->setEntry(it->first, Vector2i(0, i), false, true);
+		mMD_Grid->setEntry(it->second, Vector2i(1, i), false, it->resize);
 		i += 2;
 	}
 
-	mGrid.setEntry(mMD_Grid, Eigen::Vector2i(2, 1), false, false);
+	mGrid.setEntry(mMD_Grid, Vector2i(2, 1), false, false);
 
 	// result list
 	mResultList = std::make_shared<ComponentList>(mWindow);
@@ -178,23 +178,23 @@ void ScraperSearchComponent::updateViewStyle()
 	if(mSearchType == ALWAYS_ACCEPT_FIRST_RESULT)
 	{
 		// show name
-		mGrid.setEntry(mResultName, Eigen::Vector2i(1, 0), false, true, Eigen::Vector2i(2, 1), GridFlags::BORDER_TOP);
+		mGrid.setEntry(mResultName, Vector2i(1, 0), false, true, Vector2i(2, 1), GridFlags::BORDER_TOP);
 
 		// need a border on the bottom left
-		mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Eigen::Vector2i(0, 2), false, false, Eigen::Vector2i(3, 1), GridFlags::BORDER_BOTTOM);
+		mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Vector2i(0, 2), false, false, Vector2i(3, 1), GridFlags::BORDER_BOTTOM);
 
 		// show description on the right
-		mGrid.setEntry(mDescContainer, Eigen::Vector2i(3, 0), false, false, Eigen::Vector2i(1, 3), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
+		mGrid.setEntry(mDescContainer, Vector2i(3, 0), false, false, Vector2i(1, 3), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
 		mResultDesc->setSize(mDescContainer->getSize().x(), 0); // make desc text wrap at edge of container
 	}else{
 		// fake row where name would be
-		mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Eigen::Vector2i(1, 0), false, true, Eigen::Vector2i(2, 1), GridFlags::BORDER_TOP);
+		mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Vector2i(1, 0), false, true, Vector2i(2, 1), GridFlags::BORDER_TOP);
 
 		// show result list on the right
-		mGrid.setEntry(mResultList, Eigen::Vector2i(3, 0), true, true, Eigen::Vector2i(1, 3), GridFlags::BORDER_LEFT | GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
+		mGrid.setEntry(mResultList, Vector2i(3, 0), true, true, Vector2i(1, 3), GridFlags::BORDER_LEFT | GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
 
 		// show description under image/info
-		mGrid.setEntry(mDescContainer, Eigen::Vector2i(1, 2), false, false, Eigen::Vector2i(2, 1), GridFlags::BORDER_BOTTOM);
+		mGrid.setEntry(mDescContainer, Vector2i(1, 2), false, false, Vector2i(2, 1), GridFlags::BORDER_BOTTOM);
 		mResultDesc->setSize(mDescContainer->getSize().x(), 0); // make desc text wrap at edge of container
 	}
 }
@@ -341,9 +341,9 @@ bool ScraperSearchComponent::input(InputConfig* config, Input input)
 	return GuiComponent::input(config, input);
 }
 
-void ScraperSearchComponent::render(const Eigen::Affine3f& parentTrans)
+void ScraperSearchComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 
 	renderChildren(trans);
 

--- a/es-app/src/components/ScraperSearchComponent.cpp
+++ b/es-app/src/components/ScraperSearchComponent.cpp
@@ -22,17 +22,15 @@ ScraperSearchComponent::ScraperSearchComponent(Window* window, SearchType type) 
 
 	mBlockAccept = false;
 
-	using namespace Eigen;
-
 	// left spacer (empty component, needed for borders)
-	mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Vector2i(0, 0), false, false, Vector2i(1, 3), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
+	mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Eigen::Vector2i(0, 0), false, false, Eigen::Vector2i(1, 3), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
 
 	// selected result name
 	mResultName = std::make_shared<TextComponent>(mWindow, "Result name", Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
 
 	// selected result thumbnail
 	mResultThumbnail = std::make_shared<ImageComponent>(mWindow);
-	mGrid.setEntry(mResultThumbnail, Vector2i(1, 1), false, false, Vector2i(1, 1));
+	mGrid.setEntry(mResultThumbnail, Eigen::Vector2i(1, 1), false, false, Eigen::Vector2i(1, 1));
 
 	// selected result desc + container
 	mDescContainer = std::make_shared<ScrollableContainer>(mWindow);
@@ -59,16 +57,16 @@ ScraperSearchComponent::ScraperSearchComponent(Window* window, SearchType type) 
 	mMD_Pairs.push_back(MetaDataPair(std::make_shared<TextComponent>(mWindow, "GENRE:", font, mdLblColor), mMD_Genre));
 	mMD_Pairs.push_back(MetaDataPair(std::make_shared<TextComponent>(mWindow, "PLAYERS:", font, mdLblColor), mMD_Players));
 
-	mMD_Grid = std::make_shared<ComponentGrid>(mWindow, Vector2i(2, mMD_Pairs.size()*2 - 1));
+	mMD_Grid = std::make_shared<ComponentGrid>(mWindow, Eigen::Vector2i(2, mMD_Pairs.size()*2 - 1));
 	unsigned int i = 0;
 	for(auto it = mMD_Pairs.begin(); it != mMD_Pairs.end(); it++)
 	{
-		mMD_Grid->setEntry(it->first, Vector2i(0, i), false, true);
-		mMD_Grid->setEntry(it->second, Vector2i(1, i), false, it->resize);
+		mMD_Grid->setEntry(it->first, Eigen::Vector2i(0, i), false, true);
+		mMD_Grid->setEntry(it->second, Eigen::Vector2i(1, i), false, it->resize);
 		i += 2;
 	}
 
-	mGrid.setEntry(mMD_Grid, Vector2i(2, 1), false, false);
+	mGrid.setEntry(mMD_Grid, Eigen::Vector2i(2, 1), false, false);
 
 	// result list
 	mResultList = std::make_shared<ComponentList>(mWindow);
@@ -171,8 +169,6 @@ void ScraperSearchComponent::resizeMetadata()
 
 void ScraperSearchComponent::updateViewStyle()
 {
-	using namespace Eigen;
-
 	// unlink description and result list and result name
 	mGrid.removeEntry(mResultName);
 	mGrid.removeEntry(mResultDesc);
@@ -182,23 +178,23 @@ void ScraperSearchComponent::updateViewStyle()
 	if(mSearchType == ALWAYS_ACCEPT_FIRST_RESULT)
 	{
 		// show name
-		mGrid.setEntry(mResultName, Vector2i(1, 0), false, true, Vector2i(2, 1), GridFlags::BORDER_TOP);
+		mGrid.setEntry(mResultName, Eigen::Vector2i(1, 0), false, true, Eigen::Vector2i(2, 1), GridFlags::BORDER_TOP);
 
 		// need a border on the bottom left
-		mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Vector2i(0, 2), false, false, Vector2i(3, 1), GridFlags::BORDER_BOTTOM);
+		mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Eigen::Vector2i(0, 2), false, false, Eigen::Vector2i(3, 1), GridFlags::BORDER_BOTTOM);
 
 		// show description on the right
-		mGrid.setEntry(mDescContainer, Vector2i(3, 0), false, false, Vector2i(1, 3), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
+		mGrid.setEntry(mDescContainer, Eigen::Vector2i(3, 0), false, false, Eigen::Vector2i(1, 3), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
 		mResultDesc->setSize(mDescContainer->getSize().x(), 0); // make desc text wrap at edge of container
 	}else{
 		// fake row where name would be
-		mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Vector2i(1, 0), false, true, Vector2i(2, 1), GridFlags::BORDER_TOP);
+		mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Eigen::Vector2i(1, 0), false, true, Eigen::Vector2i(2, 1), GridFlags::BORDER_TOP);
 
 		// show result list on the right
-		mGrid.setEntry(mResultList, Vector2i(3, 0), true, true, Vector2i(1, 3), GridFlags::BORDER_LEFT | GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
+		mGrid.setEntry(mResultList, Eigen::Vector2i(3, 0), true, true, Eigen::Vector2i(1, 3), GridFlags::BORDER_LEFT | GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
 
 		// show description under image/info
-		mGrid.setEntry(mDescContainer, Vector2i(1, 2), false, false, Vector2i(2, 1), GridFlags::BORDER_BOTTOM);
+		mGrid.setEntry(mDescContainer, Eigen::Vector2i(1, 2), false, false, Eigen::Vector2i(2, 1), GridFlags::BORDER_BOTTOM);
 		mResultDesc->setSize(mDescContainer->getSize().x(), 0); // make desc text wrap at edge of container
 	}
 }

--- a/es-app/src/components/ScraperSearchComponent.cpp
+++ b/es-app/src/components/ScraperSearchComponent.cpp
@@ -341,9 +341,9 @@ bool ScraperSearchComponent::input(InputConfig* config, Input input)
 	return GuiComponent::input(config, input);
 }
 
-void ScraperSearchComponent::render(const Affine3f& parentTrans)
+void ScraperSearchComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 
 	renderChildren(trans);
 

--- a/es-app/src/components/ScraperSearchComponent.h
+++ b/es-app/src/components/ScraperSearchComponent.h
@@ -39,7 +39,7 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 	std::vector<HelpPrompt> getHelpPrompts() override;
 	void onSizeChanged() override;	
 	void onFocusGained() override;

--- a/es-app/src/components/ScraperSearchComponent.h
+++ b/es-app/src/components/ScraperSearchComponent.h
@@ -39,7 +39,7 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 	std::vector<HelpPrompt> getHelpPrompts() override;
 	void onSizeChanged() override;	
 	void onFocusGained() override;

--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -42,7 +42,7 @@ public:
 	
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 	void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
 	void add(const std::string& name, const T& obj, unsigned int colorId);
@@ -134,9 +134,9 @@ TextListComponent<T>::TextListComponent(Window* window) :
 }
 
 template <typename T>
-void TextListComponent<T>::render(const Eigen::Affine3f& parentTrans)
+void TextListComponent<T>::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 	
 	std::shared_ptr<Font>& font = mFont;
 
@@ -178,10 +178,10 @@ void TextListComponent<T>::render(const Eigen::Affine3f& parentTrans)
 	}
 
 	// clip to inside margins
-	Eigen::Vector3f dim(mSize.x(), mSize.y(), 0);
+	Vector3f dim(mSize.x(), mSize.y(), 0);
 	dim = trans * dim - trans.translation();
-	Renderer::pushClipRect(Eigen::Vector2i((int)(trans.translation().x() + mHorizontalMargin), (int)trans.translation().y()), 
-		Eigen::Vector2i((int)(dim.x() - mHorizontalMargin*2), (int)dim.y()));
+	Renderer::pushClipRect(Vector2i((int)(trans.translation().x() + mHorizontalMargin), (int)trans.translation().y()), 
+		Vector2i((int)(dim.x() - mHorizontalMargin*2), (int)dim.y()));
 
 	for(int i = startEntry; i < listCutoff; i++)
 	{
@@ -198,7 +198,7 @@ void TextListComponent<T>::render(const Eigen::Affine3f& parentTrans)
 
 		entry.data.textCache->setColor(color);
 
-		Eigen::Vector3f offset(0, y, 0);
+		Vector3f offset(0, y, 0);
 
 		switch(mAlignment)
 		{
@@ -221,7 +221,7 @@ void TextListComponent<T>::render(const Eigen::Affine3f& parentTrans)
 		if(mCursor == i)
 			offset[0] -= mMarqueeOffset;
 		
-		Eigen::Affine3f drawTrans = trans;
+		Affine3f drawTrans = trans;
 		drawTrans.translate(offset);
 		Renderer::setMatrix(drawTrans);
 
@@ -287,7 +287,7 @@ void TextListComponent<T>::update(int deltaTime)
 		//if we're not scrolling and this object's text goes outside our size, marquee it!
 		const std::string& text = mEntries.at((unsigned int)mCursor).name;
 
-		Eigen::Vector2f textSize = mFont->sizeText(text);
+		Vector2f textSize = mFont->sizeText(text);
 
 		//it's long enough to marquee
 		if(textSize.x() - mMarqueeOffset > mSize.x() - 12 - mHorizontalMargin * 2)

--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -42,7 +42,7 @@ public:
 	
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 	void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
 	void add(const std::string& name, const T& obj, unsigned int colorId);
@@ -134,9 +134,9 @@ TextListComponent<T>::TextListComponent(Window* window) :
 }
 
 template <typename T>
-void TextListComponent<T>::render(const Affine3f& parentTrans)
+void TextListComponent<T>::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 	
 	std::shared_ptr<Font>& font = mFont;
 
@@ -221,7 +221,7 @@ void TextListComponent<T>::render(const Affine3f& parentTrans)
 		if(mCursor == i)
 			offset[0] -= mMarqueeOffset;
 		
-		Affine3f drawTrans = trans;
+		Matrix4x4f drawTrans = trans;
 		drawTrans.translate(offset);
 		Renderer::setMatrix(drawTrans);
 

--- a/es-app/src/guis/GuiGameScraper.cpp
+++ b/es-app/src/guis/GuiGameScraper.cpp
@@ -10,7 +10,7 @@
 #include "Settings.h"
 
 GuiGameScraper::GuiGameScraper(Window* window, ScraperSearchParams params, std::function<void(const ScraperSearchResult&)> doneFunc) : GuiComponent(window),
-	mGrid(window, Eigen::Vector2i(1, 7)),
+	mGrid(window, Vector2i(1, 7)),
 	mBox(window, ":/frame.png"),
 	mSearchParams(params),
 	mClose(false)
@@ -23,19 +23,19 @@ GuiGameScraper::GuiGameScraper(Window* window, ScraperSearchParams params, std::
 
 	mGameName = std::make_shared<TextComponent>(mWindow, strToUpper(mSearchParams.game->getPath().filename().generic_string()),
 		Font::get(FONT_SIZE_MEDIUM), 0x777777FF, ALIGN_CENTER);
-	mGrid.setEntry(mGameName, Eigen::Vector2i(0, 1), false, true);
+	mGrid.setEntry(mGameName, Vector2i(0, 1), false, true);
 
 	// row 2 is a spacer
 
 	mSystemName = std::make_shared<TextComponent>(mWindow, strToUpper(mSearchParams.system->getFullName()), Font::get(FONT_SIZE_SMALL),
 		0x888888FF, ALIGN_CENTER);
-	mGrid.setEntry(mSystemName, Eigen::Vector2i(0, 3), false, true);
+	mGrid.setEntry(mSystemName, Vector2i(0, 3), false, true);
 
 	// row 4 is a spacer
 
 	// ScraperSearchComponent
 	mSearch = std::make_shared<ScraperSearchComponent>(window, ScraperSearchComponent::NEVER_AUTO_ACCEPT);
-	mGrid.setEntry(mSearch, Eigen::Vector2i(0, 5), true);
+	mGrid.setEntry(mSearch, Vector2i(0, 5), true);
 
 	// buttons
 	std::vector< std::shared_ptr<ButtonComponent> > buttons;
@@ -47,7 +47,7 @@ GuiGameScraper::GuiGameScraper(Window* window, ScraperSearchParams params, std::
 	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, "CANCEL", "cancel", [&] { delete this; }));
 	mButtonGrid = makeButtonGrid(mWindow, buttons);
 
-	mGrid.setEntry(mButtonGrid, Eigen::Vector2i(0, 6), true, false);
+	mGrid.setEntry(mButtonGrid, Vector2i(0, 6), true, false);
 
 	// we call this->close() instead of just delete this; in the accept callback:
 	// this is because of how GuiComponent::update works.  if it was just delete this, this would happen when the metadata resolver is done:
@@ -83,7 +83,7 @@ GuiGameScraper::GuiGameScraper(Window* window, ScraperSearchParams params, std::
 
 void GuiGameScraper::onSizeChanged()
 {
-	mBox.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
+	mBox.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	mGrid.setRowHeightPerc(0, 0.04f, false);
 	mGrid.setRowHeightPerc(1, mGameName->getFont()->getLetterHeight() / mSize.y(), false); // game name

--- a/es-app/src/guis/GuiInfoPopup.cpp
+++ b/es-app/src/guis/GuiInfoPopup.cpp
@@ -60,10 +60,10 @@ GuiInfoPopup::~GuiInfoPopup()
 
 }
 
-void GuiInfoPopup::render(const Affine3f& parentTrans)
+void GuiInfoPopup::render(const Matrix4x4f& parentTrans)
 {
 	// we use identity as we want to render on a specific window position, not on the view
-	Affine3f trans = getTransform() * Affine3f::Identity();
+	Matrix4x4f trans = getTransform() * Matrix4x4f::Identity();
 	if(running && updateState())
 	{
 		// if we're still supposed to be rendering it

--- a/es-app/src/guis/GuiInfoPopup.cpp
+++ b/es-app/src/guis/GuiInfoPopup.cpp
@@ -43,15 +43,15 @@ GuiInfoPopup::GuiInfoPopup(Window* window, std::string message, int duration) :
 	setPosition(posX, posY, 0);
 
 	mFrame->setImagePath(":/frame.png");
-	mFrame->fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
+	mFrame->fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 	addChild(mFrame);
 
 	// we only init the actual time when we first start to render
 	mStartTime = 0;
 
-	mGrid = new ComponentGrid(window, Eigen::Vector2i(1, 3));
+	mGrid = new ComponentGrid(window, Vector2i(1, 3));
 	mGrid->setSize(mSize);
-	mGrid->setEntry(s, Eigen::Vector2i(0, 1), false, true);
+	mGrid->setEntry(s, Vector2i(0, 1), false, true);
 	addChild(mGrid);
 }
 
@@ -60,10 +60,10 @@ GuiInfoPopup::~GuiInfoPopup()
 
 }
 
-void GuiInfoPopup::render(const Eigen::Affine3f& parentTrans)
+void GuiInfoPopup::render(const Affine3f& parentTrans)
 {
 	// we use identity as we want to render on a specific window position, not on the view
-	Eigen::Affine3f trans = getTransform() * Eigen::Affine3f::Identity();
+	Affine3f trans = getTransform() * Affine3f::Identity();
 	if(running && updateState())
 	{
 		// if we're still supposed to be rendering it

--- a/es-app/src/guis/GuiInfoPopup.h
+++ b/es-app/src/guis/GuiInfoPopup.h
@@ -13,7 +13,7 @@ class GuiInfoPopup : public GuiComponent, public Window::InfoPopup
 public:
 	GuiInfoPopup(Window* window, std::string message, int duration);
 	~GuiInfoPopup();
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 	inline void stop() { running = false; };
 private:
 	std::string mMessage;

--- a/es-app/src/guis/GuiInfoPopup.h
+++ b/es-app/src/guis/GuiInfoPopup.h
@@ -13,7 +13,7 @@ class GuiInfoPopup : public GuiComponent, public Window::InfoPopup
 public:
 	GuiInfoPopup(Window* window, std::string message, int duration);
 	~GuiInfoPopup();
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 	inline void stop() { running = false; };
 private:
 	std::string mMessage;

--- a/es-app/src/guis/GuiMetaDataEd.cpp
+++ b/es-app/src/guis/GuiMetaDataEd.cpp
@@ -19,7 +19,7 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 	mScraperParams(scraperParams),
 
 	mBackground(window, ":/frame.png"),
-	mGrid(window, Eigen::Vector2i(1, 3)),
+	mGrid(window, Vector2i(1, 3)),
 
 	mMetaDataDecl(mdd),
 	mMetaData(md),
@@ -28,18 +28,18 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 	addChild(&mBackground);
 	addChild(&mGrid);
 
-	mHeaderGrid = std::make_shared<ComponentGrid>(mWindow, Eigen::Vector2i(1, 5));
+	mHeaderGrid = std::make_shared<ComponentGrid>(mWindow, Vector2i(1, 5));
 
 	mTitle = std::make_shared<TextComponent>(mWindow, "EDIT METADATA", Font::get(FONT_SIZE_LARGE), 0x555555FF, ALIGN_CENTER);
 	mSubtitle = std::make_shared<TextComponent>(mWindow, strToUpper(scraperParams.game->getPath().filename().generic_string()),
 		Font::get(FONT_SIZE_SMALL), 0x777777FF, ALIGN_CENTER);
-	mHeaderGrid->setEntry(mTitle, Eigen::Vector2i(0, 1), false, true);
-	mHeaderGrid->setEntry(mSubtitle, Eigen::Vector2i(0, 3), false, true);
+	mHeaderGrid->setEntry(mTitle, Vector2i(0, 1), false, true);
+	mHeaderGrid->setEntry(mSubtitle, Vector2i(0, 3), false, true);
 
-	mGrid.setEntry(mHeaderGrid, Eigen::Vector2i(0, 0), false, true);
+	mGrid.setEntry(mHeaderGrid, Vector2i(0, 0), false, true);
 
 	mList = std::make_shared<ComponentList>(mWindow);
-	mGrid.setEntry(mList, Eigen::Vector2i(0, 1), true, true);
+	mGrid.setEntry(mList, Vector2i(0, 1), true, true);
 
 	// populate list
 	for(auto iter = mdd.begin(); iter != mdd.end(); iter++)
@@ -113,7 +113,7 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 
 				auto bracket = std::make_shared<ImageComponent>(mWindow);
 				bracket->setImage(":/arrow.svg");
-				bracket->setResize(Eigen::Vector2f(0, lbl->getFont()->getLetterHeight()));
+				bracket->setResize(Vector2f(0, lbl->getFont()->getLetterHeight()));
 				row.addElement(bracket, false);
 
 				bool multiLine = iter->type == MD_MULTILINE_STRING;
@@ -148,7 +148,7 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 	}
 
 	mButtons = makeButtonGrid(mWindow, buttons);
-	mGrid.setEntry(mButtons, Eigen::Vector2i(0, 2), true, false);
+	mGrid.setEntry(mButtons, Vector2i(0, 2), true, false);
 
 	// resize + center
 	float width = std::min(Renderer::getScreenHeight(), (unsigned int) (Renderer::getScreenWidth() * 0.90f));
@@ -158,7 +158,7 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 
 void GuiMetaDataEd::onSizeChanged()
 {
-	mBackground.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
+	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	mGrid.setSize(mSize);
 

--- a/es-app/src/guis/GuiMetaDataEd.cpp
+++ b/es-app/src/guis/GuiMetaDataEd.cpp
@@ -14,14 +14,12 @@
 #include "components/SwitchComponent.h"
 #include "guis/GuiTextEditPopup.h"
 
-using namespace Eigen;
-
 GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector<MetaDataDecl>& mdd, ScraperSearchParams scraperParams,
 	const std::string& header, std::function<void()> saveCallback, std::function<void()> deleteFunc) : GuiComponent(window),
 	mScraperParams(scraperParams),
 
 	mBackground(window, ":/frame.png"),
-	mGrid(window, Vector2i(1, 3)),
+	mGrid(window, Eigen::Vector2i(1, 3)),
 
 	mMetaDataDecl(mdd),
 	mMetaData(md),
@@ -30,18 +28,18 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 	addChild(&mBackground);
 	addChild(&mGrid);
 
-	mHeaderGrid = std::make_shared<ComponentGrid>(mWindow, Vector2i(1, 5));
+	mHeaderGrid = std::make_shared<ComponentGrid>(mWindow, Eigen::Vector2i(1, 5));
 
 	mTitle = std::make_shared<TextComponent>(mWindow, "EDIT METADATA", Font::get(FONT_SIZE_LARGE), 0x555555FF, ALIGN_CENTER);
 	mSubtitle = std::make_shared<TextComponent>(mWindow, strToUpper(scraperParams.game->getPath().filename().generic_string()),
 		Font::get(FONT_SIZE_SMALL), 0x777777FF, ALIGN_CENTER);
-	mHeaderGrid->setEntry(mTitle, Vector2i(0, 1), false, true);
-	mHeaderGrid->setEntry(mSubtitle, Vector2i(0, 3), false, true);
+	mHeaderGrid->setEntry(mTitle, Eigen::Vector2i(0, 1), false, true);
+	mHeaderGrid->setEntry(mSubtitle, Eigen::Vector2i(0, 3), false, true);
 
-	mGrid.setEntry(mHeaderGrid, Vector2i(0, 0), false, true);
+	mGrid.setEntry(mHeaderGrid, Eigen::Vector2i(0, 0), false, true);
 
 	mList = std::make_shared<ComponentList>(mWindow);
-	mGrid.setEntry(mList, Vector2i(0, 1), true, true);
+	mGrid.setEntry(mList, Eigen::Vector2i(0, 1), true, true);
 
 	// populate list
 	for(auto iter = mdd.begin(); iter != mdd.end(); iter++)
@@ -150,7 +148,7 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 	}
 
 	mButtons = makeButtonGrid(mWindow, buttons);
-	mGrid.setEntry(mButtons, Vector2i(0, 2), true, false);
+	mGrid.setEntry(mButtons, Eigen::Vector2i(0, 2), true, false);
 
 	// resize + center
 	float width = std::min(Renderer::getScreenHeight(), (unsigned int) (Renderer::getScreenWidth() * 0.90f));
@@ -160,7 +158,7 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 
 void GuiMetaDataEd::onSizeChanged()
 {
-	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
+	mBackground.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
 
 	mGrid.setSize(mSize);
 

--- a/es-app/src/guis/GuiScraperMulti.cpp
+++ b/es-app/src/guis/GuiScraperMulti.cpp
@@ -11,10 +11,8 @@
 #include "components/MenuComponent.h" // for makeButtonGrid
 #include "guis/GuiMsgBox.h"
 
-using namespace Eigen;
-
 GuiScraperMulti::GuiScraperMulti(Window* window, const std::queue<ScraperSearchParams>& searches, bool approveResults) :
-	GuiComponent(window), mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 5)),
+	GuiComponent(window), mBackground(window, ":/frame.png"), mGrid(window, Eigen::Vector2i(1, 5)),
 	mSearchQueue(searches)
 {
 	assert(mSearchQueue.size());
@@ -32,20 +30,20 @@ GuiScraperMulti::GuiScraperMulti(Window* window, const std::queue<ScraperSearchP
 
 	// set up grid
 	mTitle = std::make_shared<TextComponent>(mWindow, "SCRAPING IN PROGRESS", Font::get(FONT_SIZE_LARGE), 0x555555FF, ALIGN_CENTER);
-	mGrid.setEntry(mTitle, Vector2i(0, 0), false, true);
+	mGrid.setEntry(mTitle, Eigen::Vector2i(0, 0), false, true);
 
 	mSystem = std::make_shared<TextComponent>(mWindow, "SYSTEM", Font::get(FONT_SIZE_MEDIUM), 0x777777FF, ALIGN_CENTER);
-	mGrid.setEntry(mSystem, Vector2i(0, 1), false, true);
+	mGrid.setEntry(mSystem, Eigen::Vector2i(0, 1), false, true);
 
 	mSubtitle = std::make_shared<TextComponent>(mWindow, "subtitle text", Font::get(FONT_SIZE_SMALL), 0x888888FF, ALIGN_CENTER);
-	mGrid.setEntry(mSubtitle, Vector2i(0, 2), false, true);
+	mGrid.setEntry(mSubtitle, Eigen::Vector2i(0, 2), false, true);
 
 	mSearchComp = std::make_shared<ScraperSearchComponent>(mWindow,
 		approveResults ? ScraperSearchComponent::ALWAYS_ACCEPT_MATCHING_CRC : ScraperSearchComponent::ALWAYS_ACCEPT_FIRST_RESULT);
 	mSearchComp->setAcceptCallback(std::bind(&GuiScraperMulti::acceptResult, this, std::placeholders::_1));
 	mSearchComp->setSkipCallback(std::bind(&GuiScraperMulti::skip, this));
 	mSearchComp->setCancelCallback(std::bind(&GuiScraperMulti::finish, this));
-	mGrid.setEntry(mSearchComp, Vector2i(0, 3), mSearchComp->getSearchType() != ScraperSearchComponent::ALWAYS_ACCEPT_FIRST_RESULT, true);
+	mGrid.setEntry(mSearchComp, Eigen::Vector2i(0, 3), mSearchComp->getSearchType() != ScraperSearchComponent::ALWAYS_ACCEPT_FIRST_RESULT, true);
 
 	std::vector< std::shared_ptr<ButtonComponent> > buttons;
 
@@ -65,7 +63,7 @@ GuiScraperMulti::GuiScraperMulti(Window* window, const std::queue<ScraperSearchP
 	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, "STOP", "stop (progress saved)", std::bind(&GuiScraperMulti::finish, this)));
 
 	mButtonGrid = makeButtonGrid(mWindow, buttons);
-	mGrid.setEntry(mButtonGrid, Vector2i(0, 4), true, false);
+	mGrid.setEntry(mButtonGrid, Eigen::Vector2i(0, 4), true, false);
 
 	setSize(Renderer::getScreenWidth() * 0.95f, Renderer::getScreenHeight() * 0.849f);
 	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
@@ -82,7 +80,7 @@ GuiScraperMulti::~GuiScraperMulti()
 
 void GuiScraperMulti::onSizeChanged()
 {
-	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
+	mBackground.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
 
 	mGrid.setRowHeightPerc(0, mTitle->getFont()->getLetterHeight() * 1.9725f / mSize.y(), false);
 	mGrid.setRowHeightPerc(1, (mSystem->getFont()->getLetterHeight() + 2) / mSize.y(), false);

--- a/es-app/src/guis/GuiScraperMulti.cpp
+++ b/es-app/src/guis/GuiScraperMulti.cpp
@@ -12,7 +12,7 @@
 #include "guis/GuiMsgBox.h"
 
 GuiScraperMulti::GuiScraperMulti(Window* window, const std::queue<ScraperSearchParams>& searches, bool approveResults) :
-	GuiComponent(window), mBackground(window, ":/frame.png"), mGrid(window, Eigen::Vector2i(1, 5)),
+	GuiComponent(window), mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 5)),
 	mSearchQueue(searches)
 {
 	assert(mSearchQueue.size());
@@ -30,20 +30,20 @@ GuiScraperMulti::GuiScraperMulti(Window* window, const std::queue<ScraperSearchP
 
 	// set up grid
 	mTitle = std::make_shared<TextComponent>(mWindow, "SCRAPING IN PROGRESS", Font::get(FONT_SIZE_LARGE), 0x555555FF, ALIGN_CENTER);
-	mGrid.setEntry(mTitle, Eigen::Vector2i(0, 0), false, true);
+	mGrid.setEntry(mTitle, Vector2i(0, 0), false, true);
 
 	mSystem = std::make_shared<TextComponent>(mWindow, "SYSTEM", Font::get(FONT_SIZE_MEDIUM), 0x777777FF, ALIGN_CENTER);
-	mGrid.setEntry(mSystem, Eigen::Vector2i(0, 1), false, true);
+	mGrid.setEntry(mSystem, Vector2i(0, 1), false, true);
 
 	mSubtitle = std::make_shared<TextComponent>(mWindow, "subtitle text", Font::get(FONT_SIZE_SMALL), 0x888888FF, ALIGN_CENTER);
-	mGrid.setEntry(mSubtitle, Eigen::Vector2i(0, 2), false, true);
+	mGrid.setEntry(mSubtitle, Vector2i(0, 2), false, true);
 
 	mSearchComp = std::make_shared<ScraperSearchComponent>(mWindow,
 		approveResults ? ScraperSearchComponent::ALWAYS_ACCEPT_MATCHING_CRC : ScraperSearchComponent::ALWAYS_ACCEPT_FIRST_RESULT);
 	mSearchComp->setAcceptCallback(std::bind(&GuiScraperMulti::acceptResult, this, std::placeholders::_1));
 	mSearchComp->setSkipCallback(std::bind(&GuiScraperMulti::skip, this));
 	mSearchComp->setCancelCallback(std::bind(&GuiScraperMulti::finish, this));
-	mGrid.setEntry(mSearchComp, Eigen::Vector2i(0, 3), mSearchComp->getSearchType() != ScraperSearchComponent::ALWAYS_ACCEPT_FIRST_RESULT, true);
+	mGrid.setEntry(mSearchComp, Vector2i(0, 3), mSearchComp->getSearchType() != ScraperSearchComponent::ALWAYS_ACCEPT_FIRST_RESULT, true);
 
 	std::vector< std::shared_ptr<ButtonComponent> > buttons;
 
@@ -63,7 +63,7 @@ GuiScraperMulti::GuiScraperMulti(Window* window, const std::queue<ScraperSearchP
 	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, "STOP", "stop (progress saved)", std::bind(&GuiScraperMulti::finish, this)));
 
 	mButtonGrid = makeButtonGrid(mWindow, buttons);
-	mGrid.setEntry(mButtonGrid, Eigen::Vector2i(0, 4), true, false);
+	mGrid.setEntry(mButtonGrid, Vector2i(0, 4), true, false);
 
 	setSize(Renderer::getScreenWidth() * 0.95f, Renderer::getScreenHeight() * 0.849f);
 	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
@@ -80,7 +80,7 @@ GuiScraperMulti::~GuiScraperMulti()
 
 void GuiScraperMulti::onSizeChanged()
 {
-	mBackground.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
+	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	mGrid.setRowHeightPerc(0, mTitle->getFont()->getLetterHeight() * 1.9725f / mSize.y(), false);
 	mGrid.setRowHeightPerc(1, (mSystem->getFont()->getLetterHeight() + 2) / mSize.y(), false);

--- a/es-app/src/guis/GuiSlideshowScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiSlideshowScreensaverOptions.cpp
@@ -101,7 +101,7 @@ void GuiSlideshowScreensaverOptions::addEditableTextComponent(ComponentListRow r
 
 	auto bracket = std::make_shared<ImageComponent>(mWindow);
 	bracket->setImage(":/arrow.svg");
-	bracket->setResize(Eigen::Vector2f(0, lbl->getFont()->getLetterHeight()));
+	bracket->setResize(Vector2f(0, lbl->getFont()->getLetterHeight()));
 	row.addElement(bracket, false);
 
 	auto updateVal = [ed](const std::string& newVal) { ed->setValue(newVal); }; // ok callback (apply new value to ed)

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -327,12 +327,12 @@ void SystemView::onCursorChanged(const CursorState& state)
 	setAnimation(anim, 0, nullptr, false, 0);
 }
 
-void SystemView::render(const Affine3f& parentTrans)
+void SystemView::render(const Matrix4x4f& parentTrans)
 {
 	if(size() == 0)
 		return;  // nothing to render
 
-	Affine3f trans = getTransform() * parentTrans;
+	Matrix4x4f trans = getTransform() * parentTrans;
 
 	auto systemInfoZIndex = mSystemInfo.getZIndex();
 	auto minMax = std::minmax(mCarousel.zIndex, systemInfoZIndex);
@@ -409,10 +409,10 @@ void  SystemView::getViewElements(const std::shared_ptr<ThemeData>& theme)
 }
 
 //  Render system carousel
-void SystemView::renderCarousel(const Affine3f& trans)
+void SystemView::renderCarousel(const Matrix4x4f& trans)
 {
 	// background box behind logos
-	Affine3f carouselTrans = trans;
+	Matrix4x4f carouselTrans = trans;
 	carouselTrans.translate(Vector3f(mCarousel.pos.x(), mCarousel.pos.y(), 0.0));
 	carouselTrans.translate(Vector3f(mCarousel.origin.x() * mCarousel.size.x() * -1, mCarousel.origin.y() * mCarousel.size.y() * -1, 0.0f));
 
@@ -484,7 +484,7 @@ void SystemView::renderCarousel(const Affine3f& trans)
 		while (index >= (int)mEntries.size())
 			index -= mEntries.size();
 
-		Affine3f logoTrans = carouselTrans;
+		Matrix4x4f logoTrans = carouselTrans;
 		logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff, i * logoSpacing[1] + yOff, 0));
 
 		float distance = i - mCamOffset;
@@ -508,14 +508,14 @@ void SystemView::renderCarousel(const Affine3f& trans)
 	Renderer::popClipRect();
 }
 
-void SystemView::renderInfoBar(const Affine3f& trans)
+void SystemView::renderInfoBar(const Matrix4x4f& trans)
 {
 	Renderer::setMatrix(trans);
 	mSystemInfo.render(trans);
 }
 
 // Draw background extras
-void SystemView::renderExtras(const Affine3f& trans, float lower, float upper)
+void SystemView::renderExtras(const Matrix4x4f& trans, float lower, float upper)
 {
 	int extrasCenter = (int)mExtrasCamOffset;
 
@@ -535,7 +535,7 @@ void SystemView::renderExtras(const Affine3f& trans, float lower, float upper)
 		//Only render selected system when not showing
 		if (mShowing || index == mCursor)
 		{
-			Affine3f extrasTrans = trans;
+			Matrix4x4f extrasTrans = trans;
 			if (mCarousel.type == HORIZONTAL)
 				extrasTrans.translate(Vector3f((i - mExtrasCamOffset) * mSize.x(), 0, 0));
 			else
@@ -556,7 +556,7 @@ void SystemView::renderExtras(const Affine3f& trans, float lower, float upper)
 	Renderer::popClipRect();
 }
 
-void SystemView::renderFade(const Affine3f& trans)
+void SystemView::renderFade(const Matrix4x4f& trans)
 {
 	// fade extras if necessary
 	if (mExtrasFadeOpacity)

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -92,7 +92,7 @@ void SystemView::populate()
 				e.data.logo->setOrigin(0.5, 0.5);
 		}
 
-		Eigen::Vector2f denormalized = mCarousel.logoSize.cwiseProduct(e.data.logo->getOrigin());
+		Vector2f denormalized = mCarousel.logoSize.cwiseProduct(e.data.logo->getOrigin());
 		e.data.logo->setPosition(denormalized.x(), denormalized.y(), 0.0);
 
 		// delete any existing extras
@@ -327,12 +327,12 @@ void SystemView::onCursorChanged(const CursorState& state)
 	setAnimation(anim, 0, nullptr, false, 0);
 }
 
-void SystemView::render(const Eigen::Affine3f& parentTrans)
+void SystemView::render(const Affine3f& parentTrans)
 {
 	if(size() == 0)
 		return;  // nothing to render
 
-	Eigen::Affine3f trans = getTransform() * parentTrans;
+	Affine3f trans = getTransform() * parentTrans;
 
 	auto systemInfoZIndex = mSystemInfo.getZIndex();
 	auto minMax = std::minmax(mCarousel.zIndex, systemInfoZIndex);
@@ -409,21 +409,21 @@ void  SystemView::getViewElements(const std::shared_ptr<ThemeData>& theme)
 }
 
 //  Render system carousel
-void SystemView::renderCarousel(const Eigen::Affine3f& trans)
+void SystemView::renderCarousel(const Affine3f& trans)
 {
 	// background box behind logos
-	Eigen::Affine3f carouselTrans = trans;
-	carouselTrans.translate(Eigen::Vector3f(mCarousel.pos.x(), mCarousel.pos.y(), 0.0));
-	carouselTrans.translate(Eigen::Vector3f(mCarousel.origin.x() * mCarousel.size.x() * -1, mCarousel.origin.y() * mCarousel.size.y() * -1, 0.0f));
+	Affine3f carouselTrans = trans;
+	carouselTrans.translate(Vector3f(mCarousel.pos.x(), mCarousel.pos.y(), 0.0));
+	carouselTrans.translate(Vector3f(mCarousel.origin.x() * mCarousel.size.x() * -1, mCarousel.origin.y() * mCarousel.size.y() * -1, 0.0f));
 
-	Eigen::Vector2f clipPos(carouselTrans.translation().x(), carouselTrans.translation().y());
+	Vector2f clipPos(carouselTrans.translation().x(), carouselTrans.translation().y());
 	Renderer::pushClipRect(clipPos.cast<int>(), mCarousel.size.cast<int>());
 
 	Renderer::setMatrix(carouselTrans);
 	Renderer::drawRect(0.0, 0.0, mCarousel.size.x(), mCarousel.size.y(), mCarousel.color);
 
 	// draw logos
-	Eigen::Vector2f logoSpacing(0.0, 0.0); // NB: logoSpacing will include the size of the logo itself as well!
+	Vector2f logoSpacing(0.0, 0.0); // NB: logoSpacing will include the size of the logo itself as well!
 	float xOff = 0.0;
 	float yOff = 0.0;
 
@@ -484,8 +484,8 @@ void SystemView::renderCarousel(const Eigen::Affine3f& trans)
 		while (index >= (int)mEntries.size())
 			index -= mEntries.size();
 
-		Eigen::Affine3f logoTrans = carouselTrans;
-		logoTrans.translate(Eigen::Vector3f(i * logoSpacing[0] + xOff, i * logoSpacing[1] + yOff, 0));
+		Affine3f logoTrans = carouselTrans;
+		logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff, i * logoSpacing[1] + yOff, 0));
 
 		float distance = i - mCamOffset;
 
@@ -508,21 +508,21 @@ void SystemView::renderCarousel(const Eigen::Affine3f& trans)
 	Renderer::popClipRect();
 }
 
-void SystemView::renderInfoBar(const Eigen::Affine3f& trans)
+void SystemView::renderInfoBar(const Affine3f& trans)
 {
 	Renderer::setMatrix(trans);
 	mSystemInfo.render(trans);
 }
 
 // Draw background extras
-void SystemView::renderExtras(const Eigen::Affine3f& trans, float lower, float upper)
+void SystemView::renderExtras(const Affine3f& trans, float lower, float upper)
 {
 	int extrasCenter = (int)mExtrasCamOffset;
 
 	// Adding texture loading buffers depending on scrolling speed and status
 	int bufferIndex = getScrollingVelocity() + 1;
 
-	Renderer::pushClipRect(Eigen::Vector2i::Zero(), mSize.cast<int>());
+	Renderer::pushClipRect(Vector2i::Zero(), mSize.cast<int>());
 
 	for (int i = extrasCenter + logoBuffersLeft[bufferIndex]; i <= extrasCenter + logoBuffersRight[bufferIndex]; i++)
 	{
@@ -535,13 +535,13 @@ void SystemView::renderExtras(const Eigen::Affine3f& trans, float lower, float u
 		//Only render selected system when not showing
 		if (mShowing || index == mCursor)
 		{
-			Eigen::Affine3f extrasTrans = trans;
+			Affine3f extrasTrans = trans;
 			if (mCarousel.type == HORIZONTAL)
-				extrasTrans.translate(Eigen::Vector3f((i - mExtrasCamOffset) * mSize.x(), 0, 0));
+				extrasTrans.translate(Vector3f((i - mExtrasCamOffset) * mSize.x(), 0, 0));
 			else
-				extrasTrans.translate(Eigen::Vector3f(0, (i - mExtrasCamOffset) * mSize.y(), 0));
+				extrasTrans.translate(Vector3f(0, (i - mExtrasCamOffset) * mSize.y(), 0));
 
-			Renderer::pushClipRect(Eigen::Vector2i(extrasTrans.translation()[0], extrasTrans.translation()[1]),
+			Renderer::pushClipRect(Vector2i(extrasTrans.translation()[0], extrasTrans.translation()[1]),
 								   mSize.cast<int>());
 			SystemViewData data = mEntries.at(index).data;
 			for (unsigned int j = 0; j < data.backgroundExtras.size(); j++) {
@@ -556,7 +556,7 @@ void SystemView::renderExtras(const Eigen::Affine3f& trans, float lower, float u
 	Renderer::popClipRect();
 }
 
-void SystemView::renderFade(const Eigen::Affine3f& trans)
+void SystemView::renderFade(const Affine3f& trans)
 {
 	// fade extras if necessary
 	if (mExtrasFadeOpacity)
@@ -611,17 +611,17 @@ void SystemView::getCarouselFromTheme(const ThemeData::ThemeElement* elem)
 			mCarousel.type = HORIZONTAL;
 	}
 	if (elem->has("size"))
-		mCarousel.size = elem->get<Eigen::Vector2f>("size").cwiseProduct(mSize);
+		mCarousel.size = elem->get<Vector2f>("size").cwiseProduct(mSize);
 	if (elem->has("pos"))
-		mCarousel.pos = elem->get<Eigen::Vector2f>("pos").cwiseProduct(mSize);
+		mCarousel.pos = elem->get<Vector2f>("pos").cwiseProduct(mSize);
 	if (elem->has("origin"))
-		mCarousel.origin = elem->get<Eigen::Vector2f>("origin");
+		mCarousel.origin = elem->get<Vector2f>("origin");
 	if (elem->has("color"))
 		mCarousel.color = elem->get<unsigned int>("color");
 	if (elem->has("logoScale"))
 		mCarousel.logoScale = elem->get<float>("logoScale");
 	if (elem->has("logoSize"))
-		mCarousel.logoSize = elem->get<Eigen::Vector2f>("logoSize").cwiseProduct(mSize);
+		mCarousel.logoSize = elem->get<Vector2f>("logoSize").cwiseProduct(mSize);
 	if (elem->has("maxLogoCount"))
 		mCarousel.maxLogoCount = std::round(elem->get<float>("maxLogoCount"));
 	if (elem->has("zIndex"))
@@ -629,7 +629,7 @@ void SystemView::getCarouselFromTheme(const ThemeData::ThemeElement* elem)
 	if (elem->has("logoRotation"))
 		mCarousel.logoRotation = elem->get<float>("logoRotation");
     if (elem->has("logoRotationOrigin"))
-		mCarousel.logoRotationOrigin = elem->get<Eigen::Vector2f>("logoRotationOrigin");
+		mCarousel.logoRotationOrigin = elem->get<Vector2f>("logoRotationOrigin");
 	if (elem->has("logoAlignment"))
 	{
 		if (!(elem->get<std::string>("logoAlignment").compare("left")))

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -51,7 +51,7 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 
 	void onThemeChanged(const std::shared_ptr<ThemeData>& theme);
 
@@ -67,10 +67,10 @@ private:
 	void getDefaultElements(void);
 	void getCarouselFromTheme(const ThemeData::ThemeElement* elem);
 
-	void renderCarousel(const Affine3f& parentTrans);
-	void renderExtras(const Affine3f& parentTrans, float lower, float upper);
-	void renderInfoBar(const Affine3f& trans);
-	void renderFade(const Affine3f& trans);
+	void renderCarousel(const Matrix4x4f& parentTrans);
+	void renderExtras(const Matrix4x4f& parentTrans, float lower, float upper);
+	void renderInfoBar(const Matrix4x4f& trans);
+	void renderFade(const Matrix4x4f& trans);
 
 
 	SystemViewCarousel mCarousel;

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -26,16 +26,16 @@ struct SystemViewData
 struct SystemViewCarousel
 {
 	CarouselType type;
-	Eigen::Vector2f pos;
-	Eigen::Vector2f size;
-	Eigen::Vector2f origin;
+	Vector2f pos;
+	Vector2f size;
+	Vector2f origin;
 	float logoScale;
 	float logoRotation;
-	Eigen::Vector2f logoRotationOrigin;
+	Vector2f logoRotationOrigin;
 	Alignment logoAlignment;
 	unsigned int color;
 	int maxLogoCount; // number of logos shown on the carousel
-	Eigen::Vector2f logoSize;
+	Vector2f logoSize;
 	float zIndex;
 };
 
@@ -51,7 +51,7 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 
 	void onThemeChanged(const std::shared_ptr<ThemeData>& theme);
 
@@ -67,10 +67,10 @@ private:
 	void getDefaultElements(void);
 	void getCarouselFromTheme(const ThemeData::ThemeElement* elem);
 
-	void renderCarousel(const Eigen::Affine3f& parentTrans);
-	void renderExtras(const Eigen::Affine3f& parentTrans, float lower, float upper);
-	void renderInfoBar(const Eigen::Affine3f& trans);
-	void renderFade(const Eigen::Affine3f& trans);
+	void renderCarousel(const Affine3f& parentTrans);
+	void renderExtras(const Affine3f& parentTrans, float lower, float upper);
+	void renderInfoBar(const Affine3f& trans);
+	void renderFade(const Affine3f& trans);
 
 
 	SystemViewCarousel mCarousel;

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -30,7 +30,7 @@ void ViewController::init(Window* window)
 }
 
 ViewController::ViewController(Window* window)
-	: GuiComponent(window), mCurrentView(nullptr), mCamera(Affine3f::Identity()), mFadeOpacity(0), mLockInput(false)
+	: GuiComponent(window), mCurrentView(nullptr), mCamera(Matrix4x4f::Identity()), mFadeOpacity(0), mLockInput(false)
 {
 	mState.viewing = NOTHING;
 	mCurUIMode = Settings::getInstance()->getString("UIMode");
@@ -223,7 +223,7 @@ void ViewController::launch(FileData* game, Vector3f center)
 	if (mCurrentView)
 		mCurrentView->onHide();
 
-	Affine3f origCamera = mCamera;
+	Matrix4x4f origCamera = mCamera;
 	origCamera.translation() = -mCurrentView->getPosition();
 
 	center += mCurrentView->getPosition();
@@ -388,9 +388,9 @@ void ViewController::update(int deltaTime)
 	updateSelf(deltaTime);
 }
 
-void ViewController::render(const Affine3f& parentTrans)
+void ViewController::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = mCamera * parentTrans;
+	Matrix4x4f trans = mCamera * parentTrans;
 
 	// camera position, position + size
 	Vector3f viewStart = trans.inverse().translation();

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -30,7 +30,7 @@ void ViewController::init(Window* window)
 }
 
 ViewController::ViewController(Window* window)
-	: GuiComponent(window), mCurrentView(nullptr), mCamera(Eigen::Affine3f::Identity()), mFadeOpacity(0), mLockInput(false)
+	: GuiComponent(window), mCurrentView(nullptr), mCamera(Affine3f::Identity()), mFadeOpacity(0), mLockInput(false)
 {
 	mState.viewing = NOTHING;
 	mCurUIMode = Settings::getInstance()->getString("UIMode");
@@ -152,7 +152,7 @@ void ViewController::goToRandomGame()
 
 void ViewController::playViewTransition()
 {
-	Eigen::Vector3f target(Eigen::Vector3f::Zero());
+	Vector3f target(Vector3f::Zero());
 	if(mCurrentView)
 		target = mCurrentView->getPosition();
 
@@ -211,7 +211,7 @@ void ViewController::onFileChanged(FileData* file, FileChangeType change)
 		it->second->onFileChanged(file, change);
 }
 
-void ViewController::launch(FileData* game, Eigen::Vector3f center)
+void ViewController::launch(FileData* game, Vector3f center)
 {
 	if(game->getType() != GAME)
 	{
@@ -223,7 +223,7 @@ void ViewController::launch(FileData* game, Eigen::Vector3f center)
 	if (mCurrentView)
 		mCurrentView->onHide();
 
-	Eigen::Affine3f origCamera = mCamera;
+	Affine3f origCamera = mCamera;
 	origCamera.translation() = -mCurrentView->getPosition();
 
 	center += mCurrentView->getPosition();
@@ -388,13 +388,13 @@ void ViewController::update(int deltaTime)
 	updateSelf(deltaTime);
 }
 
-void ViewController::render(const Eigen::Affine3f& parentTrans)
+void ViewController::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = mCamera * parentTrans;
+	Affine3f trans = mCamera * parentTrans;
 
 	// camera position, position + size
-	Eigen::Vector3f viewStart = trans.inverse().translation();
-	Eigen::Vector3f viewEnd = trans.inverse() * Eigen::Vector3f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight(), 0);
+	Vector3f viewStart = trans.inverse().translation();
+	Vector3f viewEnd = trans.inverse() * Vector3f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight(), 0);
 
 	// Keep track of UI mode changes.
 	monitorUIMode();
@@ -406,8 +406,8 @@ void ViewController::render(const Eigen::Affine3f& parentTrans)
 	for(auto it = mGameListViews.begin(); it != mGameListViews.end(); it++)
 	{
 		// clipping
-		Eigen::Vector3f guiStart = it->second->getPosition();
-		Eigen::Vector3f guiEnd = it->second->getPosition() + Eigen::Vector3f(it->second->getSize().x(), it->second->getSize().y(), 0);
+		Vector3f guiStart = it->second->getPosition();
+		Vector3f guiEnd = it->second->getPosition() + Vector3f(it->second->getSize().x(), it->second->getSize().y(), 0);
 
 		if(guiEnd.x() >= viewStart.x() && guiEnd.y() >= viewStart.y() &&
 			guiStart.x() <= viewEnd.x() && guiStart.y() <= viewEnd.y())

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -152,7 +152,7 @@ void ViewController::goToRandomGame()
 
 void ViewController::playViewTransition()
 {
-	Eigen::Vector3f target(Eigen::Vector3f::Identity());
+	Eigen::Vector3f target(Eigen::Vector3f::Zero());
 	if(mCurrentView)
 		target = mCurrentView->getPosition();
 

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -42,11 +42,11 @@ public:
 
 	// Plays a nice launch effect and launches the game at the end of it.
 	// Once the game terminates, plays a return effect.
-	void launch(FileData* game, Eigen::Vector3f centerCameraOn = Eigen::Vector3f(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f, 0));
+	void launch(FileData* game, Vector3f centerCameraOn = Vector3f(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f, 0));
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 
 	enum ViewMode
 	{
@@ -96,7 +96,7 @@ private:
 	std::map< SystemData*, std::shared_ptr<IGameListView> > mGameListViews;
 	std::shared_ptr<SystemView> mSystemListView;
 	
-	Eigen::Affine3f mCamera;
+	Affine3f mCamera;
 	float mFadeOpacity;
 	bool mLockInput;
 

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -46,7 +46,7 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 
 	enum ViewMode
 	{
@@ -96,7 +96,7 @@ private:
 	std::map< SystemData*, std::shared_ptr<IGameListView> > mGameListViews;
 	std::shared_ptr<SystemView> mSystemListView;
 	
-	Affine3f mCamera;
+	Matrix4x4f mCamera;
 	float mFadeOpacity;
 	bool mLockInput;
 

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -121,7 +121,7 @@ void DetailedGameListView::initMDLabels()
 	const unsigned int colCount = 2;
 	const unsigned int rowCount = components.size() / 2;
 
-	Eigen::Vector3f start(mSize.x() * 0.01f, mSize.y() * 0.625f, 0.0f);
+	Vector3f start(mSize.x() * 0.01f, mSize.y() * 0.625f, 0.0f);
 	
 	const float colSize = (mSize.x() * 0.48f) / colCount;
 	const float rowPadding = 0.01f * mSize.y();
@@ -129,14 +129,14 @@ void DetailedGameListView::initMDLabels()
 	for(unsigned int i = 0; i < components.size(); i++)
 	{
 		const unsigned int row = i % rowCount;
-		Eigen::Vector3f pos(0.0f, 0.0f, 0.0f);
+		Vector3f pos(0.0f, 0.0f, 0.0f);
 		if(row == 0)
 		{
-			pos = start + Eigen::Vector3f(colSize * (i / rowCount), 0, 0);
+			pos = start + Vector3f(colSize * (i / rowCount), 0, 0);
 		}else{
 			// work from the last component
 			GuiComponent* lc = components[i-1];
-			pos = lc->getPosition() + Eigen::Vector3f(0, lc->getSize().y() + rowPadding, 0);
+			pos = lc->getPosition() + Vector3f(0, lc->getSize().y() + rowPadding, 0);
 		}
 
 		components[i]->setFont(Font::get(FONT_SIZE_SMALL));
@@ -166,7 +166,7 @@ void DetailedGameListView::initMDValues()
 	for(unsigned int i = 0; i < labels.size(); i++)
 	{
 		const float heightDiff = (labels[i]->getSize().y() - values[i]->getSize().y()) / 2;
-		values[i]->setPosition(labels[i]->getPosition() + Eigen::Vector3f(labels[i]->getSize().x(), heightDiff, 0));
+		values[i]->setPosition(labels[i]->getPosition() + Vector3f(labels[i]->getSize().x(), heightDiff, 0));
 		values[i]->setSize(colSize - labels[i]->getSize().x(), values[i]->getSize().y());
 		values[i]->setDefaultZIndex(40);
 
@@ -237,7 +237,7 @@ void DetailedGameListView::updateInfoPanel()
 
 void DetailedGameListView::launch(FileData* game)
 {
-	Eigen::Vector3f target(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f, 0);
+	Vector3f target(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f, 0);
 	if(mImage.hasImage())
 		target << mImage.getCenter().x(), mImage.getCenter().y(), 0;
 

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -116,14 +116,12 @@ void DetailedGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& them
 
 void DetailedGameListView::initMDLabels()
 {
-	using namespace Eigen;
-
 	std::vector<TextComponent*> components = getMDLabels();
 
 	const unsigned int colCount = 2;
 	const unsigned int rowCount = components.size() / 2;
 
-	Vector3f start(mSize.x() * 0.01f, mSize.y() * 0.625f, 0.0f);
+	Eigen::Vector3f start(mSize.x() * 0.01f, mSize.y() * 0.625f, 0.0f);
 	
 	const float colSize = (mSize.x() * 0.48f) / colCount;
 	const float rowPadding = 0.01f * mSize.y();
@@ -131,14 +129,14 @@ void DetailedGameListView::initMDLabels()
 	for(unsigned int i = 0; i < components.size(); i++)
 	{
 		const unsigned int row = i % rowCount;
-		Vector3f pos(0.0f, 0.0f, 0.0f);
+		Eigen::Vector3f pos(0.0f, 0.0f, 0.0f);
 		if(row == 0)
 		{
-			pos = start + Vector3f(colSize * (i / rowCount), 0, 0);
+			pos = start + Eigen::Vector3f(colSize * (i / rowCount), 0, 0);
 		}else{
 			// work from the last component
 			GuiComponent* lc = components[i-1];
-			pos = lc->getPosition() + Vector3f(0, lc->getSize().y() + rowPadding, 0);
+			pos = lc->getPosition() + Eigen::Vector3f(0, lc->getSize().y() + rowPadding, 0);
 		}
 
 		components[i]->setFont(Font::get(FONT_SIZE_SMALL));
@@ -149,8 +147,6 @@ void DetailedGameListView::initMDLabels()
 
 void DetailedGameListView::initMDValues()
 {
-	using namespace Eigen;
-
 	std::vector<TextComponent*> labels = getMDLabels();
 	std::vector<GuiComponent*> values = getMDValues();
 
@@ -170,7 +166,7 @@ void DetailedGameListView::initMDValues()
 	for(unsigned int i = 0; i < labels.size(); i++)
 	{
 		const float heightDiff = (labels[i]->getSize().y() - values[i]->getSize().y()) / 2;
-		values[i]->setPosition(labels[i]->getPosition() + Vector3f(labels[i]->getSize().x(), heightDiff, 0));
+		values[i]->setPosition(labels[i]->getPosition() + Eigen::Vector3f(labels[i]->getSize().x(), heightDiff, 0));
 		values[i]->setSize(colSize - labels[i]->getSize().x(), values[i]->getSize().y());
 		values[i]->setDefaultZIndex(40);
 

--- a/es-app/src/views/gamelist/IGameListView.cpp
+++ b/es-app/src/views/gamelist/IGameListView.cpp
@@ -42,9 +42,9 @@ HelpStyle IGameListView::getHelpStyle()
 	return style;
 }
 
-void IGameListView::render(const Affine3f& parentTrans)
+void IGameListView::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 
 	float scaleX = trans[0];
 	float scaleY = trans[5];

--- a/es-app/src/views/gamelist/IGameListView.cpp
+++ b/es-app/src/views/gamelist/IGameListView.cpp
@@ -46,8 +46,8 @@ void IGameListView::render(const Eigen::Affine3f& parentTrans)
 {
 	Eigen::Affine3f trans = parentTrans * getTransform();
 
-	float scaleX = trans.linear()(0,0);
-	float scaleY = trans.linear()(1,1);
+	float scaleX = trans[0];
+	float scaleY = trans[5];
 
 	Eigen::Vector2i pos(trans.translation()[0], trans.translation()[1]);
 	Eigen::Vector2i size(mSize.x() * scaleX, mSize.y() * scaleY);

--- a/es-app/src/views/gamelist/IGameListView.cpp
+++ b/es-app/src/views/gamelist/IGameListView.cpp
@@ -42,15 +42,15 @@ HelpStyle IGameListView::getHelpStyle()
 	return style;
 }
 
-void IGameListView::render(const Eigen::Affine3f& parentTrans)
+void IGameListView::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 
 	float scaleX = trans[0];
 	float scaleY = trans[5];
 
-	Eigen::Vector2i pos(trans.translation()[0], trans.translation()[1]);
-	Eigen::Vector2i size(mSize.x() * scaleX, mSize.y() * scaleY);
+	Vector2i pos(trans.translation()[0], trans.translation()[1]);
+	Vector2i size(mSize.x() * scaleX, mSize.y() * scaleY);
 
 	Renderer::pushClipRect(pos, size);
 	renderChildren(trans);

--- a/es-app/src/views/gamelist/IGameListView.h
+++ b/es-app/src/views/gamelist/IGameListView.h
@@ -39,7 +39,7 @@ public:
 
 	virtual HelpStyle getHelpStyle() override;
 
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 protected:
 	FileData* mRoot;
 	std::shared_ptr<ThemeData> mTheme;

--- a/es-app/src/views/gamelist/IGameListView.h
+++ b/es-app/src/views/gamelist/IGameListView.h
@@ -39,7 +39,7 @@ public:
 
 	virtual HelpStyle getHelpStyle() override;
 
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 protected:
 	FileData* mRoot;
 	std::shared_ptr<ThemeData> mTheme;

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -159,7 +159,7 @@ void VideoGameListView::initMDLabels()
 	const unsigned int colCount = 2;
 	const unsigned int rowCount = components.size() / 2;
 
-	Eigen::Vector3f start(mSize.x() * 0.01f, mSize.y() * 0.625f, 0.0f);
+	Vector3f start(mSize.x() * 0.01f, mSize.y() * 0.625f, 0.0f);
 
 	const float colSize = (mSize.x() * 0.48f) / colCount;
 	const float rowPadding = 0.01f * mSize.y();
@@ -167,14 +167,14 @@ void VideoGameListView::initMDLabels()
 	for(unsigned int i = 0; i < components.size(); i++)
 	{
 		const unsigned int row = i % rowCount;
-		Eigen::Vector3f pos(0.0f, 0.0f, 0.0f);
+		Vector3f pos(0.0f, 0.0f, 0.0f);
 		if(row == 0)
 		{
-			pos = start + Eigen::Vector3f(colSize * (i / rowCount), 0, 0);
+			pos = start + Vector3f(colSize * (i / rowCount), 0, 0);
 		}else{
 			// work from the last component
 			GuiComponent* lc = components[i-1];
-			pos = lc->getPosition() + Eigen::Vector3f(0, lc->getSize().y() + rowPadding, 0);
+			pos = lc->getPosition() + Vector3f(0, lc->getSize().y() + rowPadding, 0);
 		}
 
 		components[i]->setFont(Font::get(FONT_SIZE_SMALL));
@@ -204,7 +204,7 @@ void VideoGameListView::initMDValues()
 	for(unsigned int i = 0; i < labels.size(); i++)
 	{
 		const float heightDiff = (labels[i]->getSize().y() - values[i]->getSize().y()) / 2;
-		values[i]->setPosition(labels[i]->getPosition() + Eigen::Vector3f(labels[i]->getSize().x(), heightDiff, 0));
+		values[i]->setPosition(labels[i]->getPosition() + Vector3f(labels[i]->getSize().x(), heightDiff, 0));
 		values[i]->setSize(colSize - labels[i]->getSize().x(), values[i]->getSize().y());
 		values[i]->setDefaultZIndex(40);
 
@@ -319,7 +319,7 @@ void VideoGameListView::launch(FileData* game)
 	float screenWidth = Renderer::getScreenWidth();
 	float screenHeight = Renderer::getScreenHeight();
 
-	Eigen::Vector3f target(screenWidth / 2.0f, screenHeight / 2.0f, 0);
+	Vector3f target(screenWidth / 2.0f, screenHeight / 2.0f, 0);
 
 	if(mMarquee.hasImage() &&
 		(mMarquee.getPosition().x() < screenWidth && mMarquee.getPosition().x() > 0.0f &&

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -154,14 +154,12 @@ void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 
 void VideoGameListView::initMDLabels()
 {
-	using namespace Eigen;
-
 	std::vector<TextComponent*> components = getMDLabels();
 
 	const unsigned int colCount = 2;
 	const unsigned int rowCount = components.size() / 2;
 
-	Vector3f start(mSize.x() * 0.01f, mSize.y() * 0.625f, 0.0f);
+	Eigen::Vector3f start(mSize.x() * 0.01f, mSize.y() * 0.625f, 0.0f);
 
 	const float colSize = (mSize.x() * 0.48f) / colCount;
 	const float rowPadding = 0.01f * mSize.y();
@@ -169,14 +167,14 @@ void VideoGameListView::initMDLabels()
 	for(unsigned int i = 0; i < components.size(); i++)
 	{
 		const unsigned int row = i % rowCount;
-		Vector3f pos(0.0f, 0.0f, 0.0f);
+		Eigen::Vector3f pos(0.0f, 0.0f, 0.0f);
 		if(row == 0)
 		{
-			pos = start + Vector3f(colSize * (i / rowCount), 0, 0);
+			pos = start + Eigen::Vector3f(colSize * (i / rowCount), 0, 0);
 		}else{
 			// work from the last component
 			GuiComponent* lc = components[i-1];
-			pos = lc->getPosition() + Vector3f(0, lc->getSize().y() + rowPadding, 0);
+			pos = lc->getPosition() + Eigen::Vector3f(0, lc->getSize().y() + rowPadding, 0);
 		}
 
 		components[i]->setFont(Font::get(FONT_SIZE_SMALL));
@@ -187,8 +185,6 @@ void VideoGameListView::initMDLabels()
 
 void VideoGameListView::initMDValues()
 {
-	using namespace Eigen;
-
 	std::vector<TextComponent*> labels = getMDLabels();
 	std::vector<GuiComponent*> values = getMDValues();
 
@@ -208,7 +204,7 @@ void VideoGameListView::initMDValues()
 	for(unsigned int i = 0; i < labels.size(); i++)
 	{
 		const float heightDiff = (labels[i]->getSize().y() - values[i]->getSize().y()) / 2;
-		values[i]->setPosition(labels[i]->getPosition() + Vector3f(labels[i]->getSize().x(), heightDiff, 0));
+		values[i]->setPosition(labels[i]->getPosition() + Eigen::Vector3f(labels[i]->getSize().x(), heightDiff, 0));
 		values[i]->setSize(colSize - labels[i]->getSize().x(), values[i]->getSize().y());
 		values[i]->setDefaultZIndex(40);
 

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -241,11 +241,11 @@ void GuiComponent::setOpacity(unsigned char opacity)
 
 const Eigen::Affine3f& GuiComponent::getTransform()
 {
-	mTransform.setIdentity();
+	mTransform = Eigen::Affine3f::Identity();
 	mTransform.translate(mPosition);
 	if (mScale != 1.0)
 	{
-		mTransform *= Eigen::Scaling(mScale);
+		mTransform.scale(mScale);
 	}
 	if (mRotation != 0.0)
 	{
@@ -257,8 +257,8 @@ const Eigen::Affine3f& GuiComponent::getTransform()
 		if (xOff != 0.0 || yOff != 0.0)
 			mTransform.translate(Eigen::Vector3f(xOff * -1, yOff * -1, 0.0f));
 
-		// apply rotation transorm
-		mTransform *= Eigen::AngleAxisf(mRotation, Eigen::Vector3f::UnitZ());
+		// apply rotation transform
+		mTransform.rotate(mRotation, Eigen::Vector3f::UnitZ());
 
 		// Tranform back to original point
 		if (xOff != 0.0 || yOff != 0.0)

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -6,8 +6,8 @@
 #include "ThemeData.h"
 
 GuiComponent::GuiComponent(Window* window) : mWindow(window), mParent(NULL), mOpacity(255),
-	mPosition(Eigen::Vector3f::Zero()), mOrigin(Eigen::Vector2f::Zero()), mRotationOrigin(0.5, 0.5),
-	mSize(Eigen::Vector2f::Zero()), mTransform(Eigen::Affine3f::Identity()), mIsProcessing(false)
+	mPosition(Vector3f::Zero()), mOrigin(Vector2f::Zero()), mRotationOrigin(0.5, 0.5),
+	mSize(Vector2f::Zero()), mTransform(Affine3f::Identity()), mIsProcessing(false)
 {
 	for(unsigned char i = 0; i < MAX_ANIMATIONS; i++)
 		mAnimationMap[i] = NULL;
@@ -57,13 +57,13 @@ void GuiComponent::update(int deltaTime)
 	updateChildren(deltaTime);
 }
 
-void GuiComponent::render(const Eigen::Affine3f& parentTrans)
+void GuiComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 	renderChildren(trans);
 }
 
-void GuiComponent::renderChildren(const Eigen::Affine3f& transform) const
+void GuiComponent::renderChildren(const Affine3f& transform) const
 {
 	for(unsigned int i = 0; i < getChildCount(); i++)
 	{
@@ -71,7 +71,7 @@ void GuiComponent::renderChildren(const Eigen::Affine3f& transform) const
 	}
 }
 
-Eigen::Vector3f GuiComponent::getPosition() const
+Vector3f GuiComponent::getPosition() const
 {
 	return mPosition;
 }
@@ -82,7 +82,7 @@ void GuiComponent::setPosition(float x, float y, float z)
 	onPositionChanged();
 }
 
-Eigen::Vector2f GuiComponent::getOrigin() const
+Vector2f GuiComponent::getOrigin() const
 {
 	return mOrigin;
 }
@@ -93,7 +93,7 @@ void GuiComponent::setOrigin(float x, float y)
 	onOriginChanged();
 }
 
-Eigen::Vector2f GuiComponent::getRotationOrigin() const
+Vector2f GuiComponent::getRotationOrigin() const
 {
 	return mRotationOrigin;
 }
@@ -103,7 +103,7 @@ void GuiComponent::setRotationOrigin(float x, float y)
 	mRotationOrigin << x, y;;
 }
 
-Eigen::Vector2f GuiComponent::getSize() const
+Vector2f GuiComponent::getSize() const
 {
 	return mSize;
 }
@@ -154,9 +154,9 @@ void GuiComponent::setDefaultZIndex(float z)
 	mDefaultZIndex = z;
 }
 
-Eigen::Vector2f GuiComponent::getCenter() const
+Vector2f GuiComponent::getCenter() const
 {
-	return Eigen::Vector2f(mPosition.x() - (getSize().x() * mOrigin.x()) + getSize().x() / 2,
+	return Vector2f(mPosition.x() - (getSize().x() * mOrigin.x()) + getSize().x() / 2,
 						   mPosition.y() - (getSize().y() * mOrigin.y()) + getSize().y() / 2);
 }
 
@@ -239,9 +239,9 @@ void GuiComponent::setOpacity(unsigned char opacity)
 	}
 }
 
-const Eigen::Affine3f& GuiComponent::getTransform()
+const Affine3f& GuiComponent::getTransform()
 {
-	mTransform = Eigen::Affine3f::Identity();
+	mTransform = Affine3f::Identity();
 	mTransform.translate(mPosition);
 	if (mScale != 1.0)
 	{
@@ -255,16 +255,16 @@ const Eigen::Affine3f& GuiComponent::getTransform()
 
 		// transform to offset point
 		if (xOff != 0.0 || yOff != 0.0)
-			mTransform.translate(Eigen::Vector3f(xOff * -1, yOff * -1, 0.0f));
+			mTransform.translate(Vector3f(xOff * -1, yOff * -1, 0.0f));
 
 		// apply rotation transform
-		mTransform.rotate(mRotation, Eigen::Vector3f::UnitZ());
+		mTransform.rotate(mRotation, Vector3f::UnitZ());
 
 		// Tranform back to original point
 		if (xOff != 0.0 || yOff != 0.0)
-			mTransform.translate(Eigen::Vector3f(xOff, yOff, 0.0f));
+			mTransform.translate(Vector3f(xOff, yOff, 0.0f));
 	}
-	mTransform.translate(Eigen::Vector3f(mOrigin.x() * mSize.x() * -1, mOrigin.y() * mSize.y() * -1, 0.0f));
+	mTransform.translate(Vector3f(mOrigin.x() * mSize.x() * -1, mOrigin.y() * mSize.y() * -1, 0.0f));
 	return mTransform;
 }
 
@@ -389,7 +389,7 @@ int GuiComponent::getAnimationTime(unsigned char slot) const
 
 void GuiComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties)
 {
-	Eigen::Vector2f scale = getParent() ? getParent()->getSize() : Eigen::Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
+	Vector2f scale = getParent() ? getParent()->getSize() : Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
 
 	const ThemeData::ThemeElement* elem = theme->getElement(view, element, "");
 	if(!elem)
@@ -398,22 +398,22 @@ void GuiComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const std
 	using namespace ThemeFlags;
 	if(properties & POSITION && elem->has("pos"))
 	{
-		Eigen::Vector2f denormalized = elem->get<Eigen::Vector2f>("pos").cwiseProduct(scale);
-		setPosition(Eigen::Vector3f(denormalized.x(), denormalized.y(), 0));
+		Vector2f denormalized = elem->get<Vector2f>("pos").cwiseProduct(scale);
+		setPosition(Vector3f(denormalized.x(), denormalized.y(), 0));
 	}
 
 	if(properties & ThemeFlags::SIZE && elem->has("size"))
-		setSize(elem->get<Eigen::Vector2f>("size").cwiseProduct(scale));
+		setSize(elem->get<Vector2f>("size").cwiseProduct(scale));
 
 	// position + size also implies origin
 	if((properties & ORIGIN || (properties & POSITION && properties & ThemeFlags::SIZE)) && elem->has("origin"))
-		setOrigin(elem->get<Eigen::Vector2f>("origin"));
+		setOrigin(elem->get<Vector2f>("origin"));
 
 	if(properties & ThemeFlags::ROTATION) {
 		if(elem->has("rotation"))
 			setRotationDegrees(elem->get<float>("rotation"));
 		if(elem->has("rotationOrigin"))
-			setRotationOrigin(elem->get<Eigen::Vector2f>("rotationOrigin"));
+			setRotationOrigin(elem->get<Vector2f>("rotationOrigin"));
 	}
 
 	if(properties & ThemeFlags::Z_INDEX && elem->has("zIndex"))

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -7,7 +7,7 @@
 
 GuiComponent::GuiComponent(Window* window) : mWindow(window), mParent(NULL), mOpacity(255),
 	mPosition(Vector3f::Zero()), mOrigin(Vector2f::Zero()), mRotationOrigin(0.5, 0.5),
-	mSize(Vector2f::Zero()), mTransform(Affine3f::Identity()), mIsProcessing(false)
+	mSize(Vector2f::Zero()), mTransform(Matrix4x4f::Identity()), mIsProcessing(false)
 {
 	for(unsigned char i = 0; i < MAX_ANIMATIONS; i++)
 		mAnimationMap[i] = NULL;
@@ -57,13 +57,13 @@ void GuiComponent::update(int deltaTime)
 	updateChildren(deltaTime);
 }
 
-void GuiComponent::render(const Affine3f& parentTrans)
+void GuiComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 	renderChildren(trans);
 }
 
-void GuiComponent::renderChildren(const Affine3f& transform) const
+void GuiComponent::renderChildren(const Matrix4x4f& transform) const
 {
 	for(unsigned int i = 0; i < getChildCount(); i++)
 	{
@@ -239,9 +239,9 @@ void GuiComponent::setOpacity(unsigned char opacity)
 	}
 }
 
-const Affine3f& GuiComponent::getTransform()
+const Matrix4x4f& GuiComponent::getTransform()
 {
-	mTransform = Affine3f::Identity();
+	mTransform = Matrix4x4f::Identity();
 	mTransform.translate(mPosition);
 	if (mScale != 1.0)
 	{

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -32,11 +32,11 @@ public:
 
 	//Called when it's time to render.  By default, just calls renderChildren(parentTrans * getTransform()).
 	//You probably want to override this like so:
-	//1. Calculate the new transform that your control will draw at with Affine3f t = parentTrans * getTransform().
+	//1. Calculate the new transform that your control will draw at with Matrix4x4f t = parentTrans * getTransform().
 	//2. Set the renderer to use that new transform as the model matrix - Renderer::setMatrix(t);
 	//3. Draw your component.
 	//4. Tell your children to render, based on your component's transform - renderChildren(t).
-	virtual void render(const Affine3f& parentTrans);
+	virtual void render(const Matrix4x4f& parentTrans);
 
 	Vector3f getPosition() const;
 	inline void setPosition(const Vector3f& offset) { setPosition(offset.x(), offset.y(), offset.z()); }
@@ -100,7 +100,7 @@ public:
 	virtual unsigned char getOpacity() const;
 	virtual void setOpacity(unsigned char opacity);
 
-	const Affine3f& getTransform();
+	const Matrix4x4f& getTransform();
 
 	virtual std::string getValue() const;
 	virtual void setValue(const std::string& value);
@@ -131,7 +131,7 @@ public:
 	bool isProcessing() const;
 
 protected:
-	void renderChildren(const Affine3f& transform) const;
+	void renderChildren(const Matrix4x4f& transform) const;
 	void updateSelf(int deltaTime); // updates animations
 	void updateChildren(int deltaTime); // updates animations
 
@@ -158,6 +158,6 @@ public:
 	const static unsigned char MAX_ANIMATIONS = 4;
 
 private:
-	Affine3f mTransform; //Don't access this directly! Use getTransform()!
+	Matrix4x4f mTransform; //Don't access this directly! Use getTransform()!
 	AnimationController* mAnimationMap[MAX_ANIMATIONS];
 };

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -32,30 +32,30 @@ public:
 
 	//Called when it's time to render.  By default, just calls renderChildren(parentTrans * getTransform()).
 	//You probably want to override this like so:
-	//1. Calculate the new transform that your control will draw at with Eigen::Affine3f t = parentTrans * getTransform().
+	//1. Calculate the new transform that your control will draw at with Affine3f t = parentTrans * getTransform().
 	//2. Set the renderer to use that new transform as the model matrix - Renderer::setMatrix(t);
 	//3. Draw your component.
 	//4. Tell your children to render, based on your component's transform - renderChildren(t).
-	virtual void render(const Eigen::Affine3f& parentTrans);
+	virtual void render(const Affine3f& parentTrans);
 
-	Eigen::Vector3f getPosition() const;
-	inline void setPosition(const Eigen::Vector3f& offset) { setPosition(offset.x(), offset.y(), offset.z()); }
+	Vector3f getPosition() const;
+	inline void setPosition(const Vector3f& offset) { setPosition(offset.x(), offset.y(), offset.z()); }
 	void setPosition(float x, float y, float z = 0.0f);
 	virtual void onPositionChanged() {};
 
 	//Sets the origin as a percentage of this image (e.g. (0, 0) is top left, (0.5, 0.5) is the center)
-	Eigen::Vector2f getOrigin() const;
+	Vector2f getOrigin() const;
 	void setOrigin(float originX, float originY);
-	inline void setOrigin(Eigen::Vector2f origin) { setOrigin(origin.x(), origin.y()); }
+	inline void setOrigin(Vector2f origin) { setOrigin(origin.x(), origin.y()); }
 	virtual void onOriginChanged() {};
 
 	//Sets the rotation origin as a percentage of this image (e.g. (0, 0) is top left, (0.5, 0.5) is the center)
-	Eigen::Vector2f getRotationOrigin() const;
+	Vector2f getRotationOrigin() const;
 	void setRotationOrigin(float originX, float originY);
-	inline void setRotationOrigin(Eigen::Vector2f origin) { setRotationOrigin(origin.x(), origin.y()); }
+	inline void setRotationOrigin(Vector2f origin) { setRotationOrigin(origin.x(), origin.y()); }
 
-	Eigen::Vector2f getSize() const;
-    inline void setSize(const Eigen::Vector2f& size) { setSize(size.x(), size.y()); }
+	Vector2f getSize() const;
+    inline void setSize(const Vector2f& size) { setSize(size.x(), size.y()); }
     void setSize(float w, float h);
     virtual void onSizeChanged() {};
 
@@ -73,7 +73,7 @@ public:
     void setDefaultZIndex(float zIndex);
 
 	// Returns the center point of the image (takes origin into account).
-	Eigen::Vector2f getCenter() const;
+	Vector2f getCenter() const;
 
 	void setParent(GuiComponent* parent);
 	GuiComponent* getParent() const;
@@ -100,7 +100,7 @@ public:
 	virtual unsigned char getOpacity() const;
 	virtual void setOpacity(unsigned char opacity);
 
-	const Eigen::Affine3f& getTransform();
+	const Affine3f& getTransform();
 
 	virtual std::string getValue() const;
 	virtual void setValue(const std::string& value);
@@ -131,7 +131,7 @@ public:
 	bool isProcessing() const;
 
 protected:
-	void renderChildren(const Eigen::Affine3f& transform) const;
+	void renderChildren(const Affine3f& transform) const;
 	void updateSelf(int deltaTime); // updates animations
 	void updateChildren(int deltaTime); // updates animations
 
@@ -141,10 +141,10 @@ protected:
 	GuiComponent* mParent;
 	std::vector<GuiComponent*> mChildren;
 
-	Eigen::Vector3f mPosition;
-	Eigen::Vector2f mOrigin;
-	Eigen::Vector2f mRotationOrigin;
-	Eigen::Vector2f mSize;
+	Vector3f mPosition;
+	Vector2f mOrigin;
+	Vector2f mRotationOrigin;
+	Vector2f mSize;
 
 	float mRotation = 0.0;
 	float mScale = 1.0;
@@ -158,6 +158,6 @@ public:
 	const static unsigned char MAX_ANIMATIONS = 4;
 
 private:
-	Eigen::Affine3f mTransform; //Don't access this directly! Use getTransform()!
+	Affine3f mTransform; //Don't access this directly! Use getTransform()!
 	AnimationController* mAnimationMap[MAX_ANIMATIONS];
 };

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -3,7 +3,8 @@
 #include "InputConfig.h"
 #include <memory>
 #include <string>
-#include <Eigen/Dense>
+#include <functional>
+#include "math/Math.h"
 #include "HelpStyle.h"
 
 class Window;

--- a/es-core/src/HelpStyle.cpp
+++ b/es-core/src/HelpStyle.cpp
@@ -5,7 +5,7 @@
 
 HelpStyle::HelpStyle()
 {
-	position = Eigen::Vector2f(Renderer::getScreenWidth() * 0.012f, Renderer::getScreenHeight() * 0.9515f);
+	position = Vector2f(Renderer::getScreenWidth() * 0.012f, Renderer::getScreenHeight() * 0.9515f);
 	iconColor = 0x777777FF;
 	textColor = 0x777777FF;
 
@@ -22,7 +22,7 @@ void HelpStyle::applyTheme(const std::shared_ptr<ThemeData>& theme, const std::s
 		return;
 
 	if(elem->has("pos"))
-		position = elem->get<Eigen::Vector2f>("pos").cwiseProduct(Eigen::Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight()));
+		position = elem->get<Vector2f>("pos").cwiseProduct(Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight()));
 
 	if(elem->has("textColor"))
 		textColor = elem->get<unsigned int>("textColor");

--- a/es-core/src/HelpStyle.h
+++ b/es-core/src/HelpStyle.h
@@ -9,7 +9,7 @@ class Font;
 
 struct HelpStyle
 {
-	Eigen::Vector2f position;
+	Vector2f position;
 	unsigned int iconColor;
 	unsigned int textColor;
 	std::shared_ptr<Font> font;

--- a/es-core/src/HelpStyle.h
+++ b/es-core/src/HelpStyle.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Eigen/Dense>
+#include "math/Math.h"
 #include <memory>
 #include <string>
 

--- a/es-core/src/Renderer.h
+++ b/es-core/src/Renderer.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <string>
 #include "platform.h"
-#include <Eigen/Dense>
+#include "math/Math.h"
 #include GLHEADER
 
 class GuiComponent;

--- a/es-core/src/Renderer.h
+++ b/es-core/src/Renderer.h
@@ -26,11 +26,11 @@ namespace Renderer
 	//graphics commands
 	void swapBuffers();
 
-	void pushClipRect(Eigen::Vector2i pos, Eigen::Vector2i dim);
+	void pushClipRect(Vector2i pos, Vector2i dim);
 	void popClipRect();
 
 	void setMatrix(float* mat);
-	void setMatrix(const Eigen::Affine3f& transform);
+	void setMatrix(const Affine3f& transform);
 
 	void drawRect(int x, int y, int w, int h, unsigned int color, GLenum blend_sfactor = GL_SRC_ALPHA, GLenum blend_dfactor = GL_ONE_MINUS_SRC_ALPHA);
 	void drawRect(float x, float y, float w, float h, unsigned int color, GLenum blend_sfactor = GL_SRC_ALPHA, GLenum blend_dfactor = GL_ONE_MINUS_SRC_ALPHA);

--- a/es-core/src/Renderer.h
+++ b/es-core/src/Renderer.h
@@ -30,7 +30,7 @@ namespace Renderer
 	void popClipRect();
 
 	void setMatrix(float* mat);
-	void setMatrix(const Affine3f& transform);
+	void setMatrix(const Matrix4x4f& transform);
 
 	void drawRect(int x, int y, int w, int h, unsigned int color, GLenum blend_sfactor = GL_SRC_ALPHA, GLenum blend_dfactor = GL_ONE_MINUS_SRC_ALPHA);
 	void drawRect(float x, float y, float w, float h, unsigned int color, GLenum blend_sfactor = GL_SRC_ALPHA, GLenum blend_dfactor = GL_ONE_MINUS_SRC_ALPHA);

--- a/es-core/src/Renderer_draw_gl.cpp
+++ b/es-core/src/Renderer_draw_gl.cpp
@@ -9,7 +9,7 @@
 #include "Util.h"
 
 namespace Renderer {
-	std::stack<Eigen::Vector4i> clipStack;
+	std::stack<Vector4i> clipStack;
 
 	void setColor4bArray(GLubyte* array, unsigned int color)
 	{
@@ -29,9 +29,9 @@ namespace Renderer {
 		}
 	}
 
-	void pushClipRect(Eigen::Vector2i pos, Eigen::Vector2i dim)
+	void pushClipRect(Vector2i pos, Vector2i dim)
 	{
-		Eigen::Vector4i box(pos.x(), pos.y(), dim.x(), dim.y());
+		Vector4i box(pos.x(), pos.y(), dim.x(), dim.y());
 		if(box[2] == 0)
 			box[2] = Renderer::getScreenWidth() - box.x();
 		if(box[3] == 0)
@@ -46,7 +46,7 @@ namespace Renderer {
 		//make sure the box fits within clipStack.top(), and clip further accordingly
 		if(clipStack.size())
 		{
-			Eigen::Vector4i& top = clipStack.top();
+			Vector4i& top = clipStack.top();
 			if(top[0] > box[0])
 				box[0] = top[0];
 			if(top[1] > box[1])
@@ -80,7 +80,7 @@ namespace Renderer {
 		{
 			glDisable(GL_SCISSOR_TEST);
 		}else{
-			Eigen::Vector4i top = clipStack.top();
+			Vector4i top = clipStack.top();
 			glScissor(top[0], top[1], top[2], top[3]);
 		}
 	}
@@ -133,7 +133,7 @@ namespace Renderer {
 		glLoadMatrixf(matrix);
 	}
 
-	void setMatrix(const Eigen::Affine3f& matrix)
+	void setMatrix(const Affine3f& matrix)
 	{
 		setMatrix((float*)matrix.data());
 	}

--- a/es-core/src/Renderer_draw_gl.cpp
+++ b/es-core/src/Renderer_draw_gl.cpp
@@ -133,7 +133,7 @@ namespace Renderer {
 		glLoadMatrixf(matrix);
 	}
 
-	void setMatrix(const Affine3f& matrix)
+	void setMatrix(const Matrix4x4f& matrix)
 	{
 		setMatrix((float*)matrix.data());
 	}

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -419,7 +419,7 @@ void ThemeData::parseElement(const pugi::xml_node& root, const std::map<std::str
 			std::string first = str.substr(0, divider);
 			std::string second = str.substr(divider, std::string::npos);
 
-			Eigen::Vector2f val(atof(first.c_str()), atof(second.c_str()));
+			Vector2f val(atof(first.c_str()), atof(second.c_str()));
 
 			element.properties[node.name()] = val;
 			break;

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -90,7 +90,7 @@ public:
 		bool extra;
 		std::string type;
 
-		std::map< std::string, boost::variant<Eigen::Vector2f, std::string, unsigned int, float, bool> > properties;
+		std::map< std::string, boost::variant<Vector2f, std::string, unsigned int, float, bool> > properties;
 
 		template<typename T>
 		T get(const std::string& prop) const { return boost::get<T>(properties.at(prop)); }

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -9,7 +9,6 @@
 #include <boost/filesystem.hpp>
 #include <boost/variant.hpp>
 #include <boost/xpressive/xpressive.hpp>
-#include <Eigen/Dense>
 #include "pugixml/src/pugixml.hpp"
 #include "GuiComponent.h"
 

--- a/es-core/src/Util.cpp
+++ b/es-core/src/Util.cpp
@@ -34,32 +34,32 @@ float round(float num)
 }
 #endif
 
-Eigen::Affine3f& roundMatrix(Eigen::Affine3f& mat)
+Affine3f& roundMatrix(Affine3f& mat)
 {
 	mat.translation()[0] = round(mat.translation()[0]);
 	mat.translation()[1] = round(mat.translation()[1]);
 	return mat;
 }
 
-Eigen::Affine3f roundMatrix(const Eigen::Affine3f& mat)
+Affine3f roundMatrix(const Affine3f& mat)
 {
-	Eigen::Affine3f ret = mat;
+	Affine3f ret = mat;
 	roundMatrix(ret);
 	return ret;
 }
 
-Eigen::Vector3f roundVector(const Eigen::Vector3f& vec)
+Vector3f roundVector(const Vector3f& vec)
 {
-	Eigen::Vector3f ret = vec;
+	Vector3f ret = vec;
 	ret[0] = round(ret[0]);
 	ret[1] = round(ret[1]);
 	ret[2] = round(ret[2]);
 	return ret;
 }
 
-Eigen::Vector2f roundVector(const Eigen::Vector2f& vec)
+Vector2f roundVector(const Vector2f& vec)
 {
-	Eigen::Vector2f ret = vec;
+	Vector2f ret = vec;
 	ret[0] = round(ret[0]);
 	ret[1] = round(ret[1]);
 	return ret;

--- a/es-core/src/Util.cpp
+++ b/es-core/src/Util.cpp
@@ -34,16 +34,16 @@ float round(float num)
 }
 #endif
 
-Affine3f& roundMatrix(Affine3f& mat)
+Matrix4x4f& roundMatrix(Matrix4x4f& mat)
 {
 	mat.translation()[0] = round(mat.translation()[0]);
 	mat.translation()[1] = round(mat.translation()[1]);
 	return mat;
 }
 
-Affine3f roundMatrix(const Affine3f& mat)
+Matrix4x4f roundMatrix(const Matrix4x4f& mat)
 {
-	Affine3f ret = mat;
+	Matrix4x4f ret = mat;
 	roundMatrix(ret);
 	return ret;
 }

--- a/es-core/src/Util.h
+++ b/es-core/src/Util.h
@@ -9,11 +9,11 @@ std::string strToUpper(const char* from);
 std::string& strToUpper(std::string& str);
 std::string strToUpper(const std::string& str);
 
-Eigen::Affine3f& roundMatrix(Eigen::Affine3f& mat);
-Eigen::Affine3f roundMatrix(const Eigen::Affine3f& mat);
+Affine3f& roundMatrix(Affine3f& mat);
+Affine3f roundMatrix(const Affine3f& mat);
 
-Eigen::Vector3f roundVector(const Eigen::Vector3f& vec);
-Eigen::Vector2f roundVector(const Eigen::Vector2f& vec);
+Vector3f roundVector(const Vector3f& vec);
+Vector2f roundVector(const Vector2f& vec);
 
 #if defined(_WIN32) && _MSC_VER < 1800
 float round(float num);

--- a/es-core/src/Util.h
+++ b/es-core/src/Util.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-#include <Eigen/Dense>
+#include "math/Math.h"
 #include <boost/filesystem.hpp>
 #include <boost/date_time.hpp>
 

--- a/es-core/src/Util.h
+++ b/es-core/src/Util.h
@@ -9,8 +9,8 @@ std::string strToUpper(const char* from);
 std::string& strToUpper(std::string& str);
 std::string strToUpper(const std::string& str);
 
-Affine3f& roundMatrix(Affine3f& mat);
-Affine3f roundMatrix(const Affine3f& mat);
+Matrix4x4f& roundMatrix(Matrix4x4f& mat);
+Matrix4x4f roundMatrix(const Matrix4x4f& mat);
 
 Vector3f roundVector(const Vector3f& vec);
 Vector2f roundVector(const Vector2f& vec);

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -228,7 +228,7 @@ void Window::update(int deltaTime)
 
 void Window::render()
 {
-	Affine3f transform = Affine3f::Identity();
+	Matrix4x4f transform = Matrix4x4f::Identity();
 
 	mRenderedHelpPrompts = false;
 
@@ -251,7 +251,7 @@ void Window::render()
 
 	if(Settings::getInstance()->getBool("DrawFramerate") && mFrameDataText)
 	{
-		Renderer::setMatrix(Affine3f::Identity());
+		Renderer::setMatrix(Matrix4x4f::Identity());
 		mDefaultFonts.at(1)->renderTextCache(mFrameDataText.get());
 	}
 
@@ -296,7 +296,7 @@ void Window::setAllowSleep(bool sleep)
 
 void Window::renderLoadingScreen()
 {
-	Affine3f trans = Affine3f::Identity();
+	Matrix4x4f trans = Matrix4x4f::Identity();
 	Renderer::setMatrix(trans);
 	Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), 0x000000FF);
 
@@ -319,7 +319,7 @@ void Window::renderLoadingScreen()
 
 void Window::renderHelpPromptsEarly()
 {
-	mHelp->render(Affine3f::Identity());
+	mHelp->render(Matrix4x4f::Identity());
 	mRenderedHelpPrompts = true;
 }
 

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -228,7 +228,7 @@ void Window::update(int deltaTime)
 
 void Window::render()
 {
-	Eigen::Affine3f transform = Eigen::Affine3f::Identity();
+	Affine3f transform = Affine3f::Identity();
 
 	mRenderedHelpPrompts = false;
 
@@ -251,7 +251,7 @@ void Window::render()
 
 	if(Settings::getInstance()->getBool("DrawFramerate") && mFrameDataText)
 	{
-		Renderer::setMatrix(Eigen::Affine3f::Identity());
+		Renderer::setMatrix(Affine3f::Identity());
 		mDefaultFonts.at(1)->renderTextCache(mFrameDataText.get());
 	}
 
@@ -296,7 +296,7 @@ void Window::setAllowSleep(bool sleep)
 
 void Window::renderLoadingScreen()
 {
-	Eigen::Affine3f trans = Eigen::Affine3f::Identity();
+	Affine3f trans = Affine3f::Identity();
 	Renderer::setMatrix(trans);
 	Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), 0x000000FF);
 
@@ -308,7 +308,7 @@ void Window::renderLoadingScreen()
 
 	auto& font = mDefaultFonts.at(1);
 	TextCache* cache = font->buildTextCache("LOADING...", 0, 0, 0x656565FF);
-	trans = trans.translate(Eigen::Vector3f(round((Renderer::getScreenWidth() - cache->metrics.size.x()) / 2.0f),
+	trans = trans.translate(Vector3f(round((Renderer::getScreenWidth() - cache->metrics.size.x()) / 2.0f),
 		round(Renderer::getScreenHeight() * 0.835f), 0.0f));
 	Renderer::setMatrix(trans);
 	font->renderTextCache(cache);
@@ -319,7 +319,7 @@ void Window::renderLoadingScreen()
 
 void Window::renderHelpPromptsEarly()
 {
-	mHelp->render(Eigen::Affine3f::Identity());
+	mHelp->render(Affine3f::Identity());
 	mRenderedHelpPrompts = true;
 }
 

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -28,7 +28,7 @@ public:
 
 	class InfoPopup {
 	public:
-		virtual void render(const Eigen::Affine3f& parentTrans) = 0;
+		virtual void render(const Affine3f& parentTrans) = 0;
 		virtual void stop() = 0;
 		virtual ~InfoPopup() {};
 	};

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -28,7 +28,7 @@ public:
 
 	class InfoPopup {
 	public:
-		virtual void render(const Affine3f& parentTrans) = 0;
+		virtual void render(const Matrix4x4f& parentTrans) = 0;
 		virtual void stop() = 0;
 		virtual ~InfoPopup() {};
 	};

--- a/es-core/src/animations/Animation.h
+++ b/es-core/src/animations/Animation.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <Eigen/Dense>
-
 class Animation
 {
 public:

--- a/es-core/src/components/AnimatedImageComponent.cpp
+++ b/es-core/src/components/AnimatedImageComponent.cpp
@@ -76,7 +76,7 @@ void AnimatedImageComponent::update(int deltaTime)
 	}
 }
 
-void AnimatedImageComponent::render(const Eigen::Affine3f& trans)
+void AnimatedImageComponent::render(const Affine3f& trans)
 {
 	if(mFrames.size())
 		mFrames.at(mCurrentFrame).first->render(getTransform() * trans);

--- a/es-core/src/components/AnimatedImageComponent.cpp
+++ b/es-core/src/components/AnimatedImageComponent.cpp
@@ -76,7 +76,7 @@ void AnimatedImageComponent::update(int deltaTime)
 	}
 }
 
-void AnimatedImageComponent::render(const Affine3f& trans)
+void AnimatedImageComponent::render(const Matrix4x4f& trans)
 {
 	if(mFrames.size())
 		mFrames.at(mCurrentFrame).first->render(getTransform() * trans);

--- a/es-core/src/components/AnimatedImageComponent.h
+++ b/es-core/src/components/AnimatedImageComponent.h
@@ -24,7 +24,7 @@ public:
 	void reset(); // set to frame 0
 
 	void update(int deltaTime) override;
-	void render(const Affine3f& trans) override;
+	void render(const Matrix4x4f& trans) override;
 
 	void onSizeChanged() override;
 

--- a/es-core/src/components/AnimatedImageComponent.h
+++ b/es-core/src/components/AnimatedImageComponent.h
@@ -24,7 +24,7 @@ public:
 	void reset(); // set to frame 0
 
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& trans) override;
+	void render(const Affine3f& trans) override;
 
 	void onSizeChanged() override;
 

--- a/es-core/src/components/BusyComponent.cpp
+++ b/es-core/src/components/BusyComponent.cpp
@@ -14,15 +14,15 @@ AnimationFrame BUSY_ANIMATION_FRAMES[] = {
 const AnimationDef BUSY_ANIMATION_DEF = { BUSY_ANIMATION_FRAMES, 4, true };
 
 BusyComponent::BusyComponent(Window* window) : GuiComponent(window),
-	mBackground(window, ":/frame.png"), mGrid(window, Eigen::Vector2i(5, 3))
+	mBackground(window, ":/frame.png"), mGrid(window, Vector2i(5, 3))
 {
 	mAnimation = std::make_shared<AnimatedImageComponent>(mWindow);
 	mAnimation->load(&BUSY_ANIMATION_DEF);
 	mText = std::make_shared<TextComponent>(mWindow, "WORKING...", Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
 
 	// col 0 = animation, col 1 = spacer, col 2 = text
-	mGrid.setEntry(mAnimation, Eigen::Vector2i(1, 1), false, true);
-	mGrid.setEntry(mText, Eigen::Vector2i(3, 1), false, true);
+	mGrid.setEntry(mAnimation, Vector2i(1, 1), false, true);
+	mGrid.setEntry(mText, Vector2i(3, 1), false, true);
 
 	addChild(&mBackground);
 	addChild(&mGrid);
@@ -46,8 +46,8 @@ void BusyComponent::onSizeChanged()
 
 	mGrid.setRowHeightPerc(1, textHeight / mSize.y());
 	
-	mBackground.fitTo(Eigen::Vector2f(mGrid.getColWidth(1) + mGrid.getColWidth(2) + mGrid.getColWidth(3), textHeight + 2),
-		mAnimation->getPosition(), Eigen::Vector2f(0, 0));
+	mBackground.fitTo(Vector2f(mGrid.getColWidth(1) + mGrid.getColWidth(2) + mGrid.getColWidth(3), textHeight + 2),
+		mAnimation->getPosition(), Vector2f(0, 0));
 }
 
 void BusyComponent::reset()

--- a/es-core/src/components/BusyComponent.cpp
+++ b/es-core/src/components/BusyComponent.cpp
@@ -13,18 +13,16 @@ AnimationFrame BUSY_ANIMATION_FRAMES[] = {
 };
 const AnimationDef BUSY_ANIMATION_DEF = { BUSY_ANIMATION_FRAMES, 4, true };
 
-using namespace Eigen;
-
 BusyComponent::BusyComponent(Window* window) : GuiComponent(window),
-	mBackground(window, ":/frame.png"), mGrid(window, Vector2i(5, 3))
+	mBackground(window, ":/frame.png"), mGrid(window, Eigen::Vector2i(5, 3))
 {
 	mAnimation = std::make_shared<AnimatedImageComponent>(mWindow);
 	mAnimation->load(&BUSY_ANIMATION_DEF);
 	mText = std::make_shared<TextComponent>(mWindow, "WORKING...", Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
 
 	// col 0 = animation, col 1 = spacer, col 2 = text
-	mGrid.setEntry(mAnimation, Vector2i(1, 1), false, true);
-	mGrid.setEntry(mText, Vector2i(3, 1), false, true);
+	mGrid.setEntry(mAnimation, Eigen::Vector2i(1, 1), false, true);
+	mGrid.setEntry(mText, Eigen::Vector2i(3, 1), false, true);
 
 	addChild(&mBackground);
 	addChild(&mGrid);
@@ -48,8 +46,8 @@ void BusyComponent::onSizeChanged()
 
 	mGrid.setRowHeightPerc(1, textHeight / mSize.y());
 	
-	mBackground.fitTo(Vector2f(mGrid.getColWidth(1) + mGrid.getColWidth(2) + mGrid.getColWidth(3), textHeight + 2),
-		mAnimation->getPosition(), Vector2f(0, 0));
+	mBackground.fitTo(Eigen::Vector2f(mGrid.getColWidth(1) + mGrid.getColWidth(2) + mGrid.getColWidth(3), textHeight + 2),
+		mAnimation->getPosition(), Eigen::Vector2f(0, 0));
 }
 
 void BusyComponent::reset()

--- a/es-core/src/components/ButtonComponent.cpp
+++ b/es-core/src/components/ButtonComponent.cpp
@@ -84,9 +84,9 @@ void ButtonComponent::updateImage()
 	mBox.setImagePath(mFocused ? ":/button_filled.png" : ":/button.png");
 }
 
-void ButtonComponent::render(const Affine3f& parentTrans)
+void ButtonComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = roundMatrix(parentTrans * getTransform());
+	Matrix4x4f trans = roundMatrix(parentTrans * getTransform());
 	
 	mBox.render(trans);
 

--- a/es-core/src/components/ButtonComponent.cpp
+++ b/es-core/src/components/ButtonComponent.cpp
@@ -18,7 +18,7 @@ ButtonComponent::ButtonComponent(Window* window, const std::string& text, const 
 
 void ButtonComponent::onSizeChanged()
 {
-	mBox.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
+	mBox.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 }
 
 void ButtonComponent::setPressedFunc(std::function<void()> f)
@@ -84,15 +84,15 @@ void ButtonComponent::updateImage()
 	mBox.setImagePath(mFocused ? ":/button_filled.png" : ":/button.png");
 }
 
-void ButtonComponent::render(const Eigen::Affine3f& parentTrans)
+void ButtonComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = roundMatrix(parentTrans * getTransform());
+	Affine3f trans = roundMatrix(parentTrans * getTransform());
 	
 	mBox.render(trans);
 
 	if(mTextCache)
 	{
-		Eigen::Vector3f centerOffset((mSize.x() - mTextCache->metrics.size.x()) / 2, (mSize.y() - mTextCache->metrics.size.y()) / 2, 0);
+		Vector3f centerOffset((mSize.x() - mTextCache->metrics.size.x()) / 2, (mSize.y() - mTextCache->metrics.size.y()) / 2, 0);
 		centerOffset = roundVector(centerOffset);
 		trans = trans.translate(centerOffset);
 

--- a/es-core/src/components/ButtonComponent.h
+++ b/es-core/src/components/ButtonComponent.h
@@ -15,7 +15,7 @@ public:
 	void setEnabled(bool enable);
 
 	bool input(InputConfig* config, Input input) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 
 	void setText(const std::string& text, const std::string& helpText);
 

--- a/es-core/src/components/ButtonComponent.h
+++ b/es-core/src/components/ButtonComponent.h
@@ -15,7 +15,7 @@ public:
 	void setEnabled(bool enable);
 
 	bool input(InputConfig* config, Input input) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 
 	void setText(const std::string& text, const std::string& helpText);
 

--- a/es-core/src/components/ComponentGrid.cpp
+++ b/es-core/src/components/ComponentGrid.cpp
@@ -355,9 +355,9 @@ void ComponentGrid::update(int deltaTime)
 	}
 }
 
-void ComponentGrid::render(const Affine3f& parentTrans)
+void ComponentGrid::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 
 	renderChildren(trans);
 	

--- a/es-core/src/components/ComponentGrid.cpp
+++ b/es-core/src/components/ComponentGrid.cpp
@@ -5,7 +5,7 @@
 
 using namespace GridFlags;
 
-ComponentGrid::ComponentGrid(Window* window, const Eigen::Vector2i& gridDimensions) : GuiComponent(window), 
+ComponentGrid::ComponentGrid(Window* window, const Vector2i& gridDimensions) : GuiComponent(window), 
 	mGridSize(gridDimensions), mCursor(0, 0)
 {
 	assert(gridDimensions.x() > 0 && gridDimensions.y() > 0);
@@ -82,7 +82,7 @@ void ComponentGrid::setRowHeightPerc(int row, float height, bool update)
 		onSizeChanged();
 }
 
-void ComponentGrid::setEntry(const std::shared_ptr<GuiComponent>& comp, const Eigen::Vector2i& pos, bool canFocus, bool resize, const Eigen::Vector2i& size,
+void ComponentGrid::setEntry(const std::shared_ptr<GuiComponent>& comp, const Vector2i& pos, bool canFocus, bool resize, const Vector2i& size,
 	unsigned int border, GridFlags::UpdateType updateType)
 {
 	assert(pos.x() >= 0 && pos.x() < mGridSize.x() && pos.y() >= 0 && pos.y() < mGridSize.y());
@@ -123,7 +123,7 @@ bool ComponentGrid::removeEntry(const std::shared_ptr<GuiComponent>& comp)
 void ComponentGrid::updateCellComponent(const GridEntry& cell)
 {
 	// size
-	Eigen::Vector2f size(0, 0);
+	Vector2f size(0, 0);
 	for(int x = cell.pos.x(); x < cell.pos.x() + cell.dim.x(); x++)
 		size[0] += getColWidth(x);
 	for(int y = cell.pos.y(); y < cell.pos.y() + cell.dim.y(); y++)
@@ -134,7 +134,7 @@ void ComponentGrid::updateCellComponent(const GridEntry& cell)
 
 	// position
 	// find top left corner
-	Eigen::Vector3f pos(0, 0, 0);
+	Vector3f pos(0, 0, 0);
 	for(int x = 0; x < cell.pos.x(); x++)
 		pos[0] += getColWidth(x);
 	for(int y = 0; y < cell.pos.y(); y++)
@@ -153,8 +153,8 @@ void ComponentGrid::updateSeparators()
 
 	bool drawAll = Settings::getInstance()->getBool("DebugGrid");
 
-	Eigen::Vector2f pos;
-	Eigen::Vector2f size;
+	Vector2f pos;
+	Vector2f size;
 	for(auto it = mCells.begin(); it != mCells.end(); it++)
 	{
 		if(!it->border && !drawAll)
@@ -235,19 +235,19 @@ bool ComponentGrid::input(InputConfig* config, Input input)
 
 	if(config->isMappedTo("down", input))
 	{
-		return moveCursor(Eigen::Vector2i(0, 1));
+		return moveCursor(Vector2i(0, 1));
 	}
 	if(config->isMappedTo("up", input))
 	{
-		return moveCursor(Eigen::Vector2i(0, -1));
+		return moveCursor(Vector2i(0, -1));
 	}
 	if(config->isMappedTo("left", input))
 	{
-		return moveCursor(Eigen::Vector2i(-1, 0));
+		return moveCursor(Vector2i(-1, 0));
 	}
 	if(config->isMappedTo("right", input))
 	{
-		return moveCursor(Eigen::Vector2i(1, 0));
+		return moveCursor(Vector2i(1, 0));
 	}
 
 	return false;
@@ -262,7 +262,7 @@ void ComponentGrid::resetCursor()
 	{
 		if(it->canFocus)
 		{
-			Eigen::Vector2i origCursor = mCursor;
+			Vector2i origCursor = mCursor;
 			mCursor = it->pos;
 			onCursorMoved(origCursor, mCursor);
 			break;
@@ -270,21 +270,21 @@ void ComponentGrid::resetCursor()
 	}
 }
 
-bool ComponentGrid::moveCursor(Eigen::Vector2i dir)
+bool ComponentGrid::moveCursor(Vector2i dir)
 {
 	assert(dir.x() || dir.y());
 
-	const Eigen::Vector2i origCursor = mCursor;
+	const Vector2i origCursor = mCursor;
 
 	GridEntry* currentCursorEntry = getCellAt(mCursor);
 
-	Eigen::Vector2i searchAxis(dir.x() == 0, dir.y() == 0);
+	Vector2i searchAxis(dir.x() == 0, dir.y() == 0);
 	
 	while(mCursor.x() >= 0 && mCursor.y() >= 0 && mCursor.x() < mGridSize.x() && mCursor.y() < mGridSize.y())
 	{
 		mCursor = mCursor + dir;
 
-		Eigen::Vector2i curDirPos = mCursor;
+		Vector2i curDirPos = mCursor;
 
 		GridEntry* cursorEntry;
 		//spread out on search axis+
@@ -355,9 +355,9 @@ void ComponentGrid::update(int deltaTime)
 	}
 }
 
-void ComponentGrid::render(const Eigen::Affine3f& parentTrans)
+void ComponentGrid::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 
 	renderChildren(trans);
 	
@@ -389,7 +389,7 @@ void ComponentGrid::textInput(const char* text)
 		selectedEntry->component->textInput(text);
 }
 
-void ComponentGrid::onCursorMoved(Eigen::Vector2i from, Eigen::Vector2i to)
+void ComponentGrid::onCursorMoved(Vector2i from, Vector2i to)
 {
 	GridEntry* cell = getCellAt(from);
 	if(cell)
@@ -408,7 +408,7 @@ void ComponentGrid::setCursorTo(const std::shared_ptr<GuiComponent>& comp)
 	{
 		if(it->component == comp)
 		{
-			Eigen::Vector2i oldCursor = mCursor;
+			Vector2i oldCursor = mCursor;
 			mCursor = it->pos;
 			onCursorMoved(oldCursor, mCursor);
 			return;

--- a/es-core/src/components/ComponentGrid.h
+++ b/es-core/src/components/ComponentGrid.h
@@ -26,18 +26,18 @@ namespace GridFlags
 class ComponentGrid : public GuiComponent
 {
 public:
-	ComponentGrid(Window* window, const Eigen::Vector2i& gridDimensions);
+	ComponentGrid(Window* window, const Vector2i& gridDimensions);
 	virtual ~ComponentGrid();
 
 	bool removeEntry(const std::shared_ptr<GuiComponent>& comp);
 
-	void setEntry(const std::shared_ptr<GuiComponent>& comp, const Eigen::Vector2i& pos, bool canFocus, bool resize = true, 
-		const Eigen::Vector2i& size = Eigen::Vector2i(1, 1), unsigned int border = GridFlags::BORDER_NONE, GridFlags::UpdateType updateType = GridFlags::UPDATE_ALWAYS);
+	void setEntry(const std::shared_ptr<GuiComponent>& comp, const Vector2i& pos, bool canFocus, bool resize = true, 
+		const Vector2i& size = Vector2i(1, 1), unsigned int border = GridFlags::BORDER_NONE, GridFlags::UpdateType updateType = GridFlags::UPDATE_ALWAYS);
 
 	void textInput(const char* text) override;
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 	void onSizeChanged() override;
 
 	void resetCursor();
@@ -49,7 +49,7 @@ public:
 	void setColWidthPerc(int col, float width, bool update = true); // if update is false, will not call an onSizeChanged() which triggers a (potentially costly) repositioning + resizing of every element
 	void setRowHeightPerc(int row, float height, bool update = true); // if update is false, will not call an onSizeChanged() which triggers a (potentially costly) repositioning + resizing of every element
 
-	bool moveCursor(Eigen::Vector2i dir);
+	bool moveCursor(Vector2i dir);
 	void setCursorTo(const std::shared_ptr<GuiComponent>& comp);
 
 	inline std::shared_ptr<GuiComponent> getSelectedComponent()
@@ -70,15 +70,15 @@ private:
 	class GridEntry
 	{
 	public:
-		Eigen::Vector2i pos;
-		Eigen::Vector2i dim;
+		Vector2i pos;
+		Vector2i dim;
 		std::shared_ptr<GuiComponent> component;
 		bool canFocus;
 		bool resize;
 		GridFlags::UpdateType updateType;
 		unsigned int border;
 
-		GridEntry(const Eigen::Vector2i& p = Eigen::Vector2i::Zero(), const Eigen::Vector2i& d = Eigen::Vector2i::Zero(),
+		GridEntry(const Vector2i& p = Vector2i::Zero(), const Vector2i& d = Vector2i::Zero(),
 			const std::shared_ptr<GuiComponent>& cmp = nullptr, bool f = false, bool r = true, 
 			GridFlags::UpdateType u = GridFlags::UPDATE_ALWAYS, unsigned int b = GridFlags::BORDER_NONE) : 
 			pos(p), dim(d), component(cmp), canFocus(f), resize(r), updateType(u), border(b)
@@ -108,12 +108,12 @@ private:
 	void updateSeparators();
 
 	GridEntry* getCellAt(int x, int y);
-	inline GridEntry* getCellAt(const Eigen::Vector2i& pos) { return getCellAt(pos.x(), pos.y()); }
+	inline GridEntry* getCellAt(const Vector2i& pos) { return getCellAt(pos.x(), pos.y()); }
 	
-	Eigen::Vector2i mGridSize;
+	Vector2i mGridSize;
 
 	std::vector<GridEntry> mCells;
 
-	void onCursorMoved(Eigen::Vector2i from, Eigen::Vector2i to);
-	Eigen::Vector2i mCursor;
+	void onCursorMoved(Vector2i from, Vector2i to);
+	Vector2i mCursor;
 };

--- a/es-core/src/components/ComponentGrid.h
+++ b/es-core/src/components/ComponentGrid.h
@@ -37,7 +37,7 @@ public:
 	void textInput(const char* text) override;
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 	void onSizeChanged() override;
 
 	void resetCursor();

--- a/es-core/src/components/ComponentList.cpp
+++ b/es-core/src/components/ComponentList.cpp
@@ -157,21 +157,21 @@ void ComponentList::updateCameraOffset()
 	}
 }
 
-void ComponentList::render(const Eigen::Affine3f& parentTrans)
+void ComponentList::render(const Affine3f& parentTrans)
 {
 	if(!size())
 		return;
 
-	Eigen::Affine3f trans = roundMatrix(parentTrans * getTransform());
+	Affine3f trans = roundMatrix(parentTrans * getTransform());
 
 	// clip everything to be inside our bounds
-	Eigen::Vector3f dim(mSize.x(), mSize.y(), 0);
+	Vector3f dim(mSize.x(), mSize.y(), 0);
 	dim = trans * dim - trans.translation();
-	Renderer::pushClipRect(Eigen::Vector2i((int)trans.translation().x(), (int)trans.translation().y()),
-		Eigen::Vector2i((int)round(dim.x()), (int)round(dim.y() + 1)));
+	Renderer::pushClipRect(Vector2i((int)trans.translation().x(), (int)trans.translation().y()),
+		Vector2i((int)round(dim.x()), (int)round(dim.y() + 1)));
 
 	// scroll the camera
-	trans.translate(Eigen::Vector3f(0, -round(mCameraOffset), 0));
+	trans.translate(Vector3f(0, -round(mCameraOffset), 0));
 
 	// draw our entries
 	std::vector<GuiComponent*> drawAfterCursor;

--- a/es-core/src/components/ComponentList.cpp
+++ b/es-core/src/components/ComponentList.cpp
@@ -157,12 +157,12 @@ void ComponentList::updateCameraOffset()
 	}
 }
 
-void ComponentList::render(const Affine3f& parentTrans)
+void ComponentList::render(const Matrix4x4f& parentTrans)
 {
 	if(!size())
 		return;
 
-	Affine3f trans = roundMatrix(parentTrans * getTransform());
+	Matrix4x4f trans = roundMatrix(parentTrans * getTransform());
 
 	// clip everything to be inside our bounds
 	Vector3f dim(mSize.x(), mSize.y(), 0);

--- a/es-core/src/components/ComponentList.h
+++ b/es-core/src/components/ComponentList.h
@@ -52,7 +52,7 @@ public:
 	void textInput(const char* text) override;
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 
 	void onSizeChanged() override;

--- a/es-core/src/components/ComponentList.h
+++ b/es-core/src/components/ComponentList.h
@@ -52,7 +52,7 @@ public:
 	void textInput(const char* text) override;
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 
 	void onSizeChanged() override;

--- a/es-core/src/components/DateTimeComponent.cpp
+++ b/es-core/src/components/DateTimeComponent.cpp
@@ -134,9 +134,9 @@ void DateTimeComponent::update(int deltaTime)
 	GuiComponent::update(deltaTime);
 }
 
-void DateTimeComponent::render(const Affine3f& parentTrans)
+void DateTimeComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 
 	if(mTextCache)
 	{

--- a/es-core/src/components/DateTimeComponent.cpp
+++ b/es-core/src/components/DateTimeComponent.cpp
@@ -134,14 +134,14 @@ void DateTimeComponent::update(int deltaTime)
 	GuiComponent::update(deltaTime);
 }
 
-void DateTimeComponent::render(const Eigen::Affine3f& parentTrans)
+void DateTimeComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 
 	if(mTextCache)
 	{
 		// vertically center
-		Eigen::Vector3f off(0, (mSize.y() - mTextCache->metrics.size.y()) / 2, 0);
+		Vector3f off(0, (mSize.y() - mTextCache->metrics.size.y()) / 2, 0);
 		trans.translate(off);
 		trans = roundMatrix(trans);
 
@@ -269,22 +269,22 @@ void DateTimeComponent::updateTextCache()
 		return;
 
 	//month
-	Eigen::Vector2f start(0, 0);
-	Eigen::Vector2f end = font->sizeText(dispString.substr(0, 2));
-	Eigen::Vector2f diff = end - start;
-	mCursorBoxes.push_back(Eigen::Vector4f(start[0], start[1], diff[0], diff[1]));
+	Vector2f start(0, 0);
+	Vector2f end = font->sizeText(dispString.substr(0, 2));
+	Vector2f diff = end - start;
+	mCursorBoxes.push_back(Vector4f(start[0], start[1], diff[0], diff[1]));
 
 	//day
 	start[0] = font->sizeText(dispString.substr(0, 3)).x();
 	end = font->sizeText(dispString.substr(0, 5));
 	diff = end - start;
-	mCursorBoxes.push_back(Eigen::Vector4f(start[0], start[1], diff[0], diff[1]));
+	mCursorBoxes.push_back(Vector4f(start[0], start[1], diff[0], diff[1]));
 
 	//year
 	start[0] = font->sizeText(dispString.substr(0, 6)).x();
 	end = font->sizeText(dispString.substr(0, 10));
 	diff = end - start;
-	mCursorBoxes.push_back(Eigen::Vector4f(start[0], start[1], diff[0], diff[1]));
+	mCursorBoxes.push_back(Vector4f(start[0], start[1], diff[0], diff[1]));
 
 	//if mode == DISP_DATE_TIME do times too but I don't wanna do the logic for editing times because no one will ever use it so screw it
 }

--- a/es-core/src/components/DateTimeComponent.h
+++ b/es-core/src/components/DateTimeComponent.h
@@ -22,7 +22,7 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 	void onSizeChanged() override;
 
 	// Set how the point in time will be displayed:
@@ -56,7 +56,7 @@ private:
 	int mRelativeUpdateAccumulator;
 
 	std::unique_ptr<TextCache> mTextCache;
-	std::vector<Eigen::Vector4f> mCursorBoxes;
+	std::vector<Vector4f> mCursorBoxes;
 
 	unsigned int mColor;
 	std::shared_ptr<Font> mFont;

--- a/es-core/src/components/DateTimeComponent.h
+++ b/es-core/src/components/DateTimeComponent.h
@@ -22,7 +22,7 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 	void onSizeChanged() override;
 
 	// Set how the point in time will be displayed:

--- a/es-core/src/components/HelpComponent.cpp
+++ b/es-core/src/components/HelpComponent.cpp
@@ -14,8 +14,6 @@
 #define ICON_TEXT_SPACING 8 // space between [icon] and [text] (px)
 #define ENTRY_SPACING 16 // space between [text] and next [icon] (px)
 
-using namespace Eigen;
-
 static const std::map<std::string, const char*> ICON_PATH_MAP = boost::assign::map_list_of
 	("up/down", ":/help/dpad_updown.svg")
 	("left/right", ":/help/dpad_leftright.svg")
@@ -61,7 +59,7 @@ void HelpComponent::updateGrid()
 
 	std::shared_ptr<Font>& font = mStyle.font;
 
-	mGrid = std::make_shared<ComponentGrid>(mWindow, Vector2i(mPrompts.size() * 4, 1));
+	mGrid = std::make_shared<ComponentGrid>(mWindow, Eigen::Vector2i(mPrompts.size() * 4, 1));
 	// [icon] [spacer1] [text] [spacer2]
 	
 	std::vector< std::shared_ptr<ImageComponent> > icons;
@@ -91,8 +89,8 @@ void HelpComponent::updateGrid()
 		mGrid->setColWidthPerc(col + 1, ICON_TEXT_SPACING / width);
 		mGrid->setColWidthPerc(col + 2, labels.at(i)->getSize().x() / width);
 
-		mGrid->setEntry(icons.at(i), Vector2i(col, 0), false, false);
-		mGrid->setEntry(labels.at(i), Vector2i(col + 2, 0), false, false);
+		mGrid->setEntry(icons.at(i), Eigen::Vector2i(col, 0), false, false);
+		mGrid->setEntry(labels.at(i), Eigen::Vector2i(col + 2, 0), false, false);
 	}
 
 	mGrid->setPosition(Eigen::Vector3f(mStyle.position.x(), mStyle.position.y(), 0.0f));

--- a/es-core/src/components/HelpComponent.cpp
+++ b/es-core/src/components/HelpComponent.cpp
@@ -59,7 +59,7 @@ void HelpComponent::updateGrid()
 
 	std::shared_ptr<Font>& font = mStyle.font;
 
-	mGrid = std::make_shared<ComponentGrid>(mWindow, Eigen::Vector2i(mPrompts.size() * 4, 1));
+	mGrid = std::make_shared<ComponentGrid>(mWindow, Vector2i(mPrompts.size() * 4, 1));
 	// [icon] [spacer1] [text] [spacer2]
 	
 	std::vector< std::shared_ptr<ImageComponent> > icons;
@@ -89,11 +89,11 @@ void HelpComponent::updateGrid()
 		mGrid->setColWidthPerc(col + 1, ICON_TEXT_SPACING / width);
 		mGrid->setColWidthPerc(col + 2, labels.at(i)->getSize().x() / width);
 
-		mGrid->setEntry(icons.at(i), Eigen::Vector2i(col, 0), false, false);
-		mGrid->setEntry(labels.at(i), Eigen::Vector2i(col + 2, 0), false, false);
+		mGrid->setEntry(icons.at(i), Vector2i(col, 0), false, false);
+		mGrid->setEntry(labels.at(i), Vector2i(col + 2, 0), false, false);
 	}
 
-	mGrid->setPosition(Eigen::Vector3f(mStyle.position.x(), mStyle.position.y(), 0.0f));
+	mGrid->setPosition(Vector3f(mStyle.position.x(), mStyle.position.y(), 0.0f));
 	//mGrid->setPosition(OFFSET_X, Renderer::getScreenHeight() - mGrid->getSize().y() - OFFSET_Y);
 }
 
@@ -130,9 +130,9 @@ void HelpComponent::setOpacity(unsigned char opacity)
 	}
 }
 
-void HelpComponent::render(const Eigen::Affine3f& parentTrans)
+void HelpComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 	
 	if(mGrid)
 		mGrid->render(trans);

--- a/es-core/src/components/HelpComponent.cpp
+++ b/es-core/src/components/HelpComponent.cpp
@@ -130,9 +130,9 @@ void HelpComponent::setOpacity(unsigned char opacity)
 	}
 }
 
-void HelpComponent::render(const Affine3f& parentTrans)
+void HelpComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 	
 	if(mGrid)
 		mGrid->render(trans);

--- a/es-core/src/components/HelpComponent.h
+++ b/es-core/src/components/HelpComponent.h
@@ -15,7 +15,7 @@ public:
 	void clearPrompts();
 	void setPrompts(const std::vector<HelpPrompt>& prompts);
 
-	void render(const Eigen::Affine3f& parent) override;
+	void render(const Affine3f& parent) override;
 	void setOpacity(unsigned char opacity) override;
 
 	void setStyle(const HelpStyle& style);

--- a/es-core/src/components/HelpComponent.h
+++ b/es-core/src/components/HelpComponent.h
@@ -15,7 +15,7 @@ public:
 	void clearPrompts();
 	void setPrompts(const std::vector<HelpPrompt>& prompts);
 
-	void render(const Affine3f& parent) override;
+	void render(const Matrix4x4f& parent) override;
 	void setOpacity(unsigned char opacity) override;
 
 	void setStyle(const HelpStyle& style);

--- a/es-core/src/components/IList.h
+++ b/es-core/src/components/IList.h
@@ -247,7 +247,7 @@ protected:
 			scroll(mScrollVelocity);
 	}
 
-	void listRenderTitleOverlay(const Eigen::Affine3f& trans)
+	void listRenderTitleOverlay(const Affine3f& trans)
 	{
 		if(size() == 0 || !mTitleOverlayFont || mTitleOverlayOpacity == 0)
 			return;
@@ -255,11 +255,11 @@ protected:
 		// we don't bother caching this because it's only two letters and will change pretty much every frame if we're scrolling
 		const std::string text = getSelectedName().size() >= 2 ? getSelectedName().substr(0, 2) : "??";
 
-		Eigen::Vector2f off = mTitleOverlayFont->sizeText(text);
+		Vector2f off = mTitleOverlayFont->sizeText(text);
 		off[0] = (Renderer::getScreenWidth() - off.x()) * 0.5f;
 		off[1] = (Renderer::getScreenHeight() - off.y()) * 0.5f;
 		
-		Eigen::Affine3f identTrans = Eigen::Affine3f::Identity();
+		Affine3f identTrans = Affine3f::Identity();
 
 		mGradient.setOpacity(mTitleOverlayOpacity);
 		mGradient.render(identTrans);

--- a/es-core/src/components/IList.h
+++ b/es-core/src/components/IList.h
@@ -247,7 +247,7 @@ protected:
 			scroll(mScrollVelocity);
 	}
 
-	void listRenderTitleOverlay(const Affine3f& trans)
+	void listRenderTitleOverlay(const Matrix4x4f& trans)
 	{
 		if(size() == 0 || !mTitleOverlayFont || mTitleOverlayOpacity == 0)
 			return;
@@ -259,7 +259,7 @@ protected:
 		off[0] = (Renderer::getScreenWidth() - off.x()) * 0.5f;
 		off[1] = (Renderer::getScreenHeight() - off.y()) * 0.5f;
 		
-		Affine3f identTrans = Affine3f::Identity();
+		Matrix4x4f identTrans = Matrix4x4f::Identity();
 
 		mGradient.setOpacity(mTitleOverlayOpacity);
 		mGradient.render(identTrans);

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -224,9 +224,9 @@ void ImageComponent::updateColors()
 	Renderer::buildGLColorArray(mColors, mColorShift, 6);
 }
 
-void ImageComponent::render(const Affine3f& parentTrans)
+void ImageComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 	Renderer::setMatrix(trans);
 
 	if(mTexture && mOpacity > 0)

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -7,12 +7,12 @@
 #include "ThemeData.h"
 #include "Util.h"
 
-Eigen::Vector2i ImageComponent::getTextureSize() const
+Vector2i ImageComponent::getTextureSize() const
 {
 	if(mTexture)
 		return mTexture->getSize();
 	else
-		return Eigen::Vector2i::Zero();
+		return Vector2i::Zero();
 }
 
 ImageComponent::ImageComponent(Window* window, bool forceLoad, bool dynamic) : GuiComponent(window),
@@ -31,7 +31,7 @@ void ImageComponent::resize()
 	if(!mTexture)
 		return;
 
-	const Eigen::Vector2f textureSize = mTexture->getSourceImageSize();
+	const Vector2f textureSize = mTexture->getSourceImageSize();
 	if(textureSize.isZero())
 		return;
 
@@ -49,7 +49,7 @@ void ImageComponent::resize()
 		{
 			mSize = textureSize;
 
-			Eigen::Vector2f resizeScale((mTargetSize.x() / mSize.x()), (mTargetSize.y() / mSize.y()));
+			Vector2f resizeScale((mTargetSize.x() / mSize.x()), (mTargetSize.y() / mSize.y()));
 			
 			if(resizeScale.x() < resizeScale.y())
 			{
@@ -178,8 +178,8 @@ void ImageComponent::updateVertices()
 
 	// we go through this mess to make sure everything is properly rounded
 	// if we just round vertices at the end, edge cases occur near sizes of 0.5
-	Eigen::Vector2f topLeft(0.0, 0.0);
-	Eigen::Vector2f bottomRight(round(mSize.x()), round(mSize.y()));
+	Vector2f topLeft(0.0, 0.0);
+	Vector2f bottomRight(round(mSize.x()), round(mSize.y()));
 
 	mVertices[0].pos << topLeft.x(), topLeft.y();
 	mVertices[1].pos << topLeft.x(), bottomRight.y();
@@ -224,9 +224,9 @@ void ImageComponent::updateColors()
 	Renderer::buildGLColorArray(mColors, mColorShift, 6);
 }
 
-void ImageComponent::render(const Eigen::Affine3f& parentTrans)
+void ImageComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 	Renderer::setMatrix(trans);
 
 	if(mTexture && mOpacity > 0)
@@ -324,25 +324,25 @@ void ImageComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 		return;
 	}
 
-	Eigen::Vector2f scale = getParent() ? getParent()->getSize() : Eigen::Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
+	Vector2f scale = getParent() ? getParent()->getSize() : Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
 	
 	if(properties & POSITION && elem->has("pos"))
 	{
-		Eigen::Vector2f denormalized = elem->get<Eigen::Vector2f>("pos").cwiseProduct(scale);
-		setPosition(Eigen::Vector3f(denormalized.x(), denormalized.y(), 0));
+		Vector2f denormalized = elem->get<Vector2f>("pos").cwiseProduct(scale);
+		setPosition(Vector3f(denormalized.x(), denormalized.y(), 0));
 	}
 
 	if(properties & ThemeFlags::SIZE)
 	{
 		if(elem->has("size"))
-			setResize(elem->get<Eigen::Vector2f>("size").cwiseProduct(scale));
+			setResize(elem->get<Vector2f>("size").cwiseProduct(scale));
 		else if(elem->has("maxSize"))
-			setMaxSize(elem->get<Eigen::Vector2f>("maxSize").cwiseProduct(scale));
+			setMaxSize(elem->get<Vector2f>("maxSize").cwiseProduct(scale));
 	}
 
 	// position + size also implies origin
 	if((properties & ORIGIN || (properties & POSITION && properties & ThemeFlags::SIZE)) && elem->has("origin"))
-		setOrigin(elem->get<Eigen::Vector2f>("origin"));
+		setOrigin(elem->get<Vector2f>("origin"));
 
 	if(elem->has("default")) {
 		setDefaultImage(elem->get<std::string>("default"));
@@ -361,7 +361,7 @@ void ImageComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 		if(elem->has("rotation"))
 			setRotationDegrees(elem->get<float>("rotation"));
 		if(elem->has("rotationOrigin"))
-			setRotationOrigin(elem->get<Eigen::Vector2f>("rotationOrigin"));
+			setRotationOrigin(elem->get<Vector2f>("rotationOrigin"));
 	}
 
 	if(properties & ThemeFlags::Z_INDEX && elem->has("zIndex"))

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -51,7 +51,7 @@ public:
 
 	bool hasImage();
 
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -32,13 +32,13 @@ public:
 	// Can be set before or after an image is loaded.
 	// setMaxSize() and setResize() are mutually exclusive.
 	void setResize(float width, float height);
-	inline void setResize(const Eigen::Vector2f& size) { setResize(size.x(), size.y()); }
+	inline void setResize(const Vector2f& size) { setResize(size.x(), size.y()); }
 
 	// Resize the image to be as large as possible but fit within a box of this size.
 	// Can be set before or after an image is loaded.
 	// Never breaks the aspect ratio. setMaxSize() and setResize() are mutually exclusive.
 	void setMaxSize(float width, float height);
-	inline void setMaxSize(const Eigen::Vector2f& size) { setMaxSize(size.x(), size.y()); }
+	inline void setMaxSize(const Vector2f& size) { setMaxSize(size.x(), size.y()); }
 
 	// Multiply all pixels in the image by this color when rendering.
 	void setColorShift(unsigned int color);
@@ -47,17 +47,17 @@ public:
 	void setFlipY(bool flip); // Mirror on the Y axis.
 
 	// Returns the size of the current texture, or (0, 0) if none is loaded.  May be different than drawn size (use getSize() for that).
-	Eigen::Vector2i getTextureSize() const;
+	Vector2i getTextureSize() const;
 
 	bool hasImage();
 
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 private:
-	Eigen::Vector2f mTargetSize;
+	Vector2f mTargetSize;
 
 	bool mFlipX, mFlipY, mTargetIsMax;
 
@@ -67,8 +67,8 @@ private:
 
 	struct Vertex
 	{
-		Eigen::Vector2f pos;
-		Eigen::Vector2f tex;
+		Vector2f pos;
+		Vector2f tex;
 	} mVertices[6];
 
 	GLubyte mColors[6*4];

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -37,7 +37,7 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 
 private:
 	Vector2f getSquareSize(std::shared_ptr<TextureResource> tex = nullptr) const
@@ -147,9 +147,9 @@ void ImageGridComponent<T>::update(int deltaTime)
 }
 
 template<typename T>
-void ImageGridComponent<T>::render(const Affine3f& parentTrans)
+void ImageGridComponent<T>::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = getTransform() * parentTrans;
+	Matrix4x4f trans = getTransform() * parentTrans;
 
 	if(mEntriesDirty)
 	{

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -37,16 +37,16 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 
 private:
-	Eigen::Vector2f getSquareSize(std::shared_ptr<TextureResource> tex = nullptr) const
+	Vector2f getSquareSize(std::shared_ptr<TextureResource> tex = nullptr) const
 	{
-		Eigen::Vector2f aspect(1, 1);
+		Vector2f aspect(1, 1);
 
 		if(tex)
 		{
-			const Eigen::Vector2i& texSize = tex->getSize();
+			const Vector2i& texSize = tex->getSize();
 
 			if(texSize.x() > texSize.y())
 				aspect[0] = (float)texSize.x() / texSize.y();
@@ -54,17 +54,17 @@ private:
 				aspect[1] = (float)texSize.y() / texSize.x();
 		}
 
-		return Eigen::Vector2f(156 * aspect.x(), 156 * aspect.y());
+		return Vector2f(156 * aspect.x(), 156 * aspect.y());
 	};
 
-	Eigen::Vector2f getMaxSquareSize() const
+	Vector2f getMaxSquareSize() const
 	{
-		Eigen::Vector2f squareSize(32, 32);
+		Vector2f squareSize(32, 32);
 
 		// calc biggest square size
 		for(auto it = mEntries.begin(); it != mEntries.end(); it++)
 		{
-			Eigen::Vector2f chkSize = getSquareSize(it->data.texture);
+			Vector2f chkSize = getSquareSize(it->data.texture);
 			if(chkSize.x() > squareSize.x())
 				squareSize[0] = chkSize[0];
 			if(chkSize.y() > squareSize.y())
@@ -74,14 +74,14 @@ private:
 		return squareSize;
 	};
 
-	Eigen::Vector2i getGridSize() const
+	Vector2i getGridSize() const
 	{
-		Eigen::Vector2f squareSize = getMaxSquareSize();
-		Eigen::Vector2i gridSize(mSize.x() / (squareSize.x() + getPadding().x()), mSize.y() / (squareSize.y() + getPadding().y()));
+		Vector2f squareSize = getMaxSquareSize();
+		Vector2i gridSize(mSize.x() / (squareSize.x() + getPadding().x()), mSize.y() / (squareSize.y() + getPadding().y()));
 		return gridSize;
 	};
 
-	Eigen::Vector2f getPadding() const { return Eigen::Vector2f(24, 24); }
+	Vector2f getPadding() const { return Vector2f(24, 24); }
 	
 	void buildImages();
 	void updateImages();
@@ -115,7 +115,7 @@ bool ImageGridComponent<T>::input(InputConfig* config, Input input)
 {
 	if(input.value != 0)
 	{
-		Eigen::Vector2i dir = Eigen::Vector2i::Zero();
+		Vector2i dir = Vector2i::Zero();
 		if(config->isMappedTo("up", input))
 			dir[1] = -1;
 		else if(config->isMappedTo("down", input))
@@ -125,7 +125,7 @@ bool ImageGridComponent<T>::input(InputConfig* config, Input input)
 		else if(config->isMappedTo("right", input))
 			dir[0] = 1;
 
-		if(dir != Eigen::Vector2i::Zero())
+		if(dir != Vector2i::Zero())
 		{
 			listInput(dir.x() + dir.y() * getGridSize().x());
 			return true;
@@ -147,9 +147,9 @@ void ImageGridComponent<T>::update(int deltaTime)
 }
 
 template<typename T>
-void ImageGridComponent<T>::render(const Eigen::Affine3f& parentTrans)
+void ImageGridComponent<T>::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = getTransform() * parentTrans;
+	Affine3f trans = getTransform() * parentTrans;
 
 	if(mEntriesDirty)
 	{
@@ -185,13 +185,13 @@ void ImageGridComponent<T>::buildImages()
 {
 	mImages.clear();
 
-	Eigen::Vector2i gridSize = getGridSize();
-	Eigen::Vector2f squareSize = getMaxSquareSize();
-	Eigen::Vector2f padding = getPadding();
+	Vector2i gridSize = getGridSize();
+	Vector2f squareSize = getMaxSquareSize();
+	Vector2f padding = getPadding();
 
 	// attempt to center within our size
-	Eigen::Vector2f totalSize(gridSize.x() * (squareSize.x() + padding.x()), gridSize.y() * (squareSize.y() + padding.y()));
-	Eigen::Vector2f offset(mSize.x() - totalSize.x(), mSize.y() - totalSize.y());
+	Vector2f totalSize(gridSize.x() * (squareSize.x() + padding.x()), gridSize.y() * (squareSize.y() + padding.y()));
+	Vector2f offset(mSize.x() - totalSize.x(), mSize.y() - totalSize.y());
 	offset /= 2;
 
 	for(int y = 0; y < gridSize.y(); y++)
@@ -215,7 +215,7 @@ void ImageGridComponent<T>::updateImages()
 	if(mImages.empty())
 		buildImages();
 
-	Eigen::Vector2i gridSize = getGridSize();
+	Vector2i gridSize = getGridSize();
 
 	int cursorRow = mCursor / gridSize.x();
 	int cursorCol = mCursor % gridSize.x();
@@ -239,7 +239,7 @@ void ImageGridComponent<T>::updateImages()
 			continue;
 		}
 
-		Eigen::Vector2f squareSize = getSquareSize(mEntries.at(i).data.texture);
+		Vector2f squareSize = getSquareSize(mEntries.at(i).data.texture);
 		if(i == mCursor)
 		{
 			image.setColorShift(0xFFFFFFFF);

--- a/es-core/src/components/MenuComponent.cpp
+++ b/es-core/src/components/MenuComponent.cpp
@@ -6,10 +6,8 @@
 
 #define TITLE_HEIGHT (mTitle->getFont()->getLetterHeight() + TITLE_VERT_PADDING)
 
-using namespace Eigen;
-
 MenuComponent::MenuComponent(Window* window, const char* title, const std::shared_ptr<Font>& titleFont) : GuiComponent(window),
-	mBackground(window), mGrid(window, Vector2i(1, 3))
+	mBackground(window), mGrid(window, Eigen::Vector2i(1, 3))
 {
 	addChild(&mBackground);
 	addChild(&mGrid);
@@ -21,11 +19,11 @@ MenuComponent::MenuComponent(Window* window, const char* title, const std::share
 	mTitle->setHorizontalAlignment(ALIGN_CENTER);
 	mTitle->setColor(0x555555FF);
 	setTitle(title, titleFont);
-	mGrid.setEntry(mTitle, Vector2i(0, 0), false);
+	mGrid.setEntry(mTitle, Eigen::Vector2i(0, 0), false);
 
 	// set up list which will never change (externally, anyway)
 	mList = std::make_shared<ComponentList>(mWindow);
-	mGrid.setEntry(mList, Vector2i(0, 1), true);
+	mGrid.setEntry(mList, Eigen::Vector2i(0, 1), true);
 
 	updateGrid();
 	updateSize();
@@ -95,7 +93,7 @@ void MenuComponent::updateGrid()
 	if(mButtons.size())
 	{
 		mButtonGrid = makeButtonGrid(mWindow, mButtons);
-		mGrid.setEntry(mButtonGrid, Vector2i(0, 2), true, false);
+		mGrid.setEntry(mButtonGrid, Eigen::Vector2i(0, 2), true, false);
 	}
 }
 
@@ -106,12 +104,12 @@ std::vector<HelpPrompt> MenuComponent::getHelpPrompts()
 
 std::shared_ptr<ComponentGrid> makeButtonGrid(Window* window, const std::vector< std::shared_ptr<ButtonComponent> >& buttons)
 {
-	std::shared_ptr<ComponentGrid> buttonGrid = std::make_shared<ComponentGrid>(window, Vector2i(buttons.size(), 2));
+	std::shared_ptr<ComponentGrid> buttonGrid = std::make_shared<ComponentGrid>(window, Eigen::Vector2i(buttons.size(), 2));
 
 	float buttonGridWidth = (float)BUTTON_GRID_HORIZ_PADDING * buttons.size(); // initialize to padding
 	for(int i = 0; i < (int)buttons.size(); i++)
 	{
-		buttonGrid->setEntry(buttons.at(i), Vector2i(i, 0), true, false);
+		buttonGrid->setEntry(buttons.at(i), Eigen::Vector2i(i, 0), true, false);
 		buttonGridWidth += buttons.at(i)->getSize().x();
 	}
 	for(unsigned int i = 0; i < buttons.size(); i++)

--- a/es-core/src/components/MenuComponent.cpp
+++ b/es-core/src/components/MenuComponent.cpp
@@ -7,7 +7,7 @@
 #define TITLE_HEIGHT (mTitle->getFont()->getLetterHeight() + TITLE_VERT_PADDING)
 
 MenuComponent::MenuComponent(Window* window, const char* title, const std::shared_ptr<Font>& titleFont) : GuiComponent(window),
-	mBackground(window), mGrid(window, Eigen::Vector2i(1, 3))
+	mBackground(window), mGrid(window, Vector2i(1, 3))
 {
 	addChild(&mBackground);
 	addChild(&mGrid);
@@ -19,11 +19,11 @@ MenuComponent::MenuComponent(Window* window, const char* title, const std::share
 	mTitle->setHorizontalAlignment(ALIGN_CENTER);
 	mTitle->setColor(0x555555FF);
 	setTitle(title, titleFont);
-	mGrid.setEntry(mTitle, Eigen::Vector2i(0, 0), false);
+	mGrid.setEntry(mTitle, Vector2i(0, 0), false);
 
 	// set up list which will never change (externally, anyway)
 	mList = std::make_shared<ComponentList>(mWindow);
-	mGrid.setEntry(mList, Eigen::Vector2i(0, 1), true);
+	mGrid.setEntry(mList, Vector2i(0, 1), true);
 
 	updateGrid();
 	updateSize();
@@ -67,7 +67,7 @@ void MenuComponent::updateSize()
 
 void MenuComponent::onSizeChanged()
 {
-	mBackground.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
+	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	// update grid row/col sizes
 	mGrid.setRowHeightPerc(0, TITLE_HEIGHT / mSize.y());
@@ -93,7 +93,7 @@ void MenuComponent::updateGrid()
 	if(mButtons.size())
 	{
 		mButtonGrid = makeButtonGrid(mWindow, mButtons);
-		mGrid.setEntry(mButtonGrid, Eigen::Vector2i(0, 2), true, false);
+		mGrid.setEntry(mButtonGrid, Vector2i(0, 2), true, false);
 	}
 }
 
@@ -104,12 +104,12 @@ std::vector<HelpPrompt> MenuComponent::getHelpPrompts()
 
 std::shared_ptr<ComponentGrid> makeButtonGrid(Window* window, const std::vector< std::shared_ptr<ButtonComponent> >& buttons)
 {
-	std::shared_ptr<ComponentGrid> buttonGrid = std::make_shared<ComponentGrid>(window, Eigen::Vector2i(buttons.size(), 2));
+	std::shared_ptr<ComponentGrid> buttonGrid = std::make_shared<ComponentGrid>(window, Vector2i(buttons.size(), 2));
 
 	float buttonGridWidth = (float)BUTTON_GRID_HORIZ_PADDING * buttons.size(); // initialize to padding
 	for(int i = 0; i < (int)buttons.size(); i++)
 	{
-		buttonGrid->setEntry(buttons.at(i), Eigen::Vector2i(i, 0), true, false);
+		buttonGrid->setEntry(buttons.at(i), Vector2i(i, 0), true, false);
 		buttonGridWidth += buttons.at(i)->getSize().x();
 	}
 	for(unsigned int i = 0; i < buttons.size(); i++)

--- a/es-core/src/components/NinePatchComponent.cpp
+++ b/es-core/src/components/NinePatchComponent.cpp
@@ -139,9 +139,9 @@ void NinePatchComponent::buildVertices()
 	}
 }
 
-void NinePatchComponent::render(const Affine3f& parentTrans)
+void NinePatchComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = roundMatrix(parentTrans * getTransform());
+	Matrix4x4f trans = roundMatrix(parentTrans * getTransform());
 	
 	if(mTexture && mVertices != NULL)
 	{

--- a/es-core/src/components/NinePatchComponent.cpp
+++ b/es-core/src/components/NinePatchComponent.cpp
@@ -39,7 +39,7 @@ void NinePatchComponent::buildVertices()
 
 	mTexture = TextureResource::get(mPath);
 
-	if(mTexture->getSize() == Eigen::Vector2i::Zero())
+	if(mTexture->getSize() == Vector2i::Zero())
 	{
 		mVertices = NULL;
 		mColors = NULL;
@@ -51,22 +51,22 @@ void NinePatchComponent::buildVertices()
 	mColors = new GLubyte[6 * 9 * 4];
 	updateColors();
 
-	const Eigen::Vector2f ts = mTexture->getSize().cast<float>();
+	const Vector2f ts = mTexture->getSize().cast<float>();
 
 	//coordinates on the image in pixels, top left origin
-	const Eigen::Vector2f pieceCoords[9] = {
-		Eigen::Vector2f(0,  0),
-		Eigen::Vector2f(16, 0),
-		Eigen::Vector2f(32, 0),
-		Eigen::Vector2f(0,  16),
-		Eigen::Vector2f(16, 16),
-		Eigen::Vector2f(32, 16),
-		Eigen::Vector2f(0,  32),
-		Eigen::Vector2f(16, 32),
-		Eigen::Vector2f(32, 32),
+	const Vector2f pieceCoords[9] = {
+		Vector2f(0,  0),
+		Vector2f(16, 0),
+		Vector2f(32, 0),
+		Vector2f(0,  16),
+		Vector2f(16, 16),
+		Vector2f(32, 16),
+		Vector2f(0,  32),
+		Vector2f(16, 32),
+		Vector2f(32, 32),
 	};
 
-	const Eigen::Vector2f pieceSizes = getCornerSize();
+	const Vector2f pieceSizes = getCornerSize();
 
 	//corners never stretch, so we calculate a width and height for slices 1, 3, 5, and 7
 	float borderWidth = mSize.x() - (pieceSizes.x() * 2); //should be pieceSizes[0] and pieceSizes[2]
@@ -79,20 +79,20 @@ void NinePatchComponent::buildVertices()
 
 	mVertices[0 * 6].pos = pieceCoords[0]; //top left
 	mVertices[1 * 6].pos = pieceCoords[1]; //top middle
-	mVertices[2 * 6].pos = pieceCoords[1] + Eigen::Vector2f(borderWidth, 0); //top right
+	mVertices[2 * 6].pos = pieceCoords[1] + Vector2f(borderWidth, 0); //top right
 
-	mVertices[3 * 6].pos = mVertices[0 * 6].pos + Eigen::Vector2f(0, pieceSizes.y()); //mid left
-	mVertices[4 * 6].pos = mVertices[3 * 6].pos + Eigen::Vector2f(pieceSizes.x(), 0); //mid middle
-	mVertices[5 * 6].pos = mVertices[4 * 6].pos + Eigen::Vector2f(borderWidth, 0); //mid right
+	mVertices[3 * 6].pos = mVertices[0 * 6].pos + Vector2f(0, pieceSizes.y()); //mid left
+	mVertices[4 * 6].pos = mVertices[3 * 6].pos + Vector2f(pieceSizes.x(), 0); //mid middle
+	mVertices[5 * 6].pos = mVertices[4 * 6].pos + Vector2f(borderWidth, 0); //mid right
 
-	mVertices[6 * 6].pos = mVertices[3 * 6].pos + Eigen::Vector2f(0, borderHeight); //bot left
-	mVertices[7 * 6].pos = mVertices[6 * 6].pos + Eigen::Vector2f(pieceSizes.x(), 0); //bot middle
-	mVertices[8 * 6].pos = mVertices[7 * 6].pos + Eigen::Vector2f(borderWidth, 0); //bot right
+	mVertices[6 * 6].pos = mVertices[3 * 6].pos + Vector2f(0, borderHeight); //bot left
+	mVertices[7 * 6].pos = mVertices[6 * 6].pos + Vector2f(pieceSizes.x(), 0); //bot middle
+	mVertices[8 * 6].pos = mVertices[7 * 6].pos + Vector2f(borderWidth, 0); //bot right
 
 	int v = 0;
 	for(int slice = 0; slice < 9; slice++)
 	{
-		Eigen::Vector2f size;
+		Vector2f size;
 
 		//corners
 		if(slice == 0 || slice == 2 || slice == 6 || slice == 8)
@@ -139,9 +139,9 @@ void NinePatchComponent::buildVertices()
 	}
 }
 
-void NinePatchComponent::render(const Eigen::Affine3f& parentTrans)
+void NinePatchComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = roundMatrix(parentTrans * getTransform());
+	Affine3f trans = roundMatrix(parentTrans * getTransform());
 	
 	if(mTexture && mVertices != NULL)
 	{
@@ -179,18 +179,18 @@ void NinePatchComponent::onSizeChanged()
 	buildVertices();
 }
 
-Eigen::Vector2f NinePatchComponent::getCornerSize() const
+Vector2f NinePatchComponent::getCornerSize() const
 {
-	return Eigen::Vector2f(16, 16);
+	return Vector2f(16, 16);
 }
 
-void NinePatchComponent::fitTo(Eigen::Vector2f size, Eigen::Vector3f position, Eigen::Vector2f padding)
+void NinePatchComponent::fitTo(Vector2f size, Vector3f position, Vector2f padding)
 {
 	size += padding;
 	position[0] -= padding.x() / 2;
 	position[1] -= padding.y() / 2;
 
-	setSize(size + Eigen::Vector2f(getCornerSize().x() * 2, getCornerSize().y() * 2));
+	setSize(size + Vector2f(getCornerSize().x() * 2, getCornerSize().y() * 2));
 	setPosition(-getCornerSize().x() + position.x(), -getCornerSize().y() + position.y());
 }
 

--- a/es-core/src/components/NinePatchComponent.h
+++ b/es-core/src/components/NinePatchComponent.h
@@ -20,7 +20,7 @@ public:
 	NinePatchComponent(Window* window, const std::string& path = "", unsigned int edgeColor = 0xFFFFFFFF, unsigned int centerColor = 0xFFFFFFFF);
 	virtual ~NinePatchComponent();
 
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 
 	void onSizeChanged() override;
 

--- a/es-core/src/components/NinePatchComponent.h
+++ b/es-core/src/components/NinePatchComponent.h
@@ -20,11 +20,11 @@ public:
 	NinePatchComponent(Window* window, const std::string& path = "", unsigned int edgeColor = 0xFFFFFFFF, unsigned int centerColor = 0xFFFFFFFF);
 	virtual ~NinePatchComponent();
 
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 
 	void onSizeChanged() override;
 
-	void fitTo(Eigen::Vector2f size, Eigen::Vector3f position = Eigen::Vector3f::Zero(), Eigen::Vector2f padding = Eigen::Vector2f::Zero());
+	void fitTo(Vector2f size, Vector3f position = Vector3f::Zero(), Vector2f padding = Vector2f::Zero());
 
 	void setImagePath(const std::string& path);
 	void setEdgeColor(unsigned int edgeColor); // Apply a color shift to the "edge" parts of the ninepatch.
@@ -33,15 +33,15 @@ public:
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
 private:
-	Eigen::Vector2f getCornerSize() const;
+	Vector2f getCornerSize() const;
 
 	void buildVertices();
 	void updateColors();
 
 	struct Vertex
 	{
-		Eigen::Vector2f pos;
-		Eigen::Vector2f tex;
+		Vector2f pos;
+		Vector2f tex;
 	};
 
 	Vertex* mVertices;

--- a/es-core/src/components/ScrollableContainer.cpp
+++ b/es-core/src/components/ScrollableContainer.cpp
@@ -11,9 +11,9 @@ ScrollableContainer::ScrollableContainer(Window* window) : GuiComponent(window),
 {
 }
 
-void ScrollableContainer::render(const Affine3f& parentTrans)
+void ScrollableContainer::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 
 	Vector2i clipPos((int)trans.translation().x(), (int)trans.translation().y());
 

--- a/es-core/src/components/ScrollableContainer.cpp
+++ b/es-core/src/components/ScrollableContainer.cpp
@@ -11,18 +11,18 @@ ScrollableContainer::ScrollableContainer(Window* window) : GuiComponent(window),
 {
 }
 
-void ScrollableContainer::render(const Eigen::Affine3f& parentTrans)
+void ScrollableContainer::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 
-	Eigen::Vector2i clipPos((int)trans.translation().x(), (int)trans.translation().y());
+	Vector2i clipPos((int)trans.translation().x(), (int)trans.translation().y());
 
-	Eigen::Vector3f dimScaled = trans * Eigen::Vector3f(mSize.x(), mSize.y(), 0);
-	Eigen::Vector2i clipDim((int)dimScaled.x() - trans.translation().x(), (int)dimScaled.y() - trans.translation().y());
+	Vector3f dimScaled = trans * Vector3f(mSize.x(), mSize.y(), 0);
+	Vector2i clipDim((int)dimScaled.x() - trans.translation().x(), (int)dimScaled.y() - trans.translation().y());
 
 	Renderer::pushClipRect(clipPos, clipDim);
 
-	trans.translate(-Eigen::Vector3f(mScrollPos.x(), mScrollPos.y(), 0));
+	trans.translate(-Vector3f(mScrollPos.x(), mScrollPos.y(), 0));
 	Renderer::setMatrix(trans);
 
 	GuiComponent::renderChildren(trans);
@@ -46,12 +46,12 @@ void ScrollableContainer::setAutoScroll(bool autoScroll)
 	}
 }
 
-Eigen::Vector2f ScrollableContainer::getScrollPos() const
+Vector2f ScrollableContainer::getScrollPos() const
 {
 	return mScrollPos;
 }
 
-void ScrollableContainer::setScrollPos(const Eigen::Vector2f& pos)
+void ScrollableContainer::setScrollPos(const Vector2f& pos)
 {
 	mScrollPos = pos;
 }
@@ -77,7 +77,7 @@ void ScrollableContainer::update(int deltaTime)
 	if(mScrollPos.y() < 0)
 		mScrollPos[1] = 0;
 
-	const Eigen::Vector2f contentSize = getContentSize();
+	const Vector2f contentSize = getContentSize();
 	if(mScrollPos.x() + getSize().x() > contentSize.x())
 	{
 		mScrollPos[0] = contentSize.x() - getSize().x();
@@ -104,13 +104,13 @@ void ScrollableContainer::update(int deltaTime)
 }
 
 //this should probably return a box to allow for when controls don't start at 0,0
-Eigen::Vector2f ScrollableContainer::getContentSize()
+Vector2f ScrollableContainer::getContentSize()
 {
-	Eigen::Vector2f max(0, 0);
+	Vector2f max(0, 0);
 	for(unsigned int i = 0; i < mChildren.size(); i++)
 	{
-		Eigen::Vector2f pos(mChildren.at(i)->getPosition()[0], mChildren.at(i)->getPosition()[1]);
-		Eigen::Vector2f bottomRight = mChildren.at(i)->getSize() + pos;
+		Vector2f pos(mChildren.at(i)->getPosition()[0], mChildren.at(i)->getPosition()[1]);
+		Vector2f bottomRight = mChildren.at(i)->getSize() + pos;
 		if(bottomRight.x() > max.x())
 			max.x() = bottomRight.x();
 		if(bottomRight.y() > max.y())

--- a/es-core/src/components/ScrollableContainer.h
+++ b/es-core/src/components/ScrollableContainer.h
@@ -13,7 +13,7 @@ public:
 	void reset();
 
 	void update(int deltaTime) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 
 private:
 	Vector2f getContentSize();

--- a/es-core/src/components/ScrollableContainer.h
+++ b/es-core/src/components/ScrollableContainer.h
@@ -7,19 +7,19 @@ class ScrollableContainer : public GuiComponent
 public:
 	ScrollableContainer(Window* window);
 
-	Eigen::Vector2f getScrollPos() const;
-	void setScrollPos(const Eigen::Vector2f& pos);
+	Vector2f getScrollPos() const;
+	void setScrollPos(const Vector2f& pos);
 	void setAutoScroll(bool autoScroll);
 	void reset();
 
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 
 private:
-	Eigen::Vector2f getContentSize();
+	Vector2f getContentSize();
 
-	Eigen::Vector2f mScrollPos;
-	Eigen::Vector2f mScrollDir;
+	Vector2f mScrollPos;
+	Vector2f mScrollDir;
 	int mAutoScrollDelay; // ms to wait before starting to autoscroll
 	int mAutoScrollSpeed; // ms to wait before scrolling down by mScrollDir
 	int mAutoScrollAccumulator;

--- a/es-core/src/components/SliderComponent.cpp
+++ b/es-core/src/components/SliderComponent.cpp
@@ -61,9 +61,9 @@ void SliderComponent::update(int deltaTime)
 	GuiComponent::update(deltaTime);
 }
 
-void SliderComponent::render(const Affine3f& parentTrans)
+void SliderComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = roundMatrix(parentTrans * getTransform());
+	Matrix4x4f trans = roundMatrix(parentTrans * getTransform());
 	Renderer::setMatrix(trans);
 
 	// render suffix

--- a/es-core/src/components/SliderComponent.cpp
+++ b/es-core/src/components/SliderComponent.cpp
@@ -61,9 +61,9 @@ void SliderComponent::update(int deltaTime)
 	GuiComponent::update(deltaTime);
 }
 
-void SliderComponent::render(const Eigen::Affine3f& parentTrans)
+void SliderComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = roundMatrix(parentTrans * getTransform());
+	Affine3f trans = roundMatrix(parentTrans * getTransform());
 	Renderer::setMatrix(trans);
 
 	// render suffix
@@ -126,7 +126,7 @@ void SliderComponent::onValueChanged()
 		ss << mSuffix;
 		const std::string max = ss.str();
 
-		Eigen::Vector2f textSize = mFont->sizeText(max);
+		Vector2f textSize = mFont->sizeText(max);
 		mValueCache = std::shared_ptr<TextCache>(mFont->buildTextCache(val, mSize.x() - textSize.x(), (mSize.y() - textSize.y()) / 2, 0x777777FF));
 		mValueCache->metrics.size[0] = textSize.x(); // fudge the width
 	}

--- a/es-core/src/components/SliderComponent.h
+++ b/es-core/src/components/SliderComponent.h
@@ -18,7 +18,7 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 	
 	void onSizeChanged() override;
 	

--- a/es-core/src/components/SliderComponent.h
+++ b/es-core/src/components/SliderComponent.h
@@ -18,7 +18,7 @@ public:
 
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 	
 	void onSizeChanged() override;
 	

--- a/es-core/src/components/SwitchComponent.cpp
+++ b/es-core/src/components/SwitchComponent.cpp
@@ -27,9 +27,9 @@ bool SwitchComponent::input(InputConfig* config, Input input)
 	return false;
 }
 
-void SwitchComponent::render(const Eigen::Affine3f& parentTrans)
+void SwitchComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 	
 	mImage.render(trans);
 

--- a/es-core/src/components/SwitchComponent.cpp
+++ b/es-core/src/components/SwitchComponent.cpp
@@ -27,9 +27,9 @@ bool SwitchComponent::input(InputConfig* config, Input input)
 	return false;
 }
 
-void SwitchComponent::render(const Affine3f& parentTrans)
+void SwitchComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 	
 	mImage.render(trans);
 

--- a/es-core/src/components/SwitchComponent.h
+++ b/es-core/src/components/SwitchComponent.h
@@ -11,7 +11,7 @@ public:
 	SwitchComponent(Window* window, bool state = false);
 
 	bool input(InputConfig* config, Input input) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 	void onSizeChanged() override;
 
 	bool getState() const;

--- a/es-core/src/components/SwitchComponent.h
+++ b/es-core/src/components/SwitchComponent.h
@@ -11,7 +11,7 @@ public:
 	SwitchComponent(Window* window, bool state = false);
 
 	bool input(InputConfig* config, Input input) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 	void onSizeChanged() override;
 
 	bool getState() const;

--- a/es-core/src/components/TextComponent.cpp
+++ b/es-core/src/components/TextComponent.cpp
@@ -95,9 +95,9 @@ void TextComponent::setUppercase(bool uppercase)
 	onTextChanged();
 }
 
-void TextComponent::render(const Affine3f& parentTrans)
+void TextComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 
 	if (mRenderBackground)
 	{

--- a/es-core/src/components/TextComponent.cpp
+++ b/es-core/src/components/TextComponent.cpp
@@ -15,7 +15,7 @@ TextComponent::TextComponent(Window* window) : GuiComponent(window),
 }
 
 TextComponent::TextComponent(Window* window, const std::string& text, const std::shared_ptr<Font>& font, unsigned int color, Alignment align,
-	Eigen::Vector3f pos, Eigen::Vector2f size, unsigned int bgcolor) : GuiComponent(window), 
+	Vector3f pos, Vector2f size, unsigned int bgcolor) : GuiComponent(window), 
 	mFont(NULL), mUppercase(false), mColor(0x000000FF), mAutoCalcExtent(true, true),
 	mHorizontalAlignment(align), mVerticalAlignment(ALIGN_CENTER), mLineSpacing(1.5f), mBgColor(0),
 	mRenderBackground(false)
@@ -95,9 +95,9 @@ void TextComponent::setUppercase(bool uppercase)
 	onTextChanged();
 }
 
-void TextComponent::render(const Eigen::Affine3f& parentTrans)
+void TextComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 
 	if (mRenderBackground)
 	{
@@ -107,7 +107,7 @@ void TextComponent::render(const Eigen::Affine3f& parentTrans)
 
 	if(mTextCache)
 	{
-		const Eigen::Vector2f& textSize = mTextCache->metrics.size;
+		const Vector2f& textSize = mTextCache->metrics.size;
 		float yOff;
 		switch(mVerticalAlignment)
 		{
@@ -121,7 +121,7 @@ void TextComponent::render(const Eigen::Affine3f& parentTrans)
 				yOff = (getSize().y() - textSize.y()) / 2.0f;
 				break;
 		}
-		Eigen::Vector3f off(0, yOff, 0);
+		Vector3f off(0, yOff, 0);
 
 		if(Settings::getInstance()->getBool("DebugText"))
 		{
@@ -190,12 +190,12 @@ void TextComponent::onTextChanged()
 		addAbbrev = newline != std::string::npos;
 	}
 
-	Eigen::Vector2f size = f->sizeText(text);
+	Vector2f size = f->sizeText(text);
 	if(!isMultiline && mSize.x() && text.size() && (size.x() > mSize.x() || addAbbrev))
 	{
 		// abbreviate text
 		const std::string abbrev = "...";
-		Eigen::Vector2f abbrevSize = f->sizeText(abbrev);
+		Vector2f abbrevSize = f->sizeText(abbrev);
 
 		while(text.size() && size.x() + abbrevSize.x() > mSize.x())
 		{
@@ -206,9 +206,9 @@ void TextComponent::onTextChanged()
 
 		text.append(abbrev);
 
-		mTextCache = std::shared_ptr<TextCache>(f->buildTextCache(text, Eigen::Vector2f(0, 0), (mColor >> 8 << 8) | mOpacity, mSize.x(), mHorizontalAlignment, mLineSpacing));
+		mTextCache = std::shared_ptr<TextCache>(f->buildTextCache(text, Vector2f(0, 0), (mColor >> 8 << 8) | mOpacity, mSize.x(), mHorizontalAlignment, mLineSpacing));
 	}else{
-		mTextCache = std::shared_ptr<TextCache>(f->buildTextCache(f->wrapText(text, mSize.x()), Eigen::Vector2f(0, 0), (mColor >> 8 << 8) | mOpacity, mSize.x(), mHorizontalAlignment, mLineSpacing));
+		mTextCache = std::shared_ptr<TextCache>(f->buildTextCache(f->wrapText(text, mSize.x()), Vector2f(0, 0), (mColor >> 8 << 8) | mOpacity, mSize.x(), mHorizontalAlignment, mLineSpacing));
 	}
 }
 

--- a/es-core/src/components/TextComponent.h
+++ b/es-core/src/components/TextComponent.h
@@ -16,7 +16,7 @@ class TextComponent : public GuiComponent
 public:
 	TextComponent(Window* window);
 	TextComponent(Window* window, const std::string& text, const std::shared_ptr<Font>& font, unsigned int color = 0x000000FF, Alignment align = ALIGN_LEFT,
-		Eigen::Vector3f pos = Eigen::Vector3f::Zero(), Eigen::Vector2f size = Eigen::Vector2f::Zero(), unsigned int bgcolor = 0x00000000);
+		Vector3f pos = Vector3f::Zero(), Vector2f size = Vector2f::Zero(), unsigned int bgcolor = 0x00000000);
 
 	void setFont(const std::shared_ptr<Font>& font);
 	void setUppercase(bool uppercase);
@@ -29,7 +29,7 @@ public:
 	void setBackgroundColor(unsigned int color);
 	void setRenderBackground(bool render);
 
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 
 	std::string getValue() const override;
 	void setValue(const std::string& value) override;
@@ -55,7 +55,7 @@ private:
 
 	std::shared_ptr<Font> mFont;
 	bool mUppercase;
-	Eigen::Vector2b mAutoCalcExtent;
+	Vector2b mAutoCalcExtent;
 	std::string mText;
 	std::shared_ptr<TextCache> mTextCache;
 	Alignment mHorizontalAlignment;

--- a/es-core/src/components/TextComponent.h
+++ b/es-core/src/components/TextComponent.h
@@ -55,7 +55,7 @@ private:
 
 	std::shared_ptr<Font> mFont;
 	bool mUppercase;
-	Eigen::Matrix<bool, 1, 2> mAutoCalcExtent;
+	Eigen::Vector2b mAutoCalcExtent;
 	std::string mText;
 	std::shared_ptr<TextCache> mTextCache;
 	Alignment mHorizontalAlignment;

--- a/es-core/src/components/TextComponent.h
+++ b/es-core/src/components/TextComponent.h
@@ -29,7 +29,7 @@ public:
 	void setBackgroundColor(unsigned int color);
 	void setRenderBackground(bool render);
 
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 
 	std::string getValue() const override;
 	void setValue(const std::string& value) override;

--- a/es-core/src/components/TextEditComponent.cpp
+++ b/es-core/src/components/TextEditComponent.cpp
@@ -241,9 +241,9 @@ void TextEditComponent::onCursorChanged()
 	}
 }
 
-void TextEditComponent::render(const Affine3f& parentTrans)
+void TextEditComponent::render(const Matrix4x4f& parentTrans)
 {
-	Affine3f trans = getTransform() * parentTrans;
+	Matrix4x4f trans = getTransform() * parentTrans;
 	renderChildren(trans);
 
 	// text + cursor rendering

--- a/es-core/src/components/TextEditComponent.cpp
+++ b/es-core/src/components/TextEditComponent.cpp
@@ -37,7 +37,7 @@ void TextEditComponent::onFocusLost()
 
 void TextEditComponent::onSizeChanged()
 {
-	mBox.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-34, -32 - TEXT_PADDING_VERT));
+	mBox.fitTo(mSize, Vector3f::Zero(), Vector2f(-34, -32 - TEXT_PADDING_VERT));
 	onTextChanged(); // wrap point probably changed
 }
 
@@ -219,7 +219,7 @@ void TextEditComponent::onCursorChanged()
 {
 	if(isMultiline())
 	{
-		Eigen::Vector2f textSize = mFont->getWrappedTextCursorOffset(mText, getTextAreaSize().x(), mCursor); 
+		Vector2f textSize = mFont->getWrappedTextCursorOffset(mText, getTextAreaSize().x(), mCursor); 
 
 		if(mScrollOffset.y() + getTextAreaSize().y() < textSize.y() + mFont->getHeight()) //need to scroll down?
 		{
@@ -229,7 +229,7 @@ void TextEditComponent::onCursorChanged()
 			mScrollOffset[1] = textSize.y();
 		}
 	}else{
-		Eigen::Vector2f cursorPos = mFont->sizeText(mText.substr(0, mCursor));
+		Vector2f cursorPos = mFont->sizeText(mText.substr(0, mCursor));
 
 		if(mScrollOffset.x() + getTextAreaSize().x() < cursorPos.x())
 		{
@@ -241,21 +241,21 @@ void TextEditComponent::onCursorChanged()
 	}
 }
 
-void TextEditComponent::render(const Eigen::Affine3f& parentTrans)
+void TextEditComponent::render(const Affine3f& parentTrans)
 {
-	Eigen::Affine3f trans = getTransform() * parentTrans;
+	Affine3f trans = getTransform() * parentTrans;
 	renderChildren(trans);
 
 	// text + cursor rendering
 	// offset into our "text area" (padding)
-	trans.translation() += Eigen::Vector3f(getTextAreaPos().x(), getTextAreaPos().y(), 0);
+	trans.translation() += Vector3f(getTextAreaPos().x(), getTextAreaPos().y(), 0);
 
-	Eigen::Vector2i clipPos((int)trans.translation().x(), (int)trans.translation().y());
-	Eigen::Vector3f dimScaled = trans * Eigen::Vector3f(getTextAreaSize().x(), getTextAreaSize().y(), 0); // use "text area" size for clipping
-	Eigen::Vector2i clipDim((int)dimScaled.x() - trans.translation().x(), (int)dimScaled.y() - trans.translation().y());
+	Vector2i clipPos((int)trans.translation().x(), (int)trans.translation().y());
+	Vector3f dimScaled = trans * Vector3f(getTextAreaSize().x(), getTextAreaSize().y(), 0); // use "text area" size for clipping
+	Vector2i clipDim((int)dimScaled.x() - trans.translation().x(), (int)dimScaled.y() - trans.translation().y());
 	Renderer::pushClipRect(clipPos, clipDim);
 
-	trans.translate(Eigen::Vector3f(-mScrollOffset.x(), -mScrollOffset.y(), 0));
+	trans.translate(Vector3f(-mScrollOffset.x(), -mScrollOffset.y(), 0));
 	trans = roundMatrix(trans);
 
 	Renderer::setMatrix(trans);
@@ -271,7 +271,7 @@ void TextEditComponent::render(const Eigen::Affine3f& parentTrans)
 	// draw cursor
 	if(mEditing)
 	{
-		Eigen::Vector2f cursorPos;
+		Vector2f cursorPos;
 		if(isMultiline())
 		{
 			cursorPos = mFont->getWrappedTextCursorOffset(mText, getTextAreaSize().x(), mCursor);
@@ -290,14 +290,14 @@ bool TextEditComponent::isMultiline()
 	return (getSize().y() > mFont->getHeight() * 1.25f);
 }
 
-Eigen::Vector2f TextEditComponent::getTextAreaPos() const
+Vector2f TextEditComponent::getTextAreaPos() const
 {
-	return Eigen::Vector2f(TEXT_PADDING_HORIZ / 2.0f, TEXT_PADDING_VERT / 2.0f);
+	return Vector2f(TEXT_PADDING_HORIZ / 2.0f, TEXT_PADDING_VERT / 2.0f);
 }
 
-Eigen::Vector2f TextEditComponent::getTextAreaSize() const
+Vector2f TextEditComponent::getTextAreaSize() const
 {
-	return Eigen::Vector2f(mSize.x() - TEXT_PADDING_HORIZ, mSize.y() - TEXT_PADDING_VERT);
+	return Vector2f(mSize.x() - TEXT_PADDING_HORIZ, mSize.y() - TEXT_PADDING_VERT);
 }
 
 std::vector<HelpPrompt> TextEditComponent::getHelpPrompts()

--- a/es-core/src/components/TextEditComponent.h
+++ b/es-core/src/components/TextEditComponent.h
@@ -15,7 +15,7 @@ public:
 	void textInput(const char* text) override;
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 
 	void onFocusGained() override;
 	void onFocusLost() override;
@@ -43,8 +43,8 @@ private:
 	void moveCursor(int amt);
 
 	bool isMultiline();
-	Eigen::Vector2f getTextAreaPos() const;
-	Eigen::Vector2f getTextAreaSize() const;
+	Vector2f getTextAreaPos() const;
+	Vector2f getTextAreaSize() const;
 
 	std::string mText;
 	bool mFocused;
@@ -54,7 +54,7 @@ private:
 	int mCursorRepeatTimer;
 	int mCursorRepeatDir;
 
-	Eigen::Vector2f mScrollOffset;
+	Vector2f mScrollOffset;
 
 	NinePatchComponent mBox;
 

--- a/es-core/src/components/TextEditComponent.h
+++ b/es-core/src/components/TextEditComponent.h
@@ -15,7 +15,7 @@ public:
 	void textInput(const char* text) override;
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 
 	void onFocusGained() override;
 	void onFocusLost() override;

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -153,11 +153,11 @@ void VideoComponent::setOpacity(unsigned char opacity)
 	mStaticImage.setOpacity(opacity);
 }
 
-void VideoComponent::render(const Affine3f& parentTrans)
+void VideoComponent::render(const Matrix4x4f& parentTrans)
 {
 	float x, y;
 
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 	GuiComponent::renderChildren(trans);
 
 	Renderer::setMatrix(trans);
@@ -169,7 +169,7 @@ void VideoComponent::render(const Affine3f& parentTrans)
 	handleLooping();
 }
 
-void VideoComponent::renderSnapshot(const Affine3f& parentTrans)
+void VideoComponent::renderSnapshot(const Matrix4x4f& parentTrans)
 {
 	// This is the case where the video is not currently being displayed. Work out
 	// if we need to display a static image

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -153,11 +153,11 @@ void VideoComponent::setOpacity(unsigned char opacity)
 	mStaticImage.setOpacity(opacity);
 }
 
-void VideoComponent::render(const Eigen::Affine3f& parentTrans)
+void VideoComponent::render(const Affine3f& parentTrans)
 {
 	float x, y;
 
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 	GuiComponent::renderChildren(trans);
 
 	Renderer::setMatrix(trans);
@@ -169,7 +169,7 @@ void VideoComponent::render(const Eigen::Affine3f& parentTrans)
 	handleLooping();
 }
 
-void VideoComponent::renderSnapshot(const Eigen::Affine3f& parentTrans)
+void VideoComponent::renderSnapshot(const Affine3f& parentTrans)
 {
 	// This is the case where the video is not currently being displayed. Work out
 	// if we need to display a static image
@@ -191,26 +191,26 @@ void VideoComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 		return;
 	}
 
-	Eigen::Vector2f scale = getParent() ? getParent()->getSize() : Eigen::Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
+	Vector2f scale = getParent() ? getParent()->getSize() : Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
 
 	if ((properties & POSITION) && elem->has("pos"))
 	{
-		Eigen::Vector2f denormalized = elem->get<Eigen::Vector2f>("pos").cwiseProduct(scale);
-		setPosition(Eigen::Vector3f(denormalized.x(), denormalized.y(), 0));
-		mStaticImage.setPosition(Eigen::Vector3f(denormalized.x(), denormalized.y(), 0));
+		Vector2f denormalized = elem->get<Vector2f>("pos").cwiseProduct(scale);
+		setPosition(Vector3f(denormalized.x(), denormalized.y(), 0));
+		mStaticImage.setPosition(Vector3f(denormalized.x(), denormalized.y(), 0));
 	}
 
 	if(properties & ThemeFlags::SIZE)
 	{
 		if(elem->has("size"))
-			setResize(elem->get<Eigen::Vector2f>("size").cwiseProduct(scale));
+			setResize(elem->get<Vector2f>("size").cwiseProduct(scale));
 		else if(elem->has("maxSize"))
-			setMaxSize(elem->get<Eigen::Vector2f>("maxSize").cwiseProduct(scale));
+			setMaxSize(elem->get<Vector2f>("maxSize").cwiseProduct(scale));
 	}
 
 	// position + size also implies origin
 	if (((properties & ORIGIN) || ((properties & POSITION) && (properties & ThemeFlags::SIZE))) && elem->has("origin"))
-		setOrigin(elem->get<Eigen::Vector2f>("origin"));
+		setOrigin(elem->get<Vector2f>("origin"));
 
 	if(elem->has("default"))
 		mConfig.defaultVideoPath = elem->get<std::string>("default");
@@ -228,7 +228,7 @@ void VideoComponent::applyTheme(const std::shared_ptr<ThemeData>& theme, const s
 		if(elem->has("rotation"))
 			setRotationDegrees(elem->get<float>("rotation"));
 		if(elem->has("rotationOrigin"))
-			setRotationOrigin(elem->get<Eigen::Vector2f>("rotationOrigin"));
+			setRotationOrigin(elem->get<Vector2f>("rotationOrigin"));
 	}
 
 	if(properties & ThemeFlags::Z_INDEX && elem->has("zIndex"))

--- a/es-core/src/components/VideoComponent.h
+++ b/es-core/src/components/VideoComponent.h
@@ -52,8 +52,8 @@ public:
 	void onSizeChanged() override;
 	void setOpacity(unsigned char opacity) override;
 
-	void render(const Eigen::Affine3f& parentTrans) override;
-	void renderSnapshot(const Eigen::Affine3f& parentTrans);
+	void render(const Affine3f& parentTrans) override;
+	void renderSnapshot(const Affine3f& parentTrans);
 
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
@@ -66,13 +66,13 @@ public:
 	// Can be set before or after a video is loaded.
 	// setMaxSize() and setResize() are mutually exclusive.
 	virtual void setResize(float width, float height) = 0;
-	inline void setResize(const Eigen::Vector2f& size) { setResize(size.x(), size.y()); }
+	inline void setResize(const Vector2f& size) { setResize(size.x(), size.y()); }
 
 	// Resize the video to be as large as possible but fit within a box of this size.
 	// Can be set before or after a video is loaded.
 	// Never breaks the aspect ratio. setMaxSize() and setResize() are mutually exclusive.
 	virtual void setMaxSize(float width, float height) = 0;
-	inline void setMaxSize(const Eigen::Vector2f& size) { setMaxSize(size.x(), size.y()); }
+	inline void setMaxSize(const Vector2f& size) { setMaxSize(size.x(), size.y()); }
 
 private:
 	// Start the video Immediately
@@ -94,7 +94,7 @@ private:
 protected:
 	unsigned						mVideoWidth;
 	unsigned						mVideoHeight;
-	Eigen::Vector2f					mTargetSize;
+	Vector2f					mTargetSize;
 	std::shared_ptr<TextureResource> mTexture;
 	float							mFadeIn;
 	std::string						mStaticImagePath;

--- a/es-core/src/components/VideoComponent.h
+++ b/es-core/src/components/VideoComponent.h
@@ -52,8 +52,8 @@ public:
 	void onSizeChanged() override;
 	void setOpacity(unsigned char opacity) override;
 
-	void render(const Affine3f& parentTrans) override;
-	void renderSnapshot(const Affine3f& parentTrans);
+	void render(const Matrix4x4f& parentTrans) override;
+	void renderSnapshot(const Matrix4x4f& parentTrans);
 
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -32,7 +32,7 @@ VideoPlayerComponent::~VideoPlayerComponent()
 	stopVideo();
 }
 
-void VideoPlayerComponent::render(const Affine3f& parentTrans)
+void VideoPlayerComponent::render(const Matrix4x4f& parentTrans)
 {
 	VideoComponent::render(parentTrans);
 

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -32,7 +32,7 @@ VideoPlayerComponent::~VideoPlayerComponent()
 	stopVideo();
 }
 
-void VideoPlayerComponent::render(const Eigen::Affine3f& parentTrans)
+void VideoPlayerComponent::render(const Affine3f& parentTrans)
 {
 	VideoComponent::render(parentTrans);
 

--- a/es-core/src/components/VideoPlayerComponent.h
+++ b/es-core/src/components/VideoPlayerComponent.h
@@ -15,7 +15,7 @@ public:
 	VideoPlayerComponent(Window* window, std::string path);
 	virtual ~VideoPlayerComponent();
 
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 
 	// Resize the video to fit this size. If one axis is zero, scale that axis to maintain aspect ratio.
 	// If both are non-zero, potentially break the aspect ratio.  If both are zero, no resizing.

--- a/es-core/src/components/VideoPlayerComponent.h
+++ b/es-core/src/components/VideoPlayerComponent.h
@@ -15,7 +15,7 @@ public:
 	VideoPlayerComponent(Window* window, std::string path);
 	virtual ~VideoPlayerComponent();
 
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 
 	// Resize the video to fit this size. If one axis is zero, scale that axis to maintain aspect ratio.
 	// If both are non-zero, potentially break the aspect ratio.  If both are zero, no resizing.

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -71,7 +71,7 @@ void VideoVlcComponent::resize()
 	if(!mTexture)
 		return;
 
-	const Eigen::Vector2f textureSize(mVideoWidth, mVideoHeight);
+	const Vector2f textureSize(mVideoWidth, mVideoHeight);
 
 	if(textureSize.isZero())
 		return;
@@ -87,7 +87,7 @@ void VideoVlcComponent::resize()
 
 			mSize = textureSize;
 
-			Eigen::Vector2f resizeScale((mTargetSize.x() / mSize.x()), (mTargetSize.y() / mSize.y()));
+			Vector2f resizeScale((mTargetSize.x() / mSize.x()), (mTargetSize.y() / mSize.y()));
 
 			if(resizeScale.x() < resizeScale.y())
 			{
@@ -126,12 +126,12 @@ void VideoVlcComponent::resize()
 	onSizeChanged();
 }
 
-void VideoVlcComponent::render(const Eigen::Affine3f& parentTrans)
+void VideoVlcComponent::render(const Affine3f& parentTrans)
 {
 	VideoComponent::render(parentTrans);
 	float x, y;
 
-	Eigen::Affine3f trans = parentTrans * getTransform();
+	Affine3f trans = parentTrans * getTransform();
 	GuiComponent::renderChildren(trans);
 
 	Renderer::setMatrix(trans);
@@ -151,9 +151,9 @@ void VideoVlcComponent::render(const Eigen::Affine3f& parentTrans)
 		// Define a structure to contain the data for each vertex
 		struct Vertex
 		{
-			Eigen::Vector2f pos;
-			Eigen::Vector2f tex;
-			Eigen::Vector4f colour;
+			Vector2f pos;
+			Vector2f tex;
+			Vector4f colour;
 		} vertices[6];
 
 		// We need two triangles to cover the rectangular area
@@ -315,7 +315,7 @@ void VideoVlcComponent::startVideo()
 					{
 						if(!Settings::getInstance()->getBool("CaptionsCompatibility")) {
 
-							Eigen::Vector2f resizeScale((Renderer::getScreenWidth() / mVideoWidth), (Renderer::getScreenHeight() / mVideoHeight));
+							Vector2f resizeScale((Renderer::getScreenWidth() / mVideoWidth), (Renderer::getScreenHeight() / mVideoHeight));
 
 							if(resizeScale.x() < resizeScale.y())
 							{

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -126,12 +126,12 @@ void VideoVlcComponent::resize()
 	onSizeChanged();
 }
 
-void VideoVlcComponent::render(const Affine3f& parentTrans)
+void VideoVlcComponent::render(const Matrix4x4f& parentTrans)
 {
 	VideoComponent::render(parentTrans);
 	float x, y;
 
-	Affine3f trans = parentTrans * getTransform();
+	Matrix4x4f trans = parentTrans * getTransform();
 	GuiComponent::renderChildren(trans);
 
 	Renderer::setMatrix(trans);

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -32,7 +32,7 @@ public:
 	VideoVlcComponent(Window* window, std::string subtitles);
 	virtual ~VideoVlcComponent();
 
-	void render(const Eigen::Affine3f& parentTrans) override;
+	void render(const Affine3f& parentTrans) override;
 
 
 	// Resize the video to fit this size. If one axis is zero, scale that axis to maintain aspect ratio.

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -32,7 +32,7 @@ public:
 	VideoVlcComponent(Window* window, std::string subtitles);
 	virtual ~VideoVlcComponent();
 
-	void render(const Affine3f& parentTrans) override;
+	void render(const Matrix4x4f& parentTrans) override;
 
 
 	// Resize the video to fit this size. If one axis is zero, scale that axis to maintain aspect ratio.

--- a/es-core/src/guis/GuiDetectDevice.cpp
+++ b/es-core/src/guis/GuiDetectDevice.cpp
@@ -17,7 +17,7 @@
 namespace fs = boost::filesystem;
 
 GuiDetectDevice::GuiDetectDevice(Window* window, bool firstRun, const std::function<void()>& doneCallback) : GuiComponent(window), mFirstRun(firstRun), 
-	mBackground(window, ":/frame.png"), mGrid(window, Eigen::Vector2i(1, 5))
+	mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 5))
 {
 	mHoldingConfig = NULL;
 	mHoldTime = 0;
@@ -29,7 +29,7 @@ GuiDetectDevice::GuiDetectDevice(Window* window, bool firstRun, const std::funct
 	// title
 	mTitle = std::make_shared<TextComponent>(mWindow, firstRun ? "WELCOME" : "CONFIGURE INPUT", 
 		Font::get(FONT_SIZE_LARGE), 0x555555FF, ALIGN_CENTER);
-	mGrid.setEntry(mTitle, Eigen::Vector2i(0, 0), false, true, Eigen::Vector2i(1, 1), GridFlags::BORDER_BOTTOM);
+	mGrid.setEntry(mTitle, Vector2i(0, 0), false, true, Vector2i(1, 1), GridFlags::BORDER_BOTTOM);
 
 	// device info
 	std::stringstream deviceInfo;
@@ -40,19 +40,19 @@ GuiDetectDevice::GuiDetectDevice(Window* window, bool firstRun, const std::funct
 	else
 		deviceInfo << "NO GAMEPADS DETECTED";
 	mDeviceInfo = std::make_shared<TextComponent>(mWindow, deviceInfo.str(), Font::get(FONT_SIZE_SMALL), 0x999999FF, ALIGN_CENTER);
-	mGrid.setEntry(mDeviceInfo, Eigen::Vector2i(0, 1), false, true);
+	mGrid.setEntry(mDeviceInfo, Vector2i(0, 1), false, true);
 
 	// message
 	mMsg1 = std::make_shared<TextComponent>(mWindow, "HOLD A BUTTON ON YOUR DEVICE TO CONFIGURE IT.", Font::get(FONT_SIZE_SMALL), 0x777777FF, ALIGN_CENTER);
-	mGrid.setEntry(mMsg1, Eigen::Vector2i(0, 2), false, true);
+	mGrid.setEntry(mMsg1, Vector2i(0, 2), false, true);
 
 	const char* msg2str = firstRun ? "PRESS F4 TO QUIT AT ANY TIME." : "PRESS ESC TO CANCEL.";
 	mMsg2 = std::make_shared<TextComponent>(mWindow, msg2str, Font::get(FONT_SIZE_SMALL), 0x777777FF, ALIGN_CENTER);
-	mGrid.setEntry(mMsg2, Eigen::Vector2i(0, 3), false, true);
+	mGrid.setEntry(mMsg2, Vector2i(0, 3), false, true);
 
 	// currently held device
 	mDeviceHeld = std::make_shared<TextComponent>(mWindow, "", Font::get(FONT_SIZE_MEDIUM), 0xFFFFFFFF, ALIGN_CENTER);
-	mGrid.setEntry(mDeviceHeld, Eigen::Vector2i(0, 4), false, true);
+	mGrid.setEntry(mDeviceHeld, Vector2i(0, 4), false, true);
 
 	setSize(Renderer::getScreenWidth() * 0.6f, Renderer::getScreenHeight() * 0.5f);
 	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
@@ -60,7 +60,7 @@ GuiDetectDevice::GuiDetectDevice(Window* window, bool firstRun, const std::funct
 
 void GuiDetectDevice::onSizeChanged()
 {
-	mBackground.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
+	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	// grid
 	mGrid.setSize(mSize);

--- a/es-core/src/guis/GuiDetectDevice.cpp
+++ b/es-core/src/guis/GuiDetectDevice.cpp
@@ -14,12 +14,10 @@
 
 #define HOLD_TIME 1000
 
-using namespace Eigen;
-
 namespace fs = boost::filesystem;
 
 GuiDetectDevice::GuiDetectDevice(Window* window, bool firstRun, const std::function<void()>& doneCallback) : GuiComponent(window), mFirstRun(firstRun), 
-	mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 5))
+	mBackground(window, ":/frame.png"), mGrid(window, Eigen::Vector2i(1, 5))
 {
 	mHoldingConfig = NULL;
 	mHoldTime = 0;
@@ -31,7 +29,7 @@ GuiDetectDevice::GuiDetectDevice(Window* window, bool firstRun, const std::funct
 	// title
 	mTitle = std::make_shared<TextComponent>(mWindow, firstRun ? "WELCOME" : "CONFIGURE INPUT", 
 		Font::get(FONT_SIZE_LARGE), 0x555555FF, ALIGN_CENTER);
-	mGrid.setEntry(mTitle, Vector2i(0, 0), false, true, Vector2i(1, 1), GridFlags::BORDER_BOTTOM);
+	mGrid.setEntry(mTitle, Eigen::Vector2i(0, 0), false, true, Eigen::Vector2i(1, 1), GridFlags::BORDER_BOTTOM);
 
 	// device info
 	std::stringstream deviceInfo;
@@ -42,19 +40,19 @@ GuiDetectDevice::GuiDetectDevice(Window* window, bool firstRun, const std::funct
 	else
 		deviceInfo << "NO GAMEPADS DETECTED";
 	mDeviceInfo = std::make_shared<TextComponent>(mWindow, deviceInfo.str(), Font::get(FONT_SIZE_SMALL), 0x999999FF, ALIGN_CENTER);
-	mGrid.setEntry(mDeviceInfo, Vector2i(0, 1), false, true);
+	mGrid.setEntry(mDeviceInfo, Eigen::Vector2i(0, 1), false, true);
 
 	// message
 	mMsg1 = std::make_shared<TextComponent>(mWindow, "HOLD A BUTTON ON YOUR DEVICE TO CONFIGURE IT.", Font::get(FONT_SIZE_SMALL), 0x777777FF, ALIGN_CENTER);
-	mGrid.setEntry(mMsg1, Vector2i(0, 2), false, true);
+	mGrid.setEntry(mMsg1, Eigen::Vector2i(0, 2), false, true);
 
 	const char* msg2str = firstRun ? "PRESS F4 TO QUIT AT ANY TIME." : "PRESS ESC TO CANCEL.";
 	mMsg2 = std::make_shared<TextComponent>(mWindow, msg2str, Font::get(FONT_SIZE_SMALL), 0x777777FF, ALIGN_CENTER);
-	mGrid.setEntry(mMsg2, Vector2i(0, 3), false, true);
+	mGrid.setEntry(mMsg2, Eigen::Vector2i(0, 3), false, true);
 
 	// currently held device
 	mDeviceHeld = std::make_shared<TextComponent>(mWindow, "", Font::get(FONT_SIZE_MEDIUM), 0xFFFFFFFF, ALIGN_CENTER);
-	mGrid.setEntry(mDeviceHeld, Vector2i(0, 4), false, true);
+	mGrid.setEntry(mDeviceHeld, Eigen::Vector2i(0, 4), false, true);
 
 	setSize(Renderer::getScreenWidth() * 0.6f, Renderer::getScreenHeight() * 0.5f);
 	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
@@ -62,7 +60,7 @@ GuiDetectDevice::GuiDetectDevice(Window* window, bool firstRun, const std::funct
 
 void GuiDetectDevice::onSizeChanged()
 {
-	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
+	mBackground.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
 
 	// grid
 	mGrid.setSize(mSize);

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -136,7 +136,7 @@ static const char* inputIcon[inputCount] =
 #define HOLD_TO_SKIP_MS 1000
 
 GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfigureAll, const std::function<void()>& okCallback) : GuiComponent(window), 
-	mBackground(window, ":/frame.png"), mGrid(window, Eigen::Vector2i(1, 7)), 
+	mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 7)), 
 	mTargetConfig(target), mHoldingInput(false), mBusyAnim(window)
 {
 	LOG(LogInfo) << "Configuring device " << target->getDeviceId() << " (" << target->getDeviceName() << ").";
@@ -151,10 +151,10 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 	addChild(&mGrid);
 
 	// 0 is a spacer row
-	mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Eigen::Vector2i(0, 0), false);
+	mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Vector2i(0, 0), false);
 
 	mTitle = std::make_shared<TextComponent>(mWindow, "CONFIGURING", Font::get(FONT_SIZE_LARGE), 0x555555FF, ALIGN_CENTER);
-	mGrid.setEntry(mTitle, Eigen::Vector2i(0, 1), false, true);
+	mGrid.setEntry(mTitle, Vector2i(0, 1), false, true);
 	
 	std::stringstream ss;
 	if(target->getDeviceId() == DEVICE_KEYBOARD)
@@ -162,15 +162,15 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 	else
 		ss << "GAMEPAD " << (target->getDeviceId() + 1);
 	mSubtitle1 = std::make_shared<TextComponent>(mWindow, strToUpper(ss.str()), Font::get(FONT_SIZE_MEDIUM), 0x555555FF, ALIGN_CENTER);
-	mGrid.setEntry(mSubtitle1, Eigen::Vector2i(0, 2), false, true);
+	mGrid.setEntry(mSubtitle1, Vector2i(0, 2), false, true);
 
 	mSubtitle2 = std::make_shared<TextComponent>(mWindow, "HOLD ANY BUTTON TO SKIP", Font::get(FONT_SIZE_SMALL), 0x99999900, ALIGN_CENTER);
-	mGrid.setEntry(mSubtitle2, Eigen::Vector2i(0, 3), false, true);
+	mGrid.setEntry(mSubtitle2, Vector2i(0, 3), false, true);
 
 	// 4 is a spacer row
 
 	mList = std::make_shared<ComponentList>(mWindow);
-	mGrid.setEntry(mList, Eigen::Vector2i(0, 5), true, true);
+	mGrid.setEntry(mList, Vector2i(0, 5), true, true);
 	for(int i = 0; i < inputCount; i++)
 	{
 		ComponentListRow row;
@@ -290,7 +290,7 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 		}
 	}));
 	mButtonGrid = makeButtonGrid(mWindow, buttons);
-	mGrid.setEntry(mButtonGrid, Eigen::Vector2i(0, 6), true, false);
+	mGrid.setEntry(mButtonGrid, Vector2i(0, 6), true, false);
 
 	setSize(Renderer::getScreenWidth() * 0.6f, Renderer::getScreenHeight() * 0.75f);
 	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
@@ -298,7 +298,7 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 
 void GuiInputConfig::onSizeChanged()
 {
-	mBackground.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
+	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	// update grid
 	mGrid.setSize(mSize);
@@ -353,7 +353,7 @@ void GuiInputConfig::rowDone()
 			// at bottom of list, done
 			mConfiguringAll = false;
 			mConfiguringRow = false;
-			mGrid.moveCursor(Eigen::Vector2i(0, 1));
+			mGrid.moveCursor(Vector2i(0, 1));
 		}else{
 			// on another one
 			setPress(mMappings.at(mList->getCursorId()));

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -133,12 +133,10 @@ static const char* inputIcon[inputCount] =
 //MasterVolUp and MasterVolDown are also hooked up, but do not appear on this screen.
 //If you want, you can manually add them to es_input.cfg.
 
-using namespace Eigen;
-
 #define HOLD_TO_SKIP_MS 1000
 
 GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfigureAll, const std::function<void()>& okCallback) : GuiComponent(window), 
-	mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 7)), 
+	mBackground(window, ":/frame.png"), mGrid(window, Eigen::Vector2i(1, 7)), 
 	mTargetConfig(target), mHoldingInput(false), mBusyAnim(window)
 {
 	LOG(LogInfo) << "Configuring device " << target->getDeviceId() << " (" << target->getDeviceName() << ").";
@@ -153,10 +151,10 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 	addChild(&mGrid);
 
 	// 0 is a spacer row
-	mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Vector2i(0, 0), false);
+	mGrid.setEntry(std::make_shared<GuiComponent>(mWindow), Eigen::Vector2i(0, 0), false);
 
 	mTitle = std::make_shared<TextComponent>(mWindow, "CONFIGURING", Font::get(FONT_SIZE_LARGE), 0x555555FF, ALIGN_CENTER);
-	mGrid.setEntry(mTitle, Vector2i(0, 1), false, true);
+	mGrid.setEntry(mTitle, Eigen::Vector2i(0, 1), false, true);
 	
 	std::stringstream ss;
 	if(target->getDeviceId() == DEVICE_KEYBOARD)
@@ -164,15 +162,15 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 	else
 		ss << "GAMEPAD " << (target->getDeviceId() + 1);
 	mSubtitle1 = std::make_shared<TextComponent>(mWindow, strToUpper(ss.str()), Font::get(FONT_SIZE_MEDIUM), 0x555555FF, ALIGN_CENTER);
-	mGrid.setEntry(mSubtitle1, Vector2i(0, 2), false, true);
+	mGrid.setEntry(mSubtitle1, Eigen::Vector2i(0, 2), false, true);
 
 	mSubtitle2 = std::make_shared<TextComponent>(mWindow, "HOLD ANY BUTTON TO SKIP", Font::get(FONT_SIZE_SMALL), 0x99999900, ALIGN_CENTER);
-	mGrid.setEntry(mSubtitle2, Vector2i(0, 3), false, true);
+	mGrid.setEntry(mSubtitle2, Eigen::Vector2i(0, 3), false, true);
 
 	// 4 is a spacer row
 
 	mList = std::make_shared<ComponentList>(mWindow);
-	mGrid.setEntry(mList, Vector2i(0, 5), true, true);
+	mGrid.setEntry(mList, Eigen::Vector2i(0, 5), true, true);
 	for(int i = 0; i < inputCount; i++)
 	{
 		ComponentListRow row;
@@ -292,7 +290,7 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 		}
 	}));
 	mButtonGrid = makeButtonGrid(mWindow, buttons);
-	mGrid.setEntry(mButtonGrid, Vector2i(0, 6), true, false);
+	mGrid.setEntry(mButtonGrid, Eigen::Vector2i(0, 6), true, false);
 
 	setSize(Renderer::getScreenWidth() * 0.6f, Renderer::getScreenHeight() * 0.75f);
 	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
@@ -300,7 +298,7 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 
 void GuiInputConfig::onSizeChanged()
 {
-	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
+	mBackground.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
 
 	// update grid
 	mGrid.setSize(mSize);
@@ -355,7 +353,7 @@ void GuiInputConfig::rowDone()
 			// at bottom of list, done
 			mConfiguringAll = false;
 			mConfiguringRow = false;
-			mGrid.moveCursor(Vector2i(0, 1));
+			mGrid.moveCursor(Eigen::Vector2i(0, 1));
 		}else{
 			// on another one
 			setPress(mMappings.at(mList->getCursorId()));

--- a/es-core/src/guis/GuiMsgBox.cpp
+++ b/es-core/src/guis/GuiMsgBox.cpp
@@ -12,13 +12,13 @@ GuiMsgBox::GuiMsgBox(Window* window, const std::string& text,
 	const std::string& name1, const std::function<void()>& func1,
 	const std::string& name2, const std::function<void()>& func2, 
 	const std::string& name3, const std::function<void()>& func3) : GuiComponent(window), 
-	mBackground(window, ":/frame.png"), mGrid(window, Eigen::Vector2i(1, 2))
+	mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 2))
 {
 	float width = Renderer::getScreenWidth() * 0.6f; // max width
 	float minWidth = Renderer::getScreenWidth() * 0.3f; // minimum width
 
 	mMsg = std::make_shared<TextComponent>(mWindow, text, Font::get(FONT_SIZE_MEDIUM), 0x777777FF, ALIGN_CENTER);
-	mGrid.setEntry(mMsg, Eigen::Vector2i(0, 0), false, false);
+	mGrid.setEntry(mMsg, Vector2i(0, 0), false, false);
 
 	// create the buttons
 	mButtons.push_back(std::make_shared<ButtonComponent>(mWindow, name1, name1, std::bind(&GuiMsgBox::deleteMeAndCall, this, func1)));
@@ -44,7 +44,7 @@ GuiMsgBox::GuiMsgBox(Window* window, const std::string& text,
 
 	// put the buttons into a ComponentGrid
 	mButtonGrid = makeButtonGrid(mWindow, mButtons);
-	mGrid.setEntry(mButtonGrid, Eigen::Vector2i(0, 1), true, false, Eigen::Vector2i(1, 1), GridFlags::BORDER_TOP);
+	mGrid.setEntry(mButtonGrid, Vector2i(0, 1), true, false, Vector2i(1, 1), GridFlags::BORDER_TOP);
 
 	// decide final width
 	if(mMsg->getSize().x() < width && mButtonGrid->getSize().x() < width)
@@ -94,7 +94,7 @@ void GuiMsgBox::onSizeChanged()
 	mMsg->setSize(mSize.x() - HORIZONTAL_PADDING_PX*2, mGrid.getRowHeight(0));
 	mGrid.onSizeChanged();
 
-	mBackground.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
+	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 }
 
 void GuiMsgBox::deleteMeAndCall(const std::function<void()>& func)

--- a/es-core/src/guis/GuiTextEditPopup.cpp
+++ b/es-core/src/guis/GuiTextEditPopup.cpp
@@ -3,7 +3,7 @@
 
 GuiTextEditPopup::GuiTextEditPopup(Window* window, const std::string& title, const std::string& initValue, 
 	const std::function<void(const std::string&)>& okCallback, bool multiLine, const char* acceptBtnText)
-	: GuiComponent(window), mBackground(window, ":/frame.png"), mGrid(window, Eigen::Vector2i(1, 3)), mMultiLine(multiLine)
+	: GuiComponent(window), mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 3)), mMultiLine(multiLine)
 {
 	addChild(&mBackground);
 	addChild(&mGrid);
@@ -22,9 +22,9 @@ GuiTextEditPopup::GuiTextEditPopup(Window* window, const std::string& title, con
 
 	mButtonGrid = makeButtonGrid(mWindow, buttons);
 
-	mGrid.setEntry(mTitle, Eigen::Vector2i(0, 0), false, true);
-	mGrid.setEntry(mText, Eigen::Vector2i(0, 1), true, false, Eigen::Vector2i(1, 1), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
-	mGrid.setEntry(mButtonGrid, Eigen::Vector2i(0, 2), true, false);
+	mGrid.setEntry(mTitle, Vector2i(0, 0), false, true);
+	mGrid.setEntry(mText, Vector2i(0, 1), true, false, Vector2i(1, 1), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
+	mGrid.setEntry(mButtonGrid, Vector2i(0, 2), true, false);
 
 	float textHeight = mText->getFont()->getHeight();
 	if(multiLine)
@@ -37,7 +37,7 @@ GuiTextEditPopup::GuiTextEditPopup(Window* window, const std::string& title, con
 
 void GuiTextEditPopup::onSizeChanged()
 {
-	mBackground.fitTo(mSize, Eigen::Vector3f::Zero(), Eigen::Vector2f(-32, -32));
+	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
 
 	mText->setSize(mSize.x() - 40, mText->getSize().y());
 

--- a/es-core/src/guis/GuiTextEditPopup.cpp
+++ b/es-core/src/guis/GuiTextEditPopup.cpp
@@ -1,11 +1,9 @@
 #include "guis/GuiTextEditPopup.h"
 #include "components/MenuComponent.h"
 
-using namespace Eigen;
-
 GuiTextEditPopup::GuiTextEditPopup(Window* window, const std::string& title, const std::string& initValue, 
 	const std::function<void(const std::string&)>& okCallback, bool multiLine, const char* acceptBtnText)
-	: GuiComponent(window), mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 3)), mMultiLine(multiLine)
+	: GuiComponent(window), mBackground(window, ":/frame.png"), mGrid(window, Eigen::Vector2i(1, 3)), mMultiLine(multiLine)
 {
 	addChild(&mBackground);
 	addChild(&mGrid);
@@ -24,9 +22,9 @@ GuiTextEditPopup::GuiTextEditPopup(Window* window, const std::string& title, con
 
 	mButtonGrid = makeButtonGrid(mWindow, buttons);
 
-	mGrid.setEntry(mTitle, Vector2i(0, 0), false, true);
-	mGrid.setEntry(mText, Vector2i(0, 1), true, false, Vector2i(1, 1), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
-	mGrid.setEntry(mButtonGrid, Vector2i(0, 2), true, false);
+	mGrid.setEntry(mTitle, Eigen::Vector2i(0, 0), false, true);
+	mGrid.setEntry(mText, Eigen::Vector2i(0, 1), true, false, Eigen::Vector2i(1, 1), GridFlags::BORDER_TOP | GridFlags::BORDER_BOTTOM);
+	mGrid.setEntry(mButtonGrid, Eigen::Vector2i(0, 2), true, false);
 
 	float textHeight = mText->getFont()->getHeight();
 	if(multiLine)

--- a/es-core/src/math/CommaInitializer.h
+++ b/es-core/src/math/CommaInitializer.h
@@ -1,0 +1,33 @@
+#ifndef _COMMAINITIALIZER_H_
+#define _COMMAINITIALIZER_H_
+
+#include <assert.h>
+
+template<typename T, typename S>
+struct CommaInitializer
+{
+	CommaInitializer(T& t, const S& s) : mT(t), mIndex(1)
+	{
+		mT[0] = s;
+	}
+
+	~CommaInitializer()
+	{
+		assert(mIndex == T::Size() && "Too few values passed to operator<<");
+	}
+
+	CommaInitializer& operator,(const S& s)
+	{
+		assert(mIndex < T::Size() && "Too many values passed to operator<<");
+		
+		if(mIndex < T::Size())
+			mT[mIndex++] = s;
+
+		return *this;
+	}
+
+	T& mT;
+	size_t mIndex;
+};
+
+#endif

--- a/es-core/src/math/Math.h
+++ b/es-core/src/math/Math.h
@@ -1,0 +1,9 @@
+#ifndef _MATH_H_
+#define _MATH_H_
+
+#include "Matrix4x4.h"
+#include "Vector4.h"
+#include "Vector3.h"
+#include "Vector2.h"
+
+#endif

--- a/es-core/src/math/Matrix4x4.h
+++ b/es-core/src/math/Matrix4x4.h
@@ -1,0 +1,169 @@
+#ifndef _MATRIX4X4_H_
+#define _MATRIX4X4_H_
+
+#include <assert.h>
+#include <math/Vector4.h>
+#include <math/Vector3.h>
+
+namespace Eigen {
+
+template<typename S>
+class Matrix4x4
+{
+public:
+
+	typedef Matrix4x4<S> M;
+
+	Matrix4x4() { }
+	Matrix4x4(const Vector4<S> x, const Vector4<S> y, const Vector4<S> z, const Vector4<S> w) : mX(x), mY(y), mZ(z), mW(w) { };
+
+	const bool operator==(const M& other) const { return ((mX == other.x()) && (mY == other.y()) && (mZ == other.z()) && (mW == other.w())); }
+	const bool operator!=(const M& other) const { return ((mX != other.x()) || (mY != other.y()) || (mZ != other.z()) || (mW != other.w())); }
+
+	const M operator+(const M& other) const { return { mX + other.x(), mY + other.y(), mZ + other.z(), mW + other.w() }; }
+	const M operator-(const M& other) const { return { mX - other.x(), mY - other.y(), mZ - other.z(), mW - other.w() }; }
+
+	const M operator*(const M& other) const
+	{
+		return
+		{
+			{ other.x() * mX.x() + other.y() * mX.y() + other.z() * mX.z() + other.w() * mX.w() },
+			{ other.x() * mY.x() + other.y() * mY.y() + other.z() * mY.z() + other.w() * mY.w() },
+			{ other.x() * mZ.x() + other.y() * mZ.y() + other.z() * mZ.z() + other.w() * mZ.w() },
+			{ other.x() * mW.x() + other.y() * mW.y() + other.z() * mW.z() + other.w() * mW.w() },
+		};
+	}
+
+	const Vector3<S> operator*(const Vector3<S>& other) const
+	{
+		return
+		{
+			other.x() * mX.x() + other.y() * mY.x() + other.z() * mZ.x() + mW.x(),
+			other.x() * mX.y() + other.y() * mY.y() + other.z() * mZ.y() + mW.y(),
+			other.x() * mX.z() + other.y() * mY.z() + other.z() * mZ.z() + mW.z(),
+		};
+	}
+
+	M& operator+=(const M& other) { *this = *this + other; return *this; }
+	M& operator-=(const M& other) { *this = *this - other; return *this; }
+	M& operator*=(const M& other) { *this = *this * other; return *this; }
+
+	S& operator[](const size_t index) { assert(index < Size() && "index out of range"); return mV[index]; }
+	const S& operator[](const size_t index) const { assert(index < Size() && "index out of range"); return mV[index]; }
+
+	CommaInitializer<M, S> M::operator<<(const S& s) { return CommaInitializer<M, S>(*this, s); }
+
+	Vector4<S>& x() { return mX; }
+	Vector4<S>& y() { return mY; }
+	Vector4<S>& z() { return mZ; }
+	Vector4<S>& w() { return mW; }
+	const Vector4<S>& x() const { return mX; }
+	const Vector4<S>& y() const { return mY; }
+	const Vector4<S>& z() const { return mZ; }
+	const Vector4<S>& w() const { return mW; }
+
+	S* data() { return (S*)this; }
+	const S* data() const { return (S*)this; }
+
+	Vector3<S>& translation() { return mW.v3(); }
+	const Vector3<S>& translation() const { return mW.v3(); }
+
+	M& scale(const Vector3<S>& scale)
+	{
+		mX.v3() *= scale;
+		mY.v3() *= scale;
+		mZ.v3() *= scale;
+		mW.v3() *= scale;
+
+		return *this;
+	}
+
+	M& rotate(const S angle, const Vector3<S>& axis)
+	{
+		const S pi = (S)3.1415926535897932384626433832795028841971693993751058209749445923;
+		const S	a  = -angle * (pi / 180);
+		const S	s  = sin(a);
+		const S	c  = cos(a);
+		const S	t  = 1 - c;
+		const S	x  = axis.x();
+		const S	y  = axis.y();
+		const S	z  = axis.z();
+		const S	tx = t * x;
+		const S	ty = t * y;
+		const S	tz = t * z;
+		const S	sx = s * x;
+		const S	sy = s * y;
+		const S	sz = s * z;
+		const Vector3<S> nx(tx * x + c,  tx * y - sz, tx * z + sy );
+		const Vector3<S> ny(ty * x + sz, ty * y + c,  ty * z - sy );
+		const Vector3<S> nz(tz * x - sy, tz * y + sx, tz * z + c  );
+
+		mX.v3() = nx * mX.x() + ny * mX.y() + nz * mX.z();
+		mY.v3() = nx * mY.x() + ny * mY.y() + nz * mY.z();
+		mZ.v3() = nx * mZ.x() + ny * mZ.y() + nz * mZ.z();
+		mW.v3() = nx * mW.x() + ny * mW.y() + nz * mW.z();
+
+		return *this;
+	}
+
+	M& translate(const Vector3<S>& translation)
+	{
+		mX.v3() += translation * mX.w();
+		mY.v3() += translation * mY.w();
+		mZ.v3() += translation * mZ.w();
+		mW.v3() += translation * mW.w();
+
+		return *this;
+	}
+
+	M& invert(const M& other)
+	{
+		mX     = { other.x().x(), other.y().x(), other.z().x(), 0 };
+		mY     = { other.x().y(), other.y().y(), other.z().y(), 0 };
+		mZ     = { other.x().z(), other.y().z(), other.z().z(), 0 };
+		mW.x() = -( other.w().x() * mX.x() + other.w().y() * mY.x() + other.w().z() * mZ.x() );
+		mW.y() = -( other.w().x() * mX.y() + other.w().y() * mY.y() + other.w().z() * mZ.y() );
+		mW.z() = -( other.w().x() * mX.z() + other.w().y() * mY.z() + other.w().z() * mZ.z() );
+		mW.w() = 1;
+
+		return *this;
+	}
+
+	M& invert()
+	{
+		return invert(M(*this));
+	}
+
+	M inverse()
+	{
+		M m;
+		m.invert(*this);
+
+		return m;
+	}
+
+	static const size_t Size() { return 16; }
+	static const M Identity() { return { { 1, 0, 0, 0 }, { 0, 1, 0, 0 }, { 0, 0, 1, 0 }, { 0, 0, 0, 1 } }; }
+
+private:
+
+	union
+	{
+		struct { Vector4<S> mX; Vector4<S> mY; Vector4<S> mZ; Vector4<S> mW; };
+		S mM[16];
+	};
+};
+
+typedef Matrix4x4<bool>   Matrix4x4b;
+typedef Matrix4x4<int>    Matrix4x4i;
+typedef Matrix4x4<float>  Matrix4x4f;
+typedef Matrix4x4<double> Matrix4x4d;
+
+typedef Matrix4x4<bool>   Affine3b;
+typedef Matrix4x4<int>    Affine3i;
+typedef Matrix4x4<float>  Affine3f;
+typedef Matrix4x4<double> Affine3d;
+
+}
+
+#endif

--- a/es-core/src/math/Matrix4x4.h
+++ b/es-core/src/math/Matrix4x4.h
@@ -157,9 +157,4 @@ typedef Matrix4x4<int>    Matrix4x4i;
 typedef Matrix4x4<float>  Matrix4x4f;
 typedef Matrix4x4<double> Matrix4x4d;
 
-typedef Matrix4x4<bool>   Affine3b;
-typedef Matrix4x4<int>    Affine3i;
-typedef Matrix4x4<float>  Affine3f;
-typedef Matrix4x4<double> Affine3d;
-
 #endif

--- a/es-core/src/math/Matrix4x4.h
+++ b/es-core/src/math/Matrix4x4.h
@@ -5,8 +5,6 @@
 #include <math/Vector4.h>
 #include <math/Vector3.h>
 
-namespace Eigen {
-
 template<typename S>
 class Matrix4x4
 {
@@ -48,8 +46,8 @@ public:
 	M& operator-=(const M& other) { *this = *this - other; return *this; }
 	M& operator*=(const M& other) { *this = *this * other; return *this; }
 
-	S& operator[](const size_t index) { assert(index < Size() && "index out of range"); return mV[index]; }
-	const S& operator[](const size_t index) const { assert(index < Size() && "index out of range"); return mV[index]; }
+	S& operator[](const size_t index) { assert(index < Size() && "index out of range"); return mM[index]; }
+	const S& operator[](const size_t index) const { assert(index < Size() && "index out of range"); return mM[index]; }
 
 	CommaInitializer<M, S> M::operator<<(const S& s) { return CommaInitializer<M, S>(*this, s); }
 
@@ -163,7 +161,5 @@ typedef Matrix4x4<bool>   Affine3b;
 typedef Matrix4x4<int>    Affine3i;
 typedef Matrix4x4<float>  Affine3f;
 typedef Matrix4x4<double> Affine3d;
-
-}
 
 #endif

--- a/es-core/src/math/Vector2.h
+++ b/es-core/src/math/Vector2.h
@@ -4,8 +4,6 @@
 #include <assert.h>
 #include "math/CommaInitializer.h"
 
-namespace Eigen {
-
 template<typename S>
 class Vector2
 {
@@ -78,7 +76,5 @@ typedef Vector2<bool>   Vector2b;
 typedef Vector2<int>    Vector2i;
 typedef Vector2<float>  Vector2f;
 typedef Vector2<double> Vector2d;
-
-}
 
 #endif

--- a/es-core/src/math/Vector2.h
+++ b/es-core/src/math/Vector2.h
@@ -1,0 +1,84 @@
+#ifndef _VECTOR2_H_
+#define _VECTOR2_H_
+
+#include <assert.h>
+#include "math/CommaInitializer.h"
+
+namespace Eigen {
+
+template<typename S>
+class Vector2
+{
+public:
+
+	typedef Vector2<S> V;
+
+	Vector2() { }
+	Vector2(const S t) : mX(t), mY(t) { };
+	Vector2(const S x, const S y) : mX(x), mY(y) { };
+
+	const bool operator==(const V& other) const { return ((mX == other.x()) && (mY == other.y())); }
+	const bool operator!=(const V& other) const { return ((mX != other.x()) || (mY != other.y())); }
+
+	const V operator+(const V& other) const { return { mX + other.x(), mY + other.y() }; }
+	const V operator-(const V& other) const { return { mX - other.x(), mY - other.y() }; }
+	const V operator*(const V& other) const { return { mX * other.x(), mY * other.y() }; }
+	const V operator/(const V& other) const { return { mX / other.x(), mY / other.y() }; }
+
+	const V operator+(const S& other) const { return { mX + other, mY + other }; }
+	const V operator-(const S& other) const { return { mX - other, mY - other }; }
+	const V operator*(const S& other) const { return { mX * other, mY * other }; }
+	const V operator/(const S& other) const { return { mX / other, mY / other }; }
+
+	const V operator-() const { return { -mX , -mY }; }
+
+	V& operator+=(const V& other) { *this = *this + other; return *this; }
+	V& operator-=(const V& other) { *this = *this - other; return *this; }
+	V& operator*=(const V& other) { *this = *this * other; return *this; }
+	V& operator/=(const V& other) { *this = *this / other; return *this; }
+
+	V& operator+=(const S& other) { *this = *this + other; return *this; }
+	V& operator-=(const S& other) { *this = *this - other; return *this; }
+	V& operator*=(const S& other) { *this = *this * other; return *this; }
+	V& operator/=(const S& other) { *this = *this / other; return *this; }
+
+	S& operator[](const size_t index) { assert(index < Size() && "index out of range"); return mV[index]; }
+	const S& operator[](const size_t index) const { assert(index < Size() && "index out of range"); return mV[index]; }
+
+	CommaInitializer<V, S> V::operator<<(const S& s) { return CommaInitializer<V, S>(*this, s); }
+
+	S& x() { return mX; }
+	S& y() { return mY; }
+	const S& x() const { return mX; }
+	const S& y() const { return mY; }
+
+	S* data() { return (S*)this; }
+	const S* data() const { return (S*)this; }
+
+	void set(const S x, const S y) { mX = x; mY = y; }
+	bool isZero() const { return *this == Zero(); }
+	const V cwiseProduct(const V& other) const { return *this * other; }
+	template<typename T> Vector2<T> cast() const { return Vector2<T>((T)mX, (T)mY); }
+
+	static const size_t Size() { return 2; }
+	static const V Zero() { return { 0, 0 }; }
+	static const V UnitX() { return { 1, 0 }; }
+	static const V UnitY() { return { 0, 1 }; }
+
+private:
+
+	union
+	{
+		struct { S mX; S mY; };
+		S mV[2];
+	};
+};
+
+typedef Vector2<bool>   Vector2b;
+typedef Vector2<int>    Vector2i;
+typedef Vector2<float>  Vector2f;
+typedef Vector2<double> Vector2d;
+
+}
+
+#endif

--- a/es-core/src/math/Vector3.h
+++ b/es-core/src/math/Vector3.h
@@ -1,0 +1,87 @@
+#ifndef _VECTOR3_H_
+#define _VECTOR3_H_
+
+#include <assert.h>
+#include "math/CommaInitializer.h"
+
+namespace Eigen {
+
+template<typename S>
+class Vector3
+{
+public:
+
+	typedef Vector3<S> V;
+
+	Vector3() { }
+	Vector3(const S t) : mX(t), mY(t), mZ(t) { };
+	Vector3(const S x, const S y, const S z) : mX(x), mY(y), mZ(z) { };
+
+	const bool operator==(const V& other) const { return ((mX == other.x()) && (mY == other.y()) && (mZ == other.z())); }
+	const bool operator!=(const V& other) const { return ((mX != other.x()) || (mY != other.y()) || (mZ != other.z())); }
+
+	const V operator+(const V& other) const { return { mX + other.x(), mY + other.y(), mZ + other.z() }; }
+	const V operator-(const V& other) const { return { mX - other.x(), mY - other.y(), mZ - other.z() }; }
+	const V operator*(const V& other) const { return { mX * other.x(), mY * other.y(), mZ * other.z() }; }
+	const V operator/(const V& other) const { return { mX / other.x(), mY / other.y(), mZ / other.z() }; }
+
+	const V operator+(const S& other) const { return { mX + other, mY + other, mZ + other }; }
+	const V operator-(const S& other) const { return { mX - other, mY - other, mZ - other }; }
+	const V operator*(const S& other) const { return { mX * other, mY * other, mZ * other }; }
+	const V operator/(const S& other) const { return { mX / other, mY / other, mZ / other }; }
+
+	const V operator-() const { return { -mX , -mY, -mZ }; }
+
+	V& operator+=(const V& other) { *this = *this + other; return *this; }
+	V& operator-=(const V& other) { *this = *this - other; return *this; }
+	V& operator*=(const V& other) { *this = *this * other; return *this; }
+	V& operator/=(const V& other) { *this = *this / other; return *this; }
+
+	V& operator+=(const S& other) { *this = *this + other; return *this; }
+	V& operator-=(const S& other) { *this = *this - other; return *this; }
+	V& operator*=(const S& other) { *this = *this * other; return *this; }
+	V& operator/=(const S& other) { *this = *this / other; return *this; }
+
+	S& operator[](const size_t index) { assert(index < Size() && "index out of range"); return mV[index]; }
+	const S& operator[](const size_t index) const { assert(index < Size() && "index out of range"); return mV[index]; }
+
+	CommaInitializer<V, S> operator<<(const S& s) { return CommaInitializer<V, S>(*this, s); }
+
+	S& x() { return mX; }
+	S& y() { return mY; }
+	S& z() { return mZ; }
+	const S& x() const { return mX; }
+	const S& y() const { return mY; }
+	const S& z() const { return mZ; }
+
+	S* data() { return (S*)this; }
+	const S* data() const { return (S*)this; }
+
+	void set(const S x, const S y, const S z) { mX = x; mY = y; mZ = z; }
+	bool isZero() const { return *this == Zero(); }
+	const V cwiseProduct(const V& other) const { return *this * other; }
+	template<typename T> Vector3<T> cast() const { return Vector3<T>((T)mX, (T)mY); }
+
+	static const size_t Size() { return 3; }
+	static const V Zero() { return { 0, 0, 0 }; }
+	static const V UnitX() { return { 1, 0, 0 }; }
+	static const V UnitY() { return { 0, 1, 0 }; }
+	static const V UnitZ() { return { 0, 0, 1 }; }
+
+private:
+
+	union
+	{
+		struct { S mX; S mY; S mZ; };
+		S mV[3];
+	};
+};
+
+typedef Vector3<bool>   Vector3b;
+typedef Vector3<int>    Vector3i;
+typedef Vector3<float>  Vector3f;
+typedef Vector3<double> Vector3d;
+
+}
+
+#endif

--- a/es-core/src/math/Vector3.h
+++ b/es-core/src/math/Vector3.h
@@ -4,8 +4,6 @@
 #include <assert.h>
 #include "math/CommaInitializer.h"
 
-namespace Eigen {
-
 template<typename S>
 class Vector3
 {
@@ -81,7 +79,5 @@ typedef Vector3<bool>   Vector3b;
 typedef Vector3<int>    Vector3i;
 typedef Vector3<float>  Vector3f;
 typedef Vector3<double> Vector3d;
-
-}
 
 #endif

--- a/es-core/src/math/Vector4.h
+++ b/es-core/src/math/Vector4.h
@@ -1,0 +1,94 @@
+#ifndef _VECTOR4_H_
+#define _VECTOR4_H_
+
+#include <assert.h>
+#include "math/Vector3.h"
+#include "math/CommaInitializer.h"
+
+namespace Eigen {
+
+template<typename S>
+class Vector4
+{
+public:
+
+	typedef Vector4<S> V;
+
+	Vector4() { }
+	Vector4(const S t) : mX(t), mY(t), mZ(t), mW(t) { };
+	Vector4(const S x, const S y, const S z, const S w) : mX(x), mY(y), mZ(z), mW(w) { };
+
+	const bool operator==(const V& other) const { return ((mX == other.x()) && (mY == other.y()) && (mZ == other.z()) && (mW == other.w())); }
+	const bool operator!=(const V& other) const { return ((mX != other.x()) || (mY != other.y()) || (mZ != other.z()) || (mW != other.w())); }
+
+	const V operator+(const V& other) const { return { mX + other.x(), mY + other.y(), mZ + other.z(), mW + other.w() }; }
+	const V operator-(const V& other) const { return { mX - other.x(), mY - other.y(), mZ - other.z(), mW - other.w() }; }
+	const V operator*(const V& other) const { return { mX * other.x(), mY * other.y(), mZ * other.z(), mW * other.w() }; }
+	const V operator/(const V& other) const { return { mX / other.x(), mY / other.y(), mZ / other.z(), mW / other.w() }; }
+
+	const V operator+(const S& other) const { return { mX + other, mY + other, mZ + other, mW + other }; }
+	const V operator-(const S& other) const { return { mX - other, mY - other, mZ - other, mW - other }; }
+	const V operator*(const S& other) const { return { mX * other, mY * other, mZ * other, mW * other }; }
+	const V operator/(const S& other) const { return { mX / other, mY / other, mZ / other, mW / other }; }
+
+	const V operator-() const { return { -mX , -mY, -mZ, -mW }; }
+
+	V& operator+=(const V& other) { *this = *this + other; return *this; }
+	V& operator-=(const V& other) { *this = *this - other; return *this; }
+	V& operator*=(const V& other) { *this = *this * other; return *this; }
+	V& operator/=(const V& other) { *this = *this / other; return *this; }
+
+	V& operator+=(const S& other) { *this = *this + other; return *this; }
+	V& operator-=(const S& other) { *this = *this - other; return *this; }
+	V& operator*=(const S& other) { *this = *this * other; return *this; }
+	V& operator/=(const S& other) { *this = *this / other; return *this; }
+
+	S& operator[](const size_t index) { assert(index < Size() && "index out of range"); return mV[index]; }
+	const S& operator[](const size_t index) const { assert(index < Size() && "index out of range"); return mV[index]; }
+
+	CommaInitializer<V, S> V::operator<<(const S& t);
+
+	S& x() { return mX; }
+	S& y() { return mY; }
+	S& z() { return mZ; }
+	S& w() { return mW; }
+	const S& x() const { return mX; }
+	const S& y() const { return mY; }
+	const S& z() const { return mZ; }
+	const S& w() const { return mW; }
+
+	Vector3<S>& v3() { return *(Vector3<S>*)this; }
+	const Vector3<S>& v3() const { return *(Vector3<S>*)this; }
+
+	S* data() { return (S*)this; }
+	const S* data() const { return (S*)this; }
+
+	void set(const S x, const S y, const S z, const S w) { mX = x; mY = y; mZ = z; mW = w; }
+	bool isZero() const { return *this == Zero(); }
+	const V cwiseProduct(const V& other) const { return *this * other; }
+	template<typename T> Vector4<T> cast() const { return Vector4<T>((T)mX, (T)mY); }
+
+	static const size_t Size() { return 4; }
+	static const V Zero() { return { 0, 0, 0, 0 }; }
+	static const V UnitX() { return { 1, 0, 0, 0 }; }
+	static const V UnitY() { return { 0, 1, 0, 0 }; }
+	static const V UnitZ() { return { 0, 0, 1, 0 }; }
+	static const V UnitW() { return { 0, 0, 0, 1 }; }
+
+private:
+
+	union
+	{
+		struct { S mX; S mY; S mZ; S mW; };
+		S mV[4];
+	};
+};
+
+typedef Vector4<bool>   Vector4b;
+typedef Vector4<int>    Vector4i;
+typedef Vector4<float>  Vector4f;
+typedef Vector4<double> Vector4d;
+
+}
+
+#endif

--- a/es-core/src/math/Vector4.h
+++ b/es-core/src/math/Vector4.h
@@ -5,8 +5,6 @@
 #include "math/Vector3.h"
 #include "math/CommaInitializer.h"
 
-namespace Eigen {
-
 template<typename S>
 class Vector4
 {
@@ -88,7 +86,5 @@ typedef Vector4<bool>   Vector4b;
 typedef Vector4<int>    Vector4i;
 typedef Vector4<float>  Vector4f;
 typedef Vector4<double> Vector4d;
-
-}
 
 #endif

--- a/es-core/src/resources/Font.cpp
+++ b/es-core/src/resources/Font.cpp
@@ -254,7 +254,7 @@ Font::FontTexture::FontTexture()
 {
 	textureId = 0;
 	textureSize << 2048, 512;
-	writePos = Eigen::Vector2i::Zero();
+	writePos = Vector2i::Zero();
 	rowHeight = 0;
 }
 
@@ -263,7 +263,7 @@ Font::FontTexture::~FontTexture()
 	deinitTexture();
 }
 
-bool Font::FontTexture::findEmpty(const Eigen::Vector2i& size, Eigen::Vector2i& cursor_out)
+bool Font::FontTexture::findEmpty(const Vector2i& size, Vector2i& cursor_out)
 {
 	if(size.x() >= textureSize.x() || size.y() >= textureSize.y())
 		return false;
@@ -321,7 +321,7 @@ void Font::FontTexture::deinitTexture()
 	}
 }
 
-void Font::getTextureForNewGlyph(const Eigen::Vector2i& glyphSize, FontTexture*& tex_out, Eigen::Vector2i& cursor_out)
+void Font::getTextureForNewGlyph(const Vector2i& glyphSize, FontTexture*& tex_out, Vector2i& cursor_out)
 {
 	if(mTextures.size())
 	{
@@ -455,10 +455,10 @@ Font::Glyph* Font::getGlyph(UnicodeChar id)
 		return NULL;
 	}
 
-	Eigen::Vector2i glyphSize(g->bitmap.width, g->bitmap.rows);
+	Vector2i glyphSize(g->bitmap.width, g->bitmap.rows);
 
 	FontTexture* tex = NULL;
-	Eigen::Vector2i cursor;
+	Vector2i cursor;
 	getTextureForNewGlyph(glyphSize, tex, cursor);
 
 	// getTextureForNewGlyph can fail if the glyph is bigger than the max texture size (absurdly large font size)
@@ -512,8 +512,8 @@ void Font::rebuildTextures()
 		FontTexture* tex = it->second.texture;
 		
 		// find the position/size
-		Eigen::Vector2i cursor(it->second.texPos.x() * tex->textureSize.x(), it->second.texPos.y() * tex->textureSize.y());
-		Eigen::Vector2i glyphSize(it->second.texSize.x() * tex->textureSize.x(), it->second.texSize.y() * tex->textureSize.y());
+		Vector2i cursor(it->second.texPos.x() * tex->textureSize.x(), it->second.texPos.y() * tex->textureSize.y());
+		Vector2i glyphSize(it->second.texSize.x() * tex->textureSize.x(), it->second.texSize.y() * tex->textureSize.y());
 		
 		// upload to texture
 		glBindTexture(GL_TEXTURE_2D, tex->textureId);
@@ -561,7 +561,7 @@ void Font::renderTextCache(TextCache* cache)
 	}
 }
 
-Eigen::Vector2f Font::sizeText(std::string text, float lineSpacing)
+Vector2f Font::sizeText(std::string text, float lineSpacing)
 {
 	float lineWidth = 0.0f;
 	float highestWidth = 0.0f;
@@ -592,7 +592,7 @@ Eigen::Vector2f Font::sizeText(std::string text, float lineSpacing)
 	if(lineWidth > highestWidth)
 		highestWidth = lineWidth;
 
-	return Eigen::Vector2f(highestWidth, y);
+	return Vector2f(highestWidth, y);
 }
 
 float Font::getHeight(float lineSpacing) const
@@ -616,7 +616,7 @@ std::string Font::wrapText(std::string text, float xLen)
 	std::string line, word, temp;
 	size_t space;
 
-	Eigen::Vector2f textSize;
+	Vector2f textSize;
 
 	while(text.length() > 0) //while there's text or we still have text to render
 	{
@@ -649,13 +649,13 @@ std::string Font::wrapText(std::string text, float xLen)
 	return out;
 }
 
-Eigen::Vector2f Font::sizeWrappedText(std::string text, float xLen, float lineSpacing)
+Vector2f Font::sizeWrappedText(std::string text, float xLen, float lineSpacing)
 {
 	text = wrapText(text, xLen);
 	return sizeText(text, lineSpacing);
 }
 
-Eigen::Vector2f Font::getWrappedTextCursorOffset(std::string text, float xLen, size_t stop, float lineSpacing)
+Vector2f Font::getWrappedTextCursorOffset(std::string text, float xLen, size_t stop, float lineSpacing)
 {
 	std::string wrappedText = wrapText(text, xLen);
 
@@ -692,7 +692,7 @@ Eigen::Vector2f Font::getWrappedTextCursorOffset(std::string text, float xLen, s
 			lineWidth += glyph->advance.x();
 	}
 
-	return Eigen::Vector2f(lineWidth, y);
+	return Vector2f(lineWidth, y);
 }
 
 //=============================================================================================================
@@ -725,7 +725,7 @@ inline float font_round(float v)
 	return round(v);
 }
 
-TextCache* Font::buildTextCache(const std::string& text, Eigen::Vector2f offset, unsigned int color, float xLen, Alignment alignment, float lineSpacing)
+TextCache* Font::buildTextCache(const std::string& text, Vector2f offset, unsigned int color, float xLen, Alignment alignment, float lineSpacing)
 {
 	float x = offset[0] + (xLen != 0 ? getNewlineStartOffset(text, 0, xLen, alignment) : 0);
 	
@@ -765,7 +765,7 @@ TextCache* Font::buildTextCache(const std::string& text, Eigen::Vector2f offset,
 
 		const float glyphStartX = x + glyph->bearing.x();
 
-		const Eigen::Vector2i& textureSize = glyph->texture->textureSize;
+		const Vector2i& textureSize = glyph->texture->textureSize;
 
 		// triangle 1
 		// round to fix some weird "cut off" text bugs
@@ -819,7 +819,7 @@ TextCache* Font::buildTextCache(const std::string& text, Eigen::Vector2f offset,
 
 TextCache* Font::buildTextCache(const std::string& text, float offsetX, float offsetY, unsigned int color)
 {
-	return buildTextCache(text, Eigen::Vector2f(offsetX, offsetY), color, 0.0f);
+	return buildTextCache(text, Vector2f(offsetX, offsetY), color, 0.0f);
 }
 
 void TextCache::setColor(unsigned int color)

--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -40,14 +40,14 @@ public:
 
 	virtual ~Font();
 
-	Eigen::Vector2f sizeText(std::string text, float lineSpacing = 1.5f); // Returns the expected size of a string when rendered.  Extra spacing is applied to the Y axis.
+	Vector2f sizeText(std::string text, float lineSpacing = 1.5f); // Returns the expected size of a string when rendered.  Extra spacing is applied to the Y axis.
 	TextCache* buildTextCache(const std::string& text, float offsetX, float offsetY, unsigned int color);
-	TextCache* buildTextCache(const std::string& text, Eigen::Vector2f offset, unsigned int color, float xLen, Alignment alignment = ALIGN_LEFT, float lineSpacing = 1.5f);
+	TextCache* buildTextCache(const std::string& text, Vector2f offset, unsigned int color, float xLen, Alignment alignment = ALIGN_LEFT, float lineSpacing = 1.5f);
 	void renderTextCache(TextCache* cache);
 	
 	std::string wrapText(std::string text, float xLen); // Inserts newlines into text to make it wrap properly.
-	Eigen::Vector2f sizeWrappedText(std::string text, float xLen, float lineSpacing = 1.5f); // Returns the expected size of a string after wrapping is applied.
-	Eigen::Vector2f getWrappedTextCursorOffset(std::string text, float xLen, size_t cursor, float lineSpacing = 1.5f); // Returns the position of of the cursor after moving "cursor" characters.
+	Vector2f sizeWrappedText(std::string text, float xLen, float lineSpacing = 1.5f); // Returns the expected size of a string after wrapping is applied.
+	Vector2f getWrappedTextCursorOffset(std::string text, float xLen, size_t cursor, float lineSpacing = 1.5f); // Returns the position of of the cursor after moving "cursor" characters.
 
 	float getHeight(float lineSpacing = 1.5f) const;
 	float getLetterHeight();
@@ -80,14 +80,14 @@ private:
 	struct FontTexture
 	{
 		GLuint textureId;
-		Eigen::Vector2i textureSize;
+		Vector2i textureSize;
 
-		Eigen::Vector2i writePos;
+		Vector2i writePos;
 		int rowHeight;
 
 		FontTexture();
 		~FontTexture();
-		bool findEmpty(const Eigen::Vector2i& size, Eigen::Vector2i& cursor_out);
+		bool findEmpty(const Vector2i& size, Vector2i& cursor_out);
 
 		// you must call initTexture() after creating a FontTexture to get a textureId
 		void initTexture(); // initializes the OpenGL texture according to this FontTexture's settings, updating textureId
@@ -108,7 +108,7 @@ private:
 
 	std::vector<FontTexture> mTextures;
 
-	void getTextureForNewGlyph(const Eigen::Vector2i& glyphSize, FontTexture*& tex_out, Eigen::Vector2i& cursor_out);
+	void getTextureForNewGlyph(const Vector2i& glyphSize, FontTexture*& tex_out, Vector2i& cursor_out);
 
 	std::map< unsigned int, std::unique_ptr<FontFace> > mFaceCache;
 	FT_Face getFaceForChar(UnicodeChar id);
@@ -118,11 +118,11 @@ private:
 	{
 		FontTexture* texture;
 		
-		Eigen::Vector2f texPos;
-		Eigen::Vector2f texSize; // in texels!
+		Vector2f texPos;
+		Vector2f texSize; // in texels!
 
-		Eigen::Vector2f advance;
-		Eigen::Vector2f bearing;
+		Vector2f advance;
+		Vector2f bearing;
 	};
 
 	std::map<UnicodeChar, Glyph> mGlyphMap;
@@ -148,8 +148,8 @@ class TextCache
 protected:
 	struct Vertex
 	{
-		Eigen::Vector2f pos;
-		Eigen::Vector2f tex;
+		Vector2f pos;
+		Vector2f tex;
 	};
 
 	struct VertexList
@@ -164,7 +164,7 @@ protected:
 public:
 	struct CacheMetrics
 	{
-		Eigen::Vector2f size;
+		Vector2f size;
 	} metrics;
 
 	void setColor(unsigned int color);

--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -5,7 +5,6 @@
 #include GLHEADER
 #include <ft2build.h>
 #include FT_FREETYPE_H
-#include <Eigen/Dense>
 #include "resources/ResourceManager.h"
 #include "ThemeData.h"
 

--- a/es-core/src/resources/TextureResource.cpp
+++ b/es-core/src/resources/TextureResource.cpp
@@ -78,7 +78,7 @@ void TextureResource::initFromMemory(const char* data, size_t length)
 	mSourceSize << mTextureData->sourceWidth(), mTextureData->sourceHeight();
 }
 
-const Eigen::Vector2i TextureResource::getSize() const
+const Vector2i TextureResource::getSize() const
 {
 	return mSize;
 }
@@ -163,7 +163,7 @@ void TextureResource::rasterizeAt(size_t width, size_t height)
 		data->load();
 }
 
-Eigen::Vector2f TextureResource::getSourceImageSize() const
+Vector2f TextureResource::getSourceImageSize() const
 {
 	return mSourceSize;
 }

--- a/es-core/src/resources/TextureResource.h
+++ b/es-core/src/resources/TextureResource.h
@@ -22,14 +22,14 @@ public:
 
 	// For scalable source images in textures we want to set the resolution to rasterize at
 	void rasterizeAt(size_t width, size_t height);
-	Eigen::Vector2f getSourceImageSize() const;
+	Vector2f getSourceImageSize() const;
 
 	virtual ~TextureResource();
 
 	bool isInitialized() const;
 	bool isTiled() const;
 
-	const Eigen::Vector2i getSize() const;
+	const Vector2i getSize() const;
 	bool bind();
 
 	static size_t getTotalMemUsage(); // returns an approximation of total VRAM used by textures (in bytes)
@@ -48,8 +48,8 @@ private:
 	// The texture data manager manages loading and unloading of filesystem based textures
 	static TextureDataManager		sTextureDataManager;
 
-	Eigen::Vector2i					mSize;
-	Eigen::Vector2f					mSourceSize;
+	Vector2i					mSize;
+	Vector2f					mSourceSize;
 	bool							mForceLoad;
 
 	typedef std::pair<std::string, bool> TextureKeyType;

--- a/es-core/src/resources/TextureResource.h
+++ b/es-core/src/resources/TextureResource.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <set>
 #include <list>
-#include <Eigen/Dense>
+#include "math/Math.h"
 #include "platform.h"
 #include "resources/TextureData.h"
 #include "resources/TextureDataManager.h"


### PR DESCRIPTION
This patch removes Eigen as a dependency. Eigen itself is a quite large library with a lot of optimized math functions, which ES uses none at all. The few things it does use has no benefits of the optimizations that Eigen can do. These 5 classes replace the few pieces that ES actually use at a much smaller footprint and way simpler (and potentially faster) code. Where Eigen is a maze of templates and inheritance this is simple and straightforward.

As an added bonus this also drops the compile time by about 30%.