### PR TITLE
Pi: use vsync by default and fix vsync on case

### DIFF
--- a/es-core/src/Renderer_init_sdlgl.cpp
+++ b/es-core/src/Renderer_init_sdlgl.cpp
@@ -105,9 +105,9 @@ namespace Renderer
 			// 1 for updates synchronized with the vertical retrace, 
 			// or -1 for late swap tearing.
 			// SDL_GL_SetSwapInterval returns 0 on success, -1 on error.
-			// if vsync is requested, try late swap tearing; if that doesn't work, try normal vsync
+			// if vsync is requested, try normal vsync; if that doesn't work, try late swap tearing
 			// if that doesn't work, report an error
-			if(SDL_GL_SetSwapInterval(-1) != 0 && SDL_GL_SetSwapInterval(1) != 0)
+			if(SDL_GL_SetSwapInterval(1) != 0 && SDL_GL_SetSwapInterval(-1) != 0)
 				LOG(LogWarning) << "Tried to enable vsync, but failed! (" << SDL_GetError() << ")";
 		}
 		else

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -49,13 +49,7 @@ void Settings::setDefaults()
 	mBoolMap["SplashScreen"] = true;
 	mStringMap["StartupSystem"] = "";
 
-#ifdef _RPI_
-	// don't enable VSync by default on the Pi, since it already
-	// has trouble trying to render things at 60fps in certain menus
-	mBoolMap["VSync"] = false;
-#else
 	mBoolMap["VSync"] = true;
-#endif
 
 	mBoolMap["EnableSounds"] = true;
 	mBoolMap["ShowHelpPrompts"] = true;


### PR DESCRIPTION
* Now that vsync off explicitly sets swap interval, it's clear that
  we've been using driver defaults (vsync on) up until now.
* Try to enable normal vsync before late swap tearing. The latter
  doesn't constrain framerate and looks basically identical to vsync
  off.