### PR TITLE
Add pragma once and ifndef header guards to all headers

### DIFF
--- a/es-app/src/CollectionSystemManager.h
+++ b/es-app/src/CollectionSystemManager.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_COLLECTION_SYSTEM_MANAGER_H
+#define ES_APP_COLLECTION_SYSTEM_MANAGER_H
 
 #include <vector>
 #include <string>
@@ -113,3 +115,5 @@ private:
 std::string getCustomCollectionConfigPath(std::string collectionName);
 std::string getCollectionsFolder();
 bool systemSort(SystemData* sys1, SystemData* sys2);
+
+#endif // ES_APP_COLLECTION_SYSTEM_MANAGER_H

--- a/es-app/src/EmulationStation.h
+++ b/es-app/src/EmulationStation.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_EMULATION_STATION_H
+#define ES_APP_EMULATION_STATION_H
 
 // These numbers and strings need to be manually updated for a new version.
 // Do this version number update as the very last commit for the new release version.
@@ -11,3 +13,5 @@
 
 #define RESOURCE_VERSION_STRING "2,6,5\0"
 #define RESOURCE_VERSION PROGRAM_VERSION_MAJOR,PROGRAM_VERSION_MINOR,PROGRAM_VERSION_MAINTENANCE
+
+#endif // ES_APP_EMULATION_STATION_H

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_FILE_DATA_H
+#define ES_APP_FILE_DATA_H
 
 #include <unordered_map>
 #include <string>
@@ -118,3 +120,5 @@ private:
 };
 
 FileData::SortType getSortTypeFromString(std::string desc);
+
+#endif // ES_APP_FILE_DATA_H

--- a/es-app/src/FileFilterIndex.h
+++ b/es-app/src/FileFilterIndex.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_FILE_FILTER_INDEX_H
+#define ES_APP_FILE_FILTER_INDEX_H
 
 #include <map>
 #include "FileData.h"
@@ -83,3 +85,5 @@ private:
 	FileData* mRootFolder;
 
 };
+
+#endif // ES_APP_FILE_FILTER_INDEX_H

--- a/es-app/src/FileSorts.h
+++ b/es-app/src/FileSorts.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_FILE_SORTS_H
+#define ES_APP_FILE_SORTS_H
 
 #include <vector>
 #include "FileData.h"
@@ -19,3 +21,5 @@ namespace FileSorts
 
 	extern const std::vector<FileData::SortType> SortTypes;
 };
+
+#endif // ES_APP_FILE_SORTS_H

--- a/es-app/src/Gamelist.h
+++ b/es-app/src/Gamelist.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_GAME_LIST_H
+#define ES_APP_GAME_LIST_H
 
 class SystemData;
 
@@ -7,3 +9,5 @@ void parseGamelist(SystemData* system);
 
 // Writes currently loaded metadata for a SystemData to gamelist.xml.
 void updateGamelist(SystemData* system);
+
+#endif // ES_APP_GAME_LIST_H

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_META_DATA_H
+#define ES_APP_META_DATA_H
 
 #include "pugixml/src/pugixml.hpp"
 #include <string>
@@ -70,3 +72,5 @@ private:
 	std::map<std::string, std::string> mMap;
 	bool mWasChanged;
 };
+
+#endif // ES_APP_META_DATA_H

--- a/es-app/src/PlatformId.h
+++ b/es-app/src/PlatformId.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_PLATFORM_ID_H
+#define ES_APP_PLATFORM_ID_H
 
 #include <map>
 
@@ -80,3 +82,5 @@ namespace PlatformIds
 
 	const char* getCleanMameName(const char* from);
 }
+
+#endif // ES_APP_PLATFORM_ID_H

--- a/es-app/src/ScraperCmdLine.h
+++ b/es-app/src/ScraperCmdLine.h
@@ -1,3 +1,7 @@
 #pragma once
+#ifndef ES_APP_SCRAPER_CMD_LINE_H
+#define ES_APP_SCRAPER_CMD_LINE_H
 
 int run_scraper_cmdline();
+
+#endif // ES_APP_SCRAPER_CMD_LINE_H

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_SYSTEM_DATA_H
+#define ES_APP_SYSTEM_DATA_H
 
 #include <vector>
 #include <string>
@@ -94,3 +96,5 @@ private:
 
 	FileData* mRootFolder;
 };
+
+#endif // ES_APP_SYSTEM_DATA_H

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_SYSTEM_SCREEN_SAVER_H
+#define ES_APP_SYSTEM_SCREEN_SAVER_H
 
 #include "Window.h"
 
@@ -60,3 +62,5 @@ private:
 	std::shared_ptr<Sound>	mBackgroundAudio;
 	bool			mStopBackgroundAudio;
 };
+
+#endif // ES_APP_SYSTEM_SCREEN_SAVER_H

--- a/es-app/src/VolumeControl.h
+++ b/es-app/src/VolumeControl.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_VOLUME_CONTROL_H
+#define ES_APP_VOLUME_CONTROL_H
 
 #include <memory>
 #include <stdint.h>
@@ -56,3 +58,5 @@ public:
 
 	~VolumeControl();
 };
+
+#endif // ES_APP_VOLUME_CONTROL_H

--- a/es-app/src/animations/LaunchAnimation.h
+++ b/es-app/src/animations/LaunchAnimation.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_ANIMATIONS_LAUNCH_ANIMATION_H
+#define ES_APP_ANIMATIONS_LAUNCH_ANIMATION_H
 
 #include "animations/Animation.h"
 #include "Log.h"
@@ -63,3 +65,5 @@ private:
 	Transform4x4f& cameraOut;
 	float& fadeOut;
 };
+
+#endif // ES_APP_ANIMATIONS_LAUNCH_ANIMATION_H

--- a/es-app/src/animations/MoveCameraAnimation.h
+++ b/es-app/src/animations/MoveCameraAnimation.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_ANIMATIONS_MOVE_CAMERA_ANIMATION_H
+#define ES_APP_ANIMATIONS_MOVE_CAMERA_ANIMATION_H
 
 #include "animations/Animation.h"
 
@@ -22,3 +24,5 @@ private:
 
 	Transform4x4f& cameraOut;
 };
+
+#endif // ES_APP_ANIMATIONS_MOVE_CAMERA_ANIMATION_H

--- a/es-app/src/components/AsyncReqComponent.h
+++ b/es-app/src/components/AsyncReqComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_COMPONENTS_ASYNC_REQ_COMPONENT_H
+#define ES_APP_COMPONENTS_ASYNC_REQ_COMPONENT_H
 
 #include "GuiComponent.h"
 #include "HttpReq.h"
@@ -43,3 +45,5 @@ private:
 	unsigned int mTime;
 	std::shared_ptr<HttpReq> mRequest;
 };
+
+#endif // ES_APP_COMPONENTS_ASYNC_REQ_COMPONENT_H

--- a/es-app/src/components/RatingComponent.h
+++ b/es-app/src/components/RatingComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_COMPONENTS_RATING_COMPONENT_H
+#define ES_APP_COMPONENTS_RATING_COMPONENT_H
 
 #include "GuiComponent.h"
 #include "resources/TextureResource.h"
