### PR TITLE
Fix for Video Screensaver not showing if menu is open

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -98,6 +98,7 @@ void SystemScreenSaver::startScreenSaver()
 			mVideoScreensaver = new VideoVlcComponent(mWindow, getTitlePath());
 #endif
 
+			mVideoScreensaver->topWindow(true);
 			mVideoScreensaver->setOrigin(0.5f, 0.5f);
 			mVideoScreensaver->setPosition(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f);
 


### PR DESCRIPTION
This fixes #245 .

Tested with VLC, OMX Player, and different combinations on the Pi. All seems good.