### PR TITLE
Video String Formatting Warning Fixes

### DIFF
--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -26,9 +26,7 @@ void writeSubtitle(const char* gameName, const char* systemName, bool always)
 	FILE* file = fopen(getTitlePath().c_str(), "w");
 	int end = (int)(Settings::getInstance()->getInt("ScreenSaverSwapVideoTimeout") / (1000));
 	if (always) {
-		fprintf(file, "1\n00:00:01,000 --> 00:00:");
-		fprintf(file, std::to_string(end).c_str());
-		fprintf(file, ",000\n");
+		fprintf(file, "1\n00:00:01,000 --> 00:00:%d,000\n", end);
 	}
 	else
 	{
@@ -40,13 +38,7 @@ void writeSubtitle(const char* gameName, const char* systemName, bool always)
 	if (!always) {
 		if (end > 12)
 		{
-			fprintf(file, "2\n00:00:");
-			fprintf(file, std::to_string(end - 4).c_str());
-			fprintf(file, ",000 --> 00:00:");
-			fprintf(file, std::to_string(end).c_str());
-			fprintf(file, ",000\n");
-			fprintf(file, "%s\n", gameName);
-			fprintf(file, "<i>%s</i>\n", systemName);
+			fprintf(file, "2\n00:00:%d,000 --> 00:00:%d,000\n%s\n<i>%s</i>\n", end-4, end, gameName, systemName);
 		}
 	}
 


### PR DESCRIPTION
I think this should have gotten rid of the warnings, after reading up on what caused them in the first place.

Apologies if that's not he case, as I can't reproduce the warnings on the default Pi compiler.