@@ -53,3 +55,4 @@ private:
 	std::shared_ptr<TextureResource> mUnfilledTexture;
 };
 
+#endif // ES_APP_COMPONENTS_RATING_COMPONENT_H

--- a/es-app/src/components/ScraperSearchComponent.h
+++ b/es-app/src/components/ScraperSearchComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_COMPONENTS_SCRAPER_SEARCH_COMPONENT_H
+#define ES_APP_COMPONENTS_SCRAPER_SEARCH_COMPONENT_H
 
 #include "GuiComponent.h"
 #include "scrapers/Scraper.h"
@@ -102,3 +104,5 @@ private:
 
 	BusyComponent mBusyAnim;
 };
+
+#endif // ES_APP_COMPONENTS_SCRAPER_SEARCH_COMPONENT_H

--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_COMPONENTS_TEXT_LIST_COMPONENT_H
+#define ES_APP_COMPONENTS_TEXT_LIST_COMPONENT_H
 
 #include "components/IList.h"
 #include "Renderer.h"
@@ -405,3 +407,5 @@ void TextListComponent<T>::applyTheme(const std::shared_ptr<ThemeData>& theme, c
 		mSelectorImage.setImage("");
 	}
 }
+
+#endif // ES_APP_COMPONENTS_TEXT_LIST_COMPONENT_H

--- a/es-app/src/guis/GuiCollectionSystemsOptions.h
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_GUIS_GUI_COLLECTION_SYSTEM_OPTIONS_H
+#define ES_APP_GUIS_GUI_COLLECTION_SYSTEM_OPTIONS_H
 
 #include "GuiComponent.h"
 #include "SystemData.h"
@@ -36,3 +38,5 @@ private:
 	MenuComponent mMenu;
 	SystemData* mSystem;
 };
+
+#endif // ES_APP_GUIS_GUI_COLLECTION_SYSTEM_OPTIONS_H

--- a/es-app/src/guis/GuiFastSelect.h
+++ b/es-app/src/guis/GuiFastSelect.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_GUIS_GUI_FAST_SELECT_H
+#define ES_APP_GUIS_GUI_FAST_SELECT_H
 
 #include "GuiComponent.h"
 #include "views/gamelist/IGameListView.h"
@@ -33,3 +35,5 @@ private:
 
 	IGameListView* mGameList;
 };
+
+#endif // ES_APP_GUIS_GUI_FAST_SELECT_H

--- a/es-app/src/guis/GuiGameScraper.h
+++ b/es-app/src/guis/GuiGameScraper.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_GUIS_GUI_GAME_SCRAPER_H
+#define ES_APP_GUIS_GUI_GAME_SCRAPER_H
 
 #include "GuiComponent.h"
 #include "components/ScraperSearchComponent.h"
@@ -31,3 +33,5 @@ private:
 
 	std::function<void()> mCancelFunc;
 };
+
+#endif // ES_APP_GUIS_GUI_GAME_SCRAPER_H

--- a/es-app/src/guis/GuiGamelistFilter.h
+++ b/es-app/src/guis/GuiGamelistFilter.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_GUIS_GUI_GAME_LIST_FILTER_H
+#define ES_APP_GUIS_GUI_GAME_LIST_FILTER_H
 
 #include "GuiComponent.h"
 #include "SystemData.h"
@@ -32,3 +34,5 @@ private:
 	SystemData* mSystem;
 	FileFilterIndex* mFilterIndex;
 };
+
+#endif // ES_APP_GUIS_GUI_GAME_LIST_FILTER_H

--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef ES_APP_GUIS_GUI_GAME_LIST_OPTIONS_H
+#define ES_APP_GUIS_GUI_GAME_LIST_OPTIONS_H
+
 #include "GuiComponent.h"
 #include "components/MenuComponent.h"
 #include "components/OptionListComponent.h"
@@ -36,3 +40,5 @@ private:
 	bool fromPlaceholder;
 	bool mFiltersChanged;
 };
+
+#endif // ES_APP_GUIS_GUI_GAME_LIST_OPTIONS_H

--- a/es-app/src/guis/GuiGeneralScreensaverOptions.h
+++ b/es-app/src/guis/GuiGeneralScreensaverOptions.h
@@ -1,5 +1,6 @@
-#ifndef _GUI_GENERAL_SCREENSAVER_OPTIONS_H_
-#define _GUI_GENERAL_SCREENSAVER_OPTIONS_H_
+#pragma once
+#ifndef ES_APP_GUIS_GUI_GENERAL_SCREENSAVER_OPTIONS_H
+#define ES_APP_GUIS_GUI_GENERAL_SCREENSAVER_OPTIONS_H
 
 #include "components/MenuComponent.h"
 #include "GuiScreensaverOptions.h"
@@ -15,4 +16,4 @@ private:
 	void openSlideshowScreensaverOptions();
 };
 
-#endif // _GUI_GENERAL_SCREENSAVER_OPTIONS_H_
+#endif // ES_APP_GUIS_GUI_GENERAL_SCREENSAVER_OPTIONS_H

--- a/es-app/src/guis/GuiInfoPopup.h
+++ b/es-app/src/guis/GuiInfoPopup.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_GUIS_GUI_INFO_POPUP_H
+#define ES_APP_GUIS_GUI_INFO_POPUP_H
 
 #include "GuiComponent.h"
 #include "components/NinePatchComponent.h"
@@ -25,3 +27,5 @@ private:
 	NinePatchComponent* mFrame;
 	bool running;
 };
+
+#endif // ES_APP_GUIS_GUI_INFO_POPUP_H

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_GUIS_GUI_MENU_H
+#define ES_APP_GUIS_GUI_MENU_H
 
 #include "GuiComponent.h"
 #include "components/MenuComponent.h"
@@ -29,3 +31,5 @@ private:
 	MenuComponent mMenu;
 	TextComponent mVersion;
 };
+
+#endif // ES_APP_GUIS_GUI_MENU_H

--- a/es-app/src/guis/GuiMetaDataEd.h
+++ b/es-app/src/guis/GuiMetaDataEd.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_GUIS_GUI_META_DATA_ED_H
+#define ES_APP_GUIS_GUI_META_DATA_ED_H
 
 #include "GuiComponent.h"
 #include "components/MenuComponent.h"
@@ -41,3 +43,5 @@ private:
 	std::function<void()> mSavedCallback;
 	std::function<void()> mDeleteFunc;
 };
+
+#endif // ES_APP_GUIS_GUI_META_DATA_ED_H

--- a/es-app/src/guis/GuiScraperMulti.h
+++ b/es-app/src/guis/GuiScraperMulti.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_GUIS_GUI_SCRAPER_MULTI_H
+#define ES_APP_GUIS_GUI_SCRAPER_MULTI_H
 
 #include "GuiComponent.h"
 #include "components/NinePatchComponent.h"
@@ -41,3 +43,5 @@ private:
 	std::shared_ptr<ScraperSearchComponent> mSearchComp;
 	std::shared_ptr<ComponentGrid> mButtonGrid;
 };
