### PR TITLE
Add SystemData::indexAllGameFilters (fixes bug #281)

### DIFF
--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -144,14 +144,6 @@ void parseGamelist(SystemData* system)
 				file->metadata.set("name", defaultName);
 
 			file->metadata.resetChangedFlag();
-
-			// index if it's a game!
-			if(type == GAME)
-			{
-				FileFilterIndex* index = system->getIndex();
-				index->addToIndex(file);
-			}
-
 		}
 	}
 }

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -36,6 +36,8 @@ SystemData::SystemData(const std::string& name, const std::string& fullName, Sys
 			parseGamelist(this);
 
 		mRootFolder->sort(FileSorts::SortTypes.at(0));
+
+		indexAllGameFilters(mRootFolder);
 	}
 	else
 	{
@@ -141,6 +143,20 @@ void SystemData::populateFolder(FileData* folder)
 				delete newFolder;
 			else
 				folder->addChild(newFolder);
+		}
+	}
+}
+
+void SystemData::indexAllGameFilters(const FileData* folder)
+{
+	const std::vector<FileData*>& children = folder->getChildren();
+
+	for(std::vector<FileData*>::const_iterator it = children.begin(); it != children.end(); ++it)
+	{
+		switch((*it)->getType())
+		{
+			case GAME:   { mFilterIndex->addToIndex(*it); } break;
+			case FOLDER: { indexAllGameFilters(*it);      } break;
 		}
 	}
 }

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -77,6 +77,7 @@ private:
 	std::shared_ptr<ThemeData> mTheme;
 
 	void populateFolder(FileData* folder);
+	void indexAllGameFilters(const FileData* folder);
 	void setIsGameSystemStatus();
 
 	FileFilterIndex* mFilterIndex;


### PR DESCRIPTION
Add SystemData::indexAllGameFilters that loops through all added games and add's their tags to the filter indexes

This fixes the hidden filtering in Kiosk mode when not using gamelist.xml
This fixes https://github.com/RetroPie/EmulationStation/issues/281