### PR TITLE
Add confirmation popup when changing to UI mode Kid or Kiosk.

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -166,10 +166,23 @@ void GuiMenu::openUISettings()
 		UImodeSelection->add(*it, *it, Settings::getInstance()->getString("UIMode") == *it);
 	s->addWithLabel("UI MODE", UImodeSelection);
 	Window* window = mWindow;
-	s->addSaveFunc([UImodeSelection, window]
+	s->addSaveFunc([ UImodeSelection, window]
 	{
-		LOG(LogDebug) << "Setting UI mode to" << UImodeSelection->getSelected();
-		Settings::getInstance()->setString("UIMode", UImodeSelection->getSelected());
+		std::string selectedMode = UImodeSelection->getSelected();
+		if (selectedMode != "Full")
+		{
+			std::string msg = "You are changing the UI to a restricted mode:\n" + selectedMode + "\n";
+			msg += "This will hide most menu-options to prevent changes to the system.\n";
+			msg += "To unlock and return to the full UI, enter this code: \n";
+			msg += "Up, up, down, down, left, right, left, right, B, A. \n\n";
+			msg += "Do you want to proceed?";
+
+			window->pushGui(new GuiMsgBox(window, msg, "YES",
+				[selectedMode] {
+					LOG(LogDebug) << "Setting UI mode to" << selectedMode;
+					Settings::getInstance()->setString("UIMode", selectedMode);
+			}, "NO", nullptr));
+		}
 	});
 
 	// screensaver


### PR DESCRIPTION
To counter [this issue](https://retropie.org.uk/forum/topic/14294/main-menu-troubles), and one other such confusion earlier this week.
Users will now see this:
![uimodepopup](https://user-images.githubusercontent.com/6103768/32629212-b7801106-c598-11e7-9e4b-3778fb7da412.png)

Limitations: 
1. The current message string is hard-coded, meaning that if people change their unlock passkey phrase (settings: `UIMode_passkey`), this message will not adjust.
I am thinking of introducing that, if anyone thinks that is worthwhile.
2. The string is in ASCII, and the font we use does not support the arrow unicode characters, so its kind-of 'wordy' right now.