+
+#endif // ES_APP_GUIS_GUI_SCRAPER_MULTI_H

--- a/es-app/src/guis/GuiScraperStart.h
+++ b/es-app/src/guis/GuiScraperStart.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_GUIS_GUI_SCRAPER_START_H
+#define ES_APP_GUIS_GUI_SCRAPER_START_H
 
 #include "GuiComponent.h"
 #include "SystemData.h"
@@ -36,3 +38,5 @@ private:
 
 	MenuComponent mMenu;
 };
+
+#endif // ES_APP_GUIS_GUI_SCRAPER_START_H

--- a/es-app/src/guis/GuiScreensaverOptions.h
+++ b/es-app/src/guis/GuiScreensaverOptions.h
@@ -1,5 +1,6 @@
-#ifndef _GUI_SCREENSAVER_OPTIONS_H_
-#define _GUI_SCREENSAVER_OPTIONS_H_
+#pragma once
+#ifndef ES_APP_GUIS_GUI_SCREENSAVER_OPTIONS_H
+#define ES_APP_GUIS_GUI_SCREENSAVER_OPTIONS_H
 
 #include "GuiComponent.h"
 #include "components/MenuComponent.h"
@@ -26,4 +27,4 @@ protected:
 	std::vector< std::function<void()> > mSaveFuncs;
 };
 
-#endif // _GUI_SCREENSAVER_OPTIONS_H_
+#endif // ES_APP_GUIS_GUI_SCREENSAVER_OPTIONS_H

--- a/es-app/src/guis/GuiSettings.h
+++ b/es-app/src/guis/GuiSettings.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef ES_APP_GUIS_GUI_SETTINGS_H
+#define ES_APP_GUIS_GUI_SETTINGS_H
+
 #include "GuiComponent.h"
 #include "components/MenuComponent.h"
 #include "SystemData.h"
@@ -22,3 +26,5 @@ private:
 	MenuComponent mMenu;
 	std::vector< std::function<void()> > mSaveFuncs;
 };
+
+#endif // ES_APP_GUIS_GUI_SETTINGS_H

--- a/es-app/src/guis/GuiSlideshowScreensaverOptions.h
+++ b/es-app/src/guis/GuiSlideshowScreensaverOptions.h
@@ -1,5 +1,6 @@
-#ifndef _GUI_SLIDESHOW_SCREENSAVER_OPTIONS_H_
-#define _GUI_SLIDESHOW_SCREENSAVER_OPTIONS_H_
+#pragma once
+#ifndef ES_APP_GUIS_GUI_SLIDESHOW_SCREENSAVER_OPTIONS_H
+#define ES_APP_GUIS_GUI_SLIDESHOW_SCREENSAVER_OPTIONS_H
 
 #include "components/MenuComponent.h"
 #include "GuiScreensaverOptions.h"
@@ -15,4 +16,4 @@ private:
 	void addEditableTextComponent(ComponentListRow row, const std::string label, std::shared_ptr<GuiComponent> ed, std::string value);
 };
 
-#endif // _GUI_SLIDESHOW_SCREENSAVER_OPTIONS_H_
+#endif // ES_APP_GUIS_GUI_SLIDESHOW_SCREENSAVER_OPTIONS_H

--- a/es-app/src/guis/GuiVideoScreensaverOptions.h
+++ b/es-app/src/guis/GuiVideoScreensaverOptions.h
@@ -1,5 +1,6 @@
-#ifndef _GUI_VIDEO_SCREENSAVER_OPTIONS_H_
-#define _GUI_VIDEO_SCREENSAVER_OPTIONS_H_
+#pragma once
+#ifndef ES_APP_GUIS_GUI_VIDEO_SCREENSAVER_OPTIONS_H
+#define ES_APP_GUIS_GUI_VIDEO_SCREENSAVER_OPTIONS_H
 
 #include "components/MenuComponent.h"
 #include "GuiScreensaverOptions.h"
@@ -13,4 +14,4 @@ public:
 	void save() override;
 };
 
-#endif // _GUI_VIDEO_SCREENSAVER_OPTIONS_H_
+#endif // ES_APP_GUIS_GUI_VIDEO_SCREENSAVER_OPTIONS_H

--- a/es-app/src/scrapers/GamesDBScraper.h
+++ b/es-app/src/scrapers/GamesDBScraper.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_SCRAPERS_GAMES_DB_SCRAPER_H
+#define ES_APP_SCRAPERS_GAMES_DB_SCRAPER_H
 
 #include "scrapers/Scraper.h"
 
@@ -23,3 +25,5 @@ protected:
 
 	std::queue< std::unique_ptr<ScraperRequest> >* mRequestQueue;
 };
+
+#endif // ES_APP_SCRAPERS_GAMES_DB_SCRAPER_H

--- a/es-app/src/scrapers/Scraper.h
+++ b/es-app/src/scrapers/Scraper.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_SCRAPERS_SCRAPER_H
+#define ES_APP_SCRAPERS_SCRAPER_H
 
 #include "MetaData.h"
 #include "SystemData.h"
@@ -154,3 +156,5 @@ std::unique_ptr<MDResolveHandle> resolveMetaDataAssets(const ScraperSearchResult
 //Will overwrite the image at [path] with the new resized one.
 //Returns true if successful, false otherwise.
 bool resizeImage(const std::string& path, int maxWidth, int maxHeight);
+
+#endif // ES_APP_SCRAPERS_SCRAPER_H

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_VIEWS_SYSTEM_VIEW_H
+#define ES_APP_VIEWS_SYSTEM_VIEW_H
 
 #include "GuiComponent.h"
 #include "components/ImageComponent.h"
@@ -84,3 +86,5 @@ private:
 	bool mViewNeedsReload;
 	bool mShowing;
 };
+
+#endif // ES_APP_VIEWS_SYSTEM_VIEW_H

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_VIEWS_VIEW_CONTROLLER_H
+#define ES_APP_VIEWS_VIEW_CONTROLLER_H
 
 #include "views/gamelist/IGameListView.h"
 #include "views/SystemView.h"
@@ -102,3 +104,5 @@ private:
 	State mState;
 	std::string mCurUIMode;
 };
+
+#endif // ES_APP_VIEWS_VIEW_CONTROLLER_H

--- a/es-app/src/views/gamelist/BasicGameListView.h
+++ b/es-app/src/views/gamelist/BasicGameListView.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_VIEWS_GAME_LIST_BASIC_GAME_LIST_VIEW_H
+#define ES_APP_VIEWS_GAME_LIST_BASIC_GAME_LIST_VIEW_H
 
 #include "views/gamelist/ISimpleGameListView.h"
 #include "components/TextListComponent.h"
@@ -28,3 +30,5 @@ protected:
 
 	TextListComponent<FileData*> mList;
 };
+
+#endif // ES_APP_VIEWS_GAME_LIST_BASIC_GAME_LIST_VIEW_H

