### PR TITLE
Fixing file deletion when present in "My Collections" bundle

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -304,7 +304,8 @@ void CollectionSystemManager::deleteCollectionFiles(FileData* file)
 			if (found) {
 				sysDataIt->second.needsSave = true;
 				FileData* collectionEntry = children.at(key);
-				ViewController::get()->getGameListView(sysDataIt->second.system).get()->remove(collectionEntry, false);
+				SystemData* systemViewToUpdate = getSystemToView(sysDataIt->second.system);
+				ViewController::get()->getGameListView(systemViewToUpdate).get()->remove(collectionEntry, false);
 			}
 		}
 	}


### PR DESCRIPTION
Should fix #289.

Edge case for file deletion when the file is present inside a collection that is itself inside the "My Collections" bundle. We were updating the System View for the collection (which is not being used in this case), instead of updating the Gamelist View for "My Collections" (the one that is being used in this case).

Segmentation fault ensues.