### PR TITLE
Trying to fix japanese text

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -185,7 +185,7 @@ int main(int argc, char* argv[])
 	unsigned int width = 0;
 	unsigned int height = 0;
 
-	std::locale::global(std::locale(std::locale(""), "C", std::locale::numeric));
+	std::locale::global(std::locale("C"));
 	boost::filesystem::path::imbue(std::locale());
 
 	if(!parseArgs(argc, argv, &width, &height))


### PR DESCRIPTION
This should fix the crash introduced by https://github.com/RetroPie/EmulationStation/commit/d3966da2b7ed13f39b2b90e6ba008c4dfdb84de6
Tested on Windows 7, Ubuntu 16.04 and on my pi3. Most themes tested shows just dots or squares, but I blame that on the font, and as far as I can tell it did this even when it was using boost::locale.