--- a/es-app/src/views/gamelist/DetailedGameListView.h
+++ b/es-app/src/views/gamelist/DetailedGameListView.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_VIEWS_GAME_LIST_DETAILED_GAME_LIST_VIEW_H
+#define ES_APP_VIEWS_GAME_LIST_DETAILED_GAME_LIST_VIEW_H
 
 #include "views/gamelist/BasicGameListView.h"
 #include "components/ScrollableContainer.h"
@@ -41,3 +43,5 @@ private:
 	ScrollableContainer mDescContainer;
 	TextComponent mDescription;
 };
+
+#endif // ES_APP_VIEWS_GAME_LIST_DETAILED_GAME_LIST_VIEW_H

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_VIEWS_GAME_LIST_GRID_GAME_LIST_VIEW_H
+#define ES_APP_VIEWS_GAME_LIST_GRID_GAME_LIST_VIEW_H
 
 #include "views/gamelist/ISimpleGameListView.h"
 #include "components/ImageGridComponent.h"
@@ -27,3 +29,5 @@ protected:
 
 	ImageGridComponent<FileData*> mGrid;
 };
+
+#endif // ES_APP_VIEWS_GAME_LIST_GRID_GAME_LIST_VIEW_H

--- a/es-app/src/views/gamelist/IGameListView.h
+++ b/es-app/src/views/gamelist/IGameListView.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_VIEWS_GAME_LIST_IGAME_LIST_VIEW_H
+#define ES_APP_VIEWS_GAME_LIST_IGAME_LIST_VIEW_H
 
 #include "FileData.h"
 #include "Renderer.h"
@@ -44,3 +46,5 @@ protected:
 	FileData* mRoot;
 	std::shared_ptr<ThemeData> mTheme;
 };
+
+#endif // ES_APP_VIEWS_GAME_LIST_IGAME_LIST_VIEW_H

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_VIEWS_GAME_LIST_ISIMPLE_GAME_LIST_VIEW_H
+#define ES_APP_VIEWS_GAME_LIST_ISIMPLE_GAME_LIST_VIEW_H
 
 #include "views/gamelist/IGameListView.h"
 
@@ -36,3 +38,5 @@ protected:
 
 	std::stack<FileData*> mCursorStack;
 };
+
+#endif // ES_APP_VIEWS_GAME_LIST_ISIMPLE_GAME_LIST_VIEW_H

--- a/es-app/src/views/gamelist/VideoGameListView.h
+++ b/es-app/src/views/gamelist/VideoGameListView.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_APP_VIEWS_GAME_LIST_VIDEO_GAME_LIST_VIEW_H
+#define ES_APP_VIEWS_GAME_LIST_VIDEO_GAME_LIST_VIEW_H
 
 #include "views/gamelist/BasicGameListView.h"
 #include "components/ScrollableContainer.h"
@@ -52,3 +54,5 @@ private:
 	bool		mVideoPlaying;
 
 };
+
+#endif // ES_APP_VIEWS_GAME_LIST_VIDEO_GAME_LIST_VIEW_H

--- a/es-core/src/AsyncHandle.h
+++ b/es-core/src/AsyncHandle.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_ASYNC_HANDLE_H
+#define ES_CORE_ASYNC_HANDLE_H
 
 enum AsyncHandleStatus
 {
@@ -42,3 +44,5 @@ protected:
 	std::string mError;
 	AsyncHandleStatus mStatus;
 };
+
+#endif // ES_CORE_ASYNC_HANDLE_H

--- a/es-core/src/AudioManager.h
+++ b/es-core/src/AudioManager.h
@@ -1,5 +1,6 @@
-#ifndef _AUDIOMANAGER_H_
-#define _AUDIOMANAGER_H_
+#pragma once
+#ifndef ES_CORE_AUDIO_MANAGER_H
+#define ES_CORE_AUDIO_MANAGER_H
 
 #include <vector>
 #include <memory>
@@ -34,4 +35,4 @@ public:
 	virtual ~AudioManager();
 };
 
-#endif
+#endif // ES_CORE_AUDIO_MANAGER_H

--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_GUI_COMPONENT_H
+#define ES_CORE_GUI_COMPONENT_H
 
 #include "InputConfig.h"
 #include <memory>
@@ -161,3 +163,5 @@ private:
 	Transform4x4f mTransform; //Don't access this directly! Use getTransform()!
 	AnimationController* mAnimationMap[MAX_ANIMATIONS];
 };
+
+#endif // ES_CORE_GUI_COMPONENT_H

--- a/es-core/src/HelpStyle.h
+++ b/es-core/src/HelpStyle.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_HELP_STYLE_H
+#define ES_CORE_HELP_STYLE_H
 
 #include "math/Vector2f.h"
 #include <memory>
@@ -17,3 +19,5 @@ struct HelpStyle
 	HelpStyle(); // default values
 	void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view);
 };
+
+#endif // ES_CORE_HELP_STYLE_H

--- a/es-core/src/HttpReq.h
+++ b/es-core/src/HttpReq.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_HTTP_REQ_H
+#define ES_CORE_HTTP_REQ_H
 
 #include <curl/curl.h>
 #include <sstream>
@@ -66,3 +68,5 @@ private:
 	std::stringstream mContent;
 	std::string mErrorMsg;
 };
+
+#endif // ES_CORE_HTTP_REQ_H

--- a/es-core/src/ImageIO.h
+++ b/es-core/src/ImageIO.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_IMAGE_IO
+#define ES_CORE_IMAGE_IO
 
 #include <vector>
 #include <FreeImage.h>
@@ -9,3 +11,5 @@ public:
 	static std::vector<unsigned char> loadFromMemoryRGBA32(const unsigned char * data, const size_t size, size_t & width, size_t & height);
 	static void flipPixelsVert(unsigned char* imagePx, const size_t& width, const size_t& height);
 };
+
+#endif // ES_CORE_IMAGE_IO

--- a/es-core/src/InputConfig.h
+++ b/es-core/src/InputConfig.h
@@ -1,5 +1,6 @@
-#ifndef _INPUTCONFIG_H_
-#define _INPUTCONFIG_H_
+#pragma once
+#ifndef ES_CORE_INPUT_CONFIG_H
+#define ES_CORE_INPUT_CONFIG_H
 
 #include <map>
 #include <vector>
@@ -115,4 +116,4 @@ private:
 	const std::string mDeviceGUID;
 };
 
-#endif
+#endif // ES_CORE_INPUT_CONFIG_H

--- a/es-core/src/InputManager.h
+++ b/es-core/src/InputManager.h
@@ -1,5 +1,6 @@
-#ifndef _INPUTMANAGER_H_
-#define _INPUTMANAGER_H_
+#pragma once
+#ifndef ES_CORE_INPUT_MANAGER_H
+#define ES_CORE_INPUT_MANAGER_H
 
 #include <SDL.h>
 #include <vector>
@@ -57,4 +58,4 @@ public:
 	bool parseEvent(const SDL_Event& ev, Window* window);
 };
 
-#endif
+#endif // ES_CORE_INPUT_MANAGER_H

