### PR TITLE
Make long romnames bounce back and forth

### DIFF
--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -2,6 +2,7 @@
 #ifndef ES_CORE_GUI_COMPONENT_H
 #define ES_CORE_GUI_COMPONENT_H
 
+#include "math/Misc.h"
 #include "math/Transform4x4f.h"
 #include "HelpPrompt.h"
 #include "HelpStyle.h"
@@ -62,7 +63,7 @@ public:
 
 	float getRotation() const;
 	void setRotation(float rotation);
-	inline void setRotationDegrees(float rotation) { setRotation((float) (rotation * M_PI / 180)); }
+	inline void setRotationDegrees(float rotation) { setRotation((float)ES_DEG_TO_RAD(rotation)); }
 
 	float getScale() const;
 	void setScale(float scale);

--- a/es-core/src/math/Misc.h
+++ b/es-core/src/math/Misc.h
@@ -1,0 +1,61 @@
+#pragma once
+#ifndef ES_CORE_MATH_MISC_H
+#define ES_CORE_MATH_MISC_H
+
+#include <math.h>
+
+#define	ES_PI (3.1415926535897932384626433832795028841971693993751058209749445923)
+#define	ES_RAD_TO_DEG(x) ((x) * (180.0 / ES_PI))
+#define	ES_DEG_TO_RAD(x) ((x) * (ES_PI / 180.0))
+
+namespace Math
+{
+	inline float scroll_bounce(const float delayTime, const float scrollTime, const float currentTime, const int scrollLength)
+	{
+		if(currentTime < delayTime)
+		{
+			// wait
+			return 0;
+		}
+		else if(currentTime < (delayTime + scrollTime))
+		{
+			// lerp from 0 to scrollLength
+			const float fraction = (currentTime - delayTime) / scrollTime;
+			return (float)(((1.0 - cos(ES_PI * fraction)) * 0.5) * scrollLength);
+		}
+		else if(currentTime < (delayTime + scrollTime + delayTime))
+		{
+			// wait some more
+			return scrollLength;
+		}
+		else if(currentTime < (delayTime + scrollTime + delayTime + scrollTime))
+		{
+			// lerp back from scrollLength to 0
+			const float fraction = 1.0 - (currentTime - delayTime - scrollTime - delayTime) / scrollTime;
+			return (float)(((1.0 - cos(ES_PI * fraction)) * 0.5) * scrollLength);
+		}
+
+		// and back to waiting
+		return 0;
+	}
+
+	inline float scroll_loop(const float delayTime, const float scrollTime, const float currentTime, const int scrollLength)
+	{
+		if(currentTime < delayTime)
+		{
+			// wait
+			return 0;
+		}
+		else if(currentTime < (delayTime + scrollTime))
+		{
+			// lerp from 0 to scrollLength
+			const float fraction = (currentTime - delayTime) / scrollTime;
+			return fraction * scrollLength;
+		}
+
+		// and back to waiting
+		return 0;
+	}
+}
+
+#endif // ES_CORE_MATH_MISC_H


### PR DESCRIPTION
I added math/Misc.h that defines ES_PI, ES_RAD_TO_DEG and ES_DEG_TO_RAD
Also added Math::bounce that takes a delay time, a bounce time and your current time
This is what it does:

```
	// returns a float between 0.0 and 1.0
	// delay, 0.0 -> 1.0, delay, 1.0 -> 0.0
```
Basically if given time is less than first delay, it does nothing and returns 0, then it goes up to 1 for the duration of bounce, delays again and returns 1 until its time to go back down to 0 for the duration of bounce, delays again and returns 0,
So a negative time or larger than delay + bounce + delay + bounce also returns 0
It's up to the code outside to handle feeding it a proper time.
I applied this to the long romname scroll so it doesn't just stops and sit at the end of a long name, but bounce back and forth.

Oh, also, the old code was based on pixels, so when I lowered my res from 1920x1080 to half that, 960x540 ( use that when dev-testing ) that caused it to scroll twice as fast ( same amount of pixels per tick, but text is now only half as many pixels wide ), this new code also fixes that.