--- a/es-core/src/Log.h
+++ b/es-core/src/Log.h
@@ -1,5 +1,6 @@
-#ifndef _LOG_H_
-#define _LOG_H_
+#pragma once
+#ifndef ES_CORE_LOG_H
+#define ES_CORE_LOG_H
 
 #define LOG(level) \
 if(level > Log::getReportingLevel()) ; \
@@ -36,4 +37,4 @@ private:
 	LogLevel messageLevel;
 };
 
-#endif
+#endif // ES_CORE_LOG_H

--- a/es-core/src/PowerSaver.h
+++ b/es-core/src/PowerSaver.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_POWER_SAVER_H
+#define ES_CORE_POWER_SAVER_H
 
 class PowerSaver
 {
@@ -42,3 +44,5 @@ private:
 
 	static void loadWakeupTime();
 };
+
+#endif // ES_CORE_POWER_SAVER_H

--- a/es-core/src/Renderer.h
+++ b/es-core/src/Renderer.h
@@ -1,5 +1,6 @@
-#ifndef _RENDERER_H_
-#define _RENDERER_H_
+#pragma once
+#ifndef ES_CORE_RENDERER_H
+#define ES_CORE_RENDERER_H
 
 #include <vector>
 #include <string>
@@ -36,4 +37,4 @@ namespace Renderer
 	void drawRect(float x, float y, float w, float h, unsigned int color, GLenum blend_sfactor = GL_SRC_ALPHA, GLenum blend_dfactor = GL_ONE_MINUS_SRC_ALPHA);
 }
 
-#endif
+#endif // ES_CORE_RENDERER_H

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef ES_CORE_SETTINGS_H
+#define ES_CORE_SETTINGS_H
+
 #include <string>
 #include <map>
 
@@ -35,3 +38,5 @@ private:
 	std::map<std::string, float> mFloatMap;
 	std::map<std::string, std::string> mStringMap;
 };
+
+#endif // ES_CORE_SETTINGS_H

--- a/es-core/src/Sound.h
+++ b/es-core/src/Sound.h
@@ -1,5 +1,6 @@
-#ifndef _SOUND_H_
-#define _SOUND_H_
+#pragma once
+#ifndef ES_CORE_SOUND_H
+#define ES_CORE_SOUND_H
 
 #include <string>
 #include <map>
@@ -43,4 +44,4 @@ private:
 	static std::map< std::string, std::shared_ptr<Sound> > sMap;
 };
 
-#endif
+#endif // ES_CORE_SOUND_H

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_THEME_DATA_H
+#define ES_CORE_THEME_DATA_H
 
 #include <iostream>
 #include <sstream>
@@ -152,3 +154,5 @@ private:
 
 	std::map<std::string, ThemeView> mViews;
 };
+
+#endif // ES_CORE_THEME_DATA_H

--- a/es-core/src/Util.h
+++ b/es-core/src/Util.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_UTIL_H
+#define ES_CORE_UTIL_H
 
 #include <string>
 #include <boost/filesystem.hpp>
@@ -42,3 +44,5 @@ std::vector<std::string> commaStringToVector(std::string commaString);
 
 // turn a vector of strings into a comma-separated string
 std::string vectorToCommaString(std::vector<std::string> stringVector);
+
+#endif // ES_CORE_UTIL_H

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_WINDOW_H
+#define ES_CORE_WInDOW_H
 
 #include "GuiComponent.h"
 #include "InputManager.h"
@@ -114,3 +116,5 @@ private:
 
 	bool mRenderedHelpPrompts;
 };
+
+#endif // ES_CORE_WINDOW_H

--- a/es-core/src/animations/Animation.h
+++ b/es-core/src/animations/Animation.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_ANIMATIONS_ANIMATION_H
+#define ES_CORE_ANIMATIONS_ANIMATION_H
 
 class Animation
 {
@@ -39,3 +41,5 @@ T lerp(const T& start, const T& end, float t)
 
 	return (start * (1 - t) + end * t);
 }
+
+#endif // ES_CORE_ANIMATIONS_ANIMATION_H

--- a/es-core/src/animations/AnimationController.h
+++ b/es-core/src/animations/AnimationController.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_ANIMATIONS_ANIMATION_CONTROLLER_H
+#define ES_CORE_ANIMATIONS_ANIMATION_CONTROLLER_H
 
 #include <memory>
 #include <functional>
@@ -29,3 +31,5 @@ private:
 	int mTime;
 	int mDelay;
 };
+
+#endif // ES_CORE_ANIMATIONS_ANIMATION_CONTROLLER_H

--- a/es-core/src/animations/LambdaAnimation.h
+++ b/es-core/src/animations/LambdaAnimation.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_ANIMATIONS_LAMBDA_ANIMATION_H
+#define ES_CORE_ANIMATIONS_LAMBDA_ANIMATION_H
 
 #include "animations/Animation.h"
 
@@ -21,3 +23,5 @@ private:
 	std::function<void(float t)> mFunction;
 	int mDuration;
 };
+
+#endif // ES_CORE_ANIMATIONS_LAMBDA_ANIMATION_H

--- a/es-core/src/components/AnimatedImageComponent.h
+++ b/es-core/src/components/AnimatedImageComponent.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef ES_CORE_COMPONENTS_ANIMATED_IMAGE_COMPONENT_H
+#define ES_CORE_COMPONENTS_ANIMATED_IMAGE_COMPONENT_H
+
 #include "GuiComponent.h"
 #include "ImageComponent.h"
 
@@ -38,3 +42,5 @@ private:
 	int mFrameAccumulator;
 	int mCurrentFrame;
 };
+
+#endif // ES_CORE_COMPONENTS_ANIMATED_IMAGE_COMPONENT_H

--- a/es-core/src/components/BusyComponent.h
+++ b/es-core/src/components/BusyComponent.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef ES_CORE_COMPONENTS_BUSY_COMPONENT_H
+#define ES_CORE_COMPONENTS_BUSY_COMPONENT_H
+
 #include "GuiComponent.h"
 #include "components/ComponentGrid.h"
 #include "components/NinePatchComponent.h"
@@ -21,3 +25,5 @@ private:
 	std::shared_ptr<AnimatedImageComponent> mAnimation;
 	std::shared_ptr<TextComponent> mText;
 };
+
+#endif // ES_CORE_COMPONENTS_BUSY_COMPONENT_H

--- a/es-core/src/components/ButtonComponent.h
+++ b/es-core/src/components/ButtonComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_BUTTON_COMPONENT_H
+#define ES_CORE_COMPONENTS_BUTTON_COMPONENT_H
 
 #include "GuiComponent.h"
 #include <functional>
@@ -45,3 +47,5 @@ private:
 	std::unique_ptr<TextCache> mTextCache;
 	NinePatchComponent mBox;
 };
+
+#endif // ES_CORE_COMPONENTS_BUTTON_COMPONENT_H

--- a/es-core/src/components/ComponentGrid.h
+++ b/es-core/src/components/ComponentGrid.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_COMPONENT_GRID_H
+#define ES_CORE_COMPONENTS_COMPONENT_GRID_H
 
 #include "GuiComponent.h"
 #include "math/Vector2i.h"
@@ -118,3 +120,5 @@ private:
 	void onCursorMoved(Vector2i from, Vector2i to);
 	Vector2i mCursor;
 };
+
+#endif // ES_CORE_COMPONENTS_COMPONENT_GRID_H

--- a/es-core/src/components/ComponentList.h
+++ b/es-core/src/components/ComponentList.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_COMPONENT_LIST_H
+#define ES_CORE_COMPONENTS_COMPONENT_LIST_H
 
 #include "IList.h"
 #include <functional>
@@ -85,3 +87,5 @@ private:
 
 	std::function<void(CursorState state)> mCursorChangedCallback;
 };
+
+#endif // ES_CORE_COMPONENTS_COMPONENT_LIST_H

--- a/es-core/src/components/DateTimeComponent.h
+++ b/es-core/src/components/DateTimeComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_DATE_TIME_COMPONENT_H
+#define ES_CORE_COMPONENTS_DATE_TIME_COMPONENT_H
 
 #include "GuiComponent.h"
 #include <boost/date_time.hpp>
@@ -64,3 +66,5 @@ private:
 
 	bool mAutoSize;
 };
+
+#endif // ES_CORE_COMPONENTS_DATE_TIME_COMPONENT_H

--- a/es-core/src/components/HelpComponent.h
+++ b/es-core/src/components/HelpComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_HELP_COMPONENT_H
+#define ES_CORE_COMPONENTS_HELP_COMPONENT_H
 
 #include "GuiComponent.h"
 #include "HelpStyle.h"
@@ -30,3 +32,5 @@ private:
 	std::vector<HelpPrompt> mPrompts;
 	HelpStyle mStyle;
 };
+
+#endif // ES_CORE_COMPONENTS_HELP_COMPONENT_H

--- a/es-core/src/components/IList.h
+++ b/es-core/src/components/IList.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_ILIST_H
+#define ES_CORE_COMPONENTS_ILIST_H
 
 #include <string>
 #include <vector>
@@ -311,3 +313,5 @@ protected:
 	virtual void onCursorChanged(const CursorState& state) {}
 	virtual void onScroll(int amt) {}
 };
+
+#endif // ES_CORE_COMPONENTS_ILIST_H

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -1,5 +1,6 @@
-#ifndef _IMAGECOMPONENT_H_
-#define _IMAGECOMPONENT_H_
+#pragma once
+#ifndef ES_CORE_COMPONENTS_IMAGE_COMPONENT_H
+#define ES_CORE_COMPONENTS_IMAGE_COMPONENT_H
 
 #include "platform.h"
 #include GLHEADER
@@ -88,4 +89,4 @@ private:
 	bool					mDynamic;
 };
 
-#endif
+#endif // ES_CORE_COMPONENTS_IMAGE_COMPONENT_H

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_IMAGE_GRID_COMPONENT_H
+#define ES_CORE_COMPONENTS_IMAGE_GRID_COMPONENT_H
 
 #include "GuiComponent.h"
 #include "components/IList.h"
@@ -252,3 +254,5 @@ void ImageGridComponent<T>::updateImages()
 		i++;
 	}
 }
+
+#endif // ES_CORE_COMPONENTS_IMAGE_GRID_COMPONENT_H

--- a/es-core/src/components/MenuComponent.h
+++ b/es-core/src/components/MenuComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_MENU_COMPONENT_H
+#define ES_CORE_COMPONENTS_MENU_COMPONENT_H
 
 #include "components/NinePatchComponent.h"
 #include "components/ComponentList.h"
@@ -53,3 +55,5 @@ private:
 	std::shared_ptr<ComponentGrid> mButtonGrid;
 	std::vector< std::shared_ptr<ButtonComponent> > mButtons;
 };
+
+#endif // ES_CORE_COMPONENTS_MENU_COMPONENT_H

--- a/es-core/src/components/NinePatchComponent.h
+++ b/es-core/src/components/NinePatchComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_NINE_PATCH_COMPONENT_H
+#define ES_CORE_COMPONENTS_NINE_PATCH_COMPONENT_H
 
 #include "GuiComponent.h"
 #include "resources/TextureResource.h"
@@ -52,3 +54,5 @@ private:
 	unsigned int mCenterColor;
 	std::shared_ptr<TextureResource> mTexture;
 };
+
+#endif // ES_CORE_COMPONENTS_NINE_PATCH_COMPONENT_H

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_OPTION_LIST_COMPONENT_H
+#define ES_CORE_COMPONENTS_OPTION_LIST_COMPONENT_H
 
 #include "GuiComponent.h"
 #include "resources/Font.h"
@@ -336,3 +338,5 @@ private:
 
 	std::vector<OptionListData> mEntries;
 };
+
+#endif // ES_CORE_COMPONENTS_OPTION_LIST_COMPONENT_H

--- a/es-core/src/components/ScrollableContainer.h
+++ b/es-core/src/components/ScrollableContainer.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_SCROLLABLE_CONTAINER_H
+#define ES_CORE_COMPONENTS_SCROLLABLE_CONTAINER_H
 
 #include "GuiComponent.h"
 
@@ -26,3 +28,5 @@ private:
 	bool mAtEnd;
 	int mAutoScrollResetAccumulator;
 };
+
+#endif // ES_CORE_COMPONENTS_SCROLLABLE_CONTAINER_H

--- a/es-core/src/components/SliderComponent.h
+++ b/es-core/src/components/SliderComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_SLIDER_COMPONENT_H
+#define ES_CORE_COMPONENTS_SLIDER_COMPONENT_H
 
 #include "GuiComponent.h"
 #include "components/ImageComponent.h"
@@ -39,3 +41,5 @@ private:
 	std::shared_ptr<Font> mFont;
 	std::shared_ptr<TextCache> mValueCache;
 };
+
+#endif // ES_CORE_COMPONENTS_SLIDER_COMPONENT_H

--- a/es-core/src/components/SwitchComponent.h
+++ b/es-core/src/components/SwitchComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_SWITCH_COMPONENT_H
+#define ES_CORE_COMPONENTS_SWITCH_COMPONENT_H
 
 #include "GuiComponent.h"
 #include "components/ImageComponent.h"
@@ -27,3 +29,5 @@ private:
 	ImageComponent mImage;
 	bool mState;
 };
+
+#endif // ES_CORE_COMPONENTS_SWITCH_COMPONENT_H

--- a/es-core/src/components/TextComponent.h
+++ b/es-core/src/components/TextComponent.h
@@ -1,5 +1,6 @@
-#ifndef _TEXTCOMPONENT_H_
-#define _TEXTCOMPONENT_H_
+#pragma once
+#ifndef ES_CORE_COMPONENTS_TEXT_COMPONENT_H
+#define ES_CORE_COMPONENTS_TEXT_COMPONENT_H
 
 #include "GuiComponent.h"
 #include "resources/Font.h"
@@ -63,4 +64,4 @@ private:
 	float mLineSpacing;
 };
 
-#endif
+#endif // ES_CORE_COMPONENTS_TEXT_COMPONENT_H

--- a/es-core/src/components/TextEditComponent.h
+++ b/es-core/src/components/TextEditComponent.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_COMPONENTS_TEXT_EDIT_COMPONENT_H
+#define ES_CORE_COMPONENTS_TEXT_EDIT_COMPONENT_H
 
 #include "GuiComponent.h"
 #include "components/NinePatchComponent.h"
@@ -61,3 +63,5 @@ private:
 	std::shared_ptr<Font> mFont;
 	std::unique_ptr<TextCache> mTextCache;
 };
+
+#endif // ES_CORE_COMPONENTS_TEXT_EDIT_COMPONENT_H

--- a/es-core/src/components/VideoComponent.h
+++ b/es-core/src/components/VideoComponent.h
@@ -1,5 +1,6 @@
-#ifndef _VIDEOCOMPONENT_H_
-#define _VIDEOCOMPONENT_H_
+#pragma once
+#ifndef ES_CORE_COMPONENTS_VIDEO_COMPONENT_H
+#define ES_CORE_COMPONENTS_VIDEO_COMPONENT_H
 
 #include "platform.h"
 #include GLHEADER
@@ -114,4 +115,4 @@ protected:
 	Configuration					mConfig;
 };
 
-#endif
+#endif // ES_CORE_COMPONENTS_VIDEO_COMPONENT_H

--- a/es-core/src/components/VideoPlayerComponent.h
+++ b/es-core/src/components/VideoPlayerComponent.h
@@ -1,6 +1,7 @@
 #ifdef _RPI_
-#ifndef _VIDEOPLAYERCOMPONENT_H_
-#define _VIDEOPLAYERCOMPONENT_H_
+#pragma once
+#ifndef ES_CORE_COMPONENTS_VIDEO_PLAYER_COMPONENT_H
+#define ES_CORE_COMPONENTS_VIDEO_PLAYER_COMPONENT_H
 
 #include "platform.h"
 #include GLHEADER
@@ -39,6 +40,5 @@ private:
 	std::string						subtitlePath;
 };
 
-#endif
-#endif
-
+#endif // ES_CORE_COMPONENTS_VIDEO_PLAYER_COMPONENT_H
+#endif // _RPI_

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -1,5 +1,6 @@
-#ifndef _VIDEOVLCCOMPONENT_H_
-#define _VIDEOVLCCOMPONENT_H_
+#pragma once
+#ifndef ES_CORE_COMPONENTS_VIDEO_VLC_COMPONENT_H
+#define ES_CORE_COMPONENTS_VIDEO_VLC_COMPONENT_H
 
 #include "platform.h"
 #include GLHEADER
@@ -68,4 +69,4 @@ private:
 	std::shared_ptr<TextureResource> mTexture;
 };
 
-#endif
+#endif // ES_CORE_COMPONENTS_VIDEO_VLC_COMPONENT_H

--- a/es-core/src/guis/GuiDetectDevice.h
+++ b/es-core/src/guis/GuiDetectDevice.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_GUIS_GUI_DETECT_DEVICE_H
+#define ES_CORE_GUIS_GUI_DETECT_DEVICE_H
 
 #include "GuiComponent.h"
 #include "components/NinePatchComponent.h"
@@ -31,3 +33,5 @@ private:
 
 	std::function<void()> mDoneCallback;
 };
+
+#endif ES_CORE_GUIS_GUI_DETECT_DEVICE_H

--- a/es-core/src/guis/GuiInputConfig.h
+++ b/es-core/src/guis/GuiInputConfig.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_GUIS_GUI_INPUT_CONFIG_H
+#define ES_CORE_GUIS_GUI_INPUT_CONFIG_H
 
 #include "GuiComponent.h"
 #include "components/NinePatchComponent.h"
@@ -50,3 +52,5 @@ private:
 
 	BusyComponent mBusyAnim;	
 };
+
+#endif // ES_CORE_GUIS_GUI_INPUT_CONFIG_H

--- a/es-core/src/guis/GuiMsgBox.h
+++ b/es-core/src/guis/GuiMsgBox.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_GUIS_GUI_MSG_BOX_H
+#define ES_CORE_GUIS_GUI_MSG_BOX_H
 
 #include "GuiComponent.h"
 #include "components/NinePatchComponent.h"
@@ -31,3 +33,5 @@ private:
 	std::shared_ptr<ComponentGrid> mButtonGrid;
 	std::function<void()> mAcceleratorFunc;
 };
+
+#endif // ES_CORE_GUIS_GUI_MSG_BOX_H

--- a/es-core/src/guis/GuiTextEditPopup.h
+++ b/es-core/src/guis/GuiTextEditPopup.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef ES_CORE_GUIS_GUI_TEXT_EDIT_POPUP_H
+#define ES_CORE_GUIS_GUI_TEXT_EDIT_POPUP_H
+
 #include "GuiComponent.h"
 
 #include "components/NinePatchComponent.h"
@@ -26,3 +30,5 @@ private:
 
 	bool mMultiLine;
 };
+
+#endif // ES_CORE_GUIS_GUI_TEXT_EDIT_POPUP_H

--- a/es-core/src/math/Matrix3x3f.h
+++ b/es-core/src/math/Matrix3x3f.h
@@ -1,5 +1,6 @@
-#ifndef _MATRIX3X3F_H_
-#define _MATRIX3X3F_H_
+#pragma once
+#ifndef ES_CORE_MATH_MATRIX3X3F_H
+#define ES_CORE_MATH_MATRIX3X3F_H
 
 #include <assert.h>
 #include <math/Vector3f.h>
@@ -74,4 +75,4 @@ protected:
 
 };
 
-#endif
+#endif // ES_CORE_MATH_MATRIX3X3F_H

--- a/es-core/src/math/Matrix4x4f.h
+++ b/es-core/src/math/Matrix4x4f.h
@@ -1,5 +1,6 @@
-#ifndef _MATRIX4X4F_H_
-#define _MATRIX4X4F_H_
+#pragma once
+#ifndef ES_CORE_MATH_MATRIX4X4F_H
+#define ES_CORE_MATH_MATRIX4X4F_H
 
 #include <assert.h>
 #include <math/Matrix3x3f.h>
@@ -176,4 +177,4 @@ protected:
 
 };
 
-#endif
+#endif // ES_CORE_MATH_MATRIX4X4F_H

--- a/es-core/src/math/Rotation3x3f.h
+++ b/es-core/src/math/Rotation3x3f.h
@@ -1,5 +1,6 @@
-#ifndef _ROTATION3X3F_H_
-#define _ROTATION3X3F_H_
+#pragma once
+#ifndef ES_CORE_MATH_ROTATION3X3F_H
+#define ES_CORE_MATH_ROTATION3X3F_H
 
 class Rotation3x3f : public Matrix3x3f
 {
@@ -36,4 +37,4 @@ public:
 
 };
 
-#endif
+#endif // ES_CORE_MATH_ROTATION3X3F_H

--- a/es-core/src/math/Scale3x3f.h
+++ b/es-core/src/math/Scale3x3f.h
@@ -1,5 +1,6 @@
-#ifndef _SCALE3X3F_H_
-#define _SCALE3X3F_H_
+#pragma once
+#ifndef ES_CORE_MATH_SCALE3X3F_H
+#define ES_CORE_MATH_SCALE3X3F_H
 
 class Scale3x3f : public Matrix3x3f
 {
@@ -23,4 +24,4 @@ public:
 
 };
 
-#endif
+#endif // ES_CORE_MATH_SCALE3X3F_H

--- a/es-core/src/math/Transform4x4f.h
+++ b/es-core/src/math/Transform4x4f.h
@@ -1,5 +1,6 @@
-#ifndef _TRANSFORM4X4F_H_
-#define _TRANSFORM4X4F_H_
+#pragma once
+#ifndef ES_CORE_MATH_TRANSFORM4X4F_H
+#define ES_CORE_MATH_TRANSFORM4X4F_H
 
 #include <math/Matrix4x4f.h>
 #include <math/Vector3f.h>
@@ -123,4 +124,4 @@ public:
 
 };
 
-#endif
+#endif // ES_CORE_MATH_TRANSFORM4X4F_H

--- a/es-core/src/math/Vector2f.h
+++ b/es-core/src/math/Vector2f.h
@@ -1,5 +1,6 @@
-#ifndef _VECTOR2F_H_
-#define _VECTOR2F_H_
+#pragma once
+#ifndef ES_CORE_MATH_VECTOR2F_H
+#define ES_CORE_MATH_VECTOR2F_H
 
 #include <assert.h>
 
@@ -62,4 +63,4 @@ private:
 
 };
 
-#endif
+#endif // ES_CORE_MATH_VECTOR2F_H

--- a/es-core/src/math/Vector2i.h
+++ b/es-core/src/math/Vector2i.h
@@ -1,5 +1,6 @@
-#ifndef _VECTOR2I_H_
-#define _VECTOR2I_H_
+#pragma once
+#ifndef ES_CORE_MATH_VECTOR2I_H
+#define ES_CORE_MATH_VECTOR2I_H
 
 #include <assert.h>
 
@@ -55,4 +56,4 @@ private:
 
 };
 
-#endif
+#endif // ES_CORE_MATH_VECTOR2I_H

--- a/es-core/src/math/Vector3f.h
+++ b/es-core/src/math/Vector3f.h
@@ -1,5 +1,6 @@
-#ifndef _VECTOR3F_H_
-#define _VECTOR3F_H_
+#pragma once
+#ifndef ES_CORE_MATH_VECTOR3F_H
+#define ES_CORE_MATH_VECTOR3F_H
 
 #include <assert.h>
 
@@ -70,4 +71,4 @@ private:
 
 };
 
-#endif
+#endif // ES_CORE_MATH_VECTOR3F_H

--- a/es-core/src/math/Vector4f.h
+++ b/es-core/src/math/Vector4f.h
@@ -1,5 +1,6 @@
-#ifndef _VECTOR4F_H_
-#define _VECTOR4F_H_
+#pragma once
+#ifndef ES_CORE_MATH_VECTOR4F_H
+#define ES_CORE_MATH_VECTOR4F_H
 
 #include <assert.h>
 
@@ -79,4 +80,4 @@ private:
 
 };
 
-#endif
+#endif // ES_CORE_MATH_VECTOR4F_H

--- a/es-core/src/platform.h
+++ b/es-core/src/platform.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef ES_CORE_PLATFORM_H
+#define ES_CORE_PLATFORM_H
+
 //the Makefile defines one of these:
 //#define USE_OPENGL_ES
 //#define USE_OPENGL_DESKTOP
@@ -25,3 +29,5 @@ int runRestartCommand(); // restart the system (returns 0 if successful)
 int runSystemCommand(const std::string& cmd_utf8); // run a utf-8 encoded in the shell (requires wstring conversion on Windows)
 int quitES(const std::string& filename);
 void touch(const std::string& filename);
+
+#endif // ES_CORE_PLATFORM_H

--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_RESOURCES_FONT_H
+#define ES_CORE_RESOURCES_FONT_H
 
 #include <string>
 #include "platform.h"
@@ -172,3 +174,5 @@ public:
 
 	friend Font;
 };
+
+#endif // ES_CORE_RESOURCES_FONT_H

--- a/es-core/src/resources/ResourceManager.h
+++ b/es-core/src/resources/ResourceManager.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_RESOURCES_RESOURCE_MANAGER_H
+#define ES_CORE_RESOURCES_RESOURCE_MANAGER_H
 
 #include <stddef.h>
 #include <memory>
@@ -46,3 +48,5 @@ private:
 
 	std::list< std::weak_ptr<IReloadable> > mReloadables;
 };
+
+#endif // ES_CORE_RESOURCES_RESOURCE_MANAGER_H

--- a/es-core/src/resources/TextureData.h
+++ b/es-core/src/resources/TextureData.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_RESOURCES_TEXTURE_DATA_H
+#define ES_CORE_RESOURCES_TEXTURE_DATA_H
 
 #include <string>
 #include <memory>
@@ -61,3 +63,5 @@ private:
 	bool			mScalable;
 	bool			mReloadable;
 };
+
+#endif // ES_CORE_RESOURCES_TEXTURE_DATA_H

--- a/es-core/src/resources/TextureDataManager.h
+++ b/es-core/src/resources/TextureDataManager.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_RESOURCES_TEXTURE_DATA_MANAGER_H
+#define ES_CORE_RESOURCES_TEXTURE_DATA_MANAGER_H
 
 #include "resources/ResourceManager.h"
 #include "platform.h"
@@ -84,3 +86,4 @@ private:
 	TextureLoader*																			mLoader;
 };
 
+#endif // ES_CORE_RESOURCES_TEXTURE_DATA_MANAGER_H

--- a/es-core/src/resources/TextureResource.h
+++ b/es-core/src/resources/TextureResource.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef ES_CORE_RESOURCES_TEXTURE_RESOURCE_H
+#define ES_CORE_RESOURCES_TEXTURE_RESOURCE_H
 
 #include "resources/ResourceManager.h"
 
@@ -57,3 +59,5 @@ private:
 	static std::map< TextureKeyType, std::weak_ptr<TextureResource> > sTextureMap; // map of textures, used to prevent duplicate textures
 	static std::set<TextureResource*> 	sAllTextures;	// Set of all textures, used for memory management
 };
+
+#endif // ES_CORE_RESOURCES_TEXTURE_RESOURCE_H


### PR DESCRIPTION
Went through all headers in es-app and es-core and made sure each and everyone has both #pragma once and #ifndef XXXX.

There was a big mixture between these two, and even quite a few that had neither, so this cleans up all that.

This should not conflict with any waiting PRs since it only touches all headers on the first 3 lines, and the very last line.

This is PR one in a series of two, if this is accepted and merged then the next one will be a huge include cleanup, I've done a few minor tests and with proper cleanup of header includes we can potentially cut compile time in half, if not even more, this is an estimate on my computer, need to do further testing on the PI.