### PR TITLE
Implement StringUtil ( Unicode )

### DIFF
--- a/es-core/src/StringUtil.h
+++ b/es-core/src/StringUtil.h
@@ -1,0 +1,136 @@
+#pragma once
+#ifndef ES_CORE_STRING_UTIL_H
+#define ES_CORE_STRING_UTIL_H
+
+namespace StringUtil
+{
+	inline unsigned int chars2Unicode(const std::string& _string, size_t& _cursor)
+	{
+		const char&  c      = _string[_cursor];
+		unsigned int result = '?';
+
+		if((c & 0x80) == 0) // 0xxxxxxx, one byte character
+		{
+			// 0xxxxxxx
+			result = ((_string[_cursor++]       )      );
+		}
+		else if((c & 0xE0) == 0xC0) // 110xxxxx, two byte character
+		{
+			// 110xxxxx 10xxxxxx
+			result = ((_string[_cursor++] & 0x1F) <<  6) |
+			         ((_string[_cursor++] & 0x3F)      );
+		}
+		else if((c & 0xF0) == 0xE0) // 1110xxxx, three byte character
+		{
+			// 1110xxxx 10xxxxxx 10xxxxxx
+			result = ((_string[_cursor++] & 0x0F) << 12) |
+			         ((_string[_cursor++] & 0x3F) <<  6) |
+			         ((_string[_cursor++] & 0x3F)      );
+		}
+		else if((c & 0xF8) == 0xF0) // 11110xxx, four byte character
+		{
+			// 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+			result = ((_string[_cursor++] & 0x07) << 18) |
+			         ((_string[_cursor++] & 0x3F) << 12) |
+			         ((_string[_cursor++] & 0x3F) <<  6) |
+			         ((_string[_cursor++] & 0x3F)      );
+		}
+		else
+		{
+			// error, invalid unicode
+			++_cursor;
+		}
+
+		return result;
+
+	} // chars2Unicode
+
+	inline std::string unicode2Chars(const unsigned int _unicode)
+	{
+		std::string result;
+
+		if(_unicode < 0x80) // one byte character
+		{
+			result += ((_unicode      )       );
+		}
+		else if(_unicode < 0x800) // two byte character
+		{
+			result += ((_unicode >>  6)       ) | 0xC0;
+			result += ((_unicode      ) & 0x3F) | 0x80;
+		}
+		else if(_unicode < 0xFFFF) // three byte character
+		{
+			result += ((_unicode >> 12)       ) | 0xE0;
+			result += ((_unicode >>  6) & 0x3F) | 0x80;
+			result += ((_unicode      ) & 0x3F) | 0x80;
+		}
+		else if(_unicode <= 0x1fffff) // four byte character
+		{
+			result += ((_unicode >> 18)       ) | 0xF0;
+			result += ((_unicode >> 12) & 0x3F) | 0x80;
+			result += ((_unicode >>  6) & 0x3F) | 0x80;
+			result += ((_unicode      ) & 0x3F) | 0x80;
+		}
+		else
+		{
+			// error, invalid unicode
+			result += '?';
+		}
+
+		return result;
+
+	} // unicode2Chars
+
+	inline size_t nextCursor(const std::string& _string, const size_t _cursor)
+	{
+		size_t result = _cursor;
+
+		while(result < _string.length())
+		{
+			++result;
+
+			if((_string[result] & 0xC0) != 0x80) // break if current character is not 10xxxxxx
+				break;
+		}
+
+		return result;
+
+	} // nextCursor
+
+	inline size_t prevCursor(const std::string& _string, const size_t _cursor)
+	{
+		size_t result = _cursor;
+
+		while(result > 0)
+		{
+			--result;
+
+			if((_string[result] & 0xC0) != 0x80) // break if current character is not 10xxxxxx
+				break;
+		}
+
+		return result;
+
+	} // prevCursor
+
+	inline size_t moveCursor(const std::string& _string, const size_t _cursor, const int _amount)
+	{
+		size_t result = _cursor;
+
+		if(_amount > 0)
+		{
+			for(int i = 0; i < _amount; ++i)
+				result = nextCursor(_string, result);
+		}
+		else if(_amount < 0)
+		{
+			for(int i = _amount; i < 0; ++i)
+				result = prevCursor(_string, result);
+		}
+
+		return result;
+
+	} // moveCursor
+}
+
+#endif // ES_CORE_STRING_UTIL_H

--- a/es-core/src/components/TextComponent.cpp
+++ b/es-core/src/components/TextComponent.cpp
@@ -3,6 +3,7 @@
 #include "Log.h"
 #include "Renderer.h"
 #include "Settings.h"
+#include "StringUtil.h"
 #include "Util.h"
 
 TextComponent::TextComponent(Window* window) : GuiComponent(window), 
@@ -197,7 +198,7 @@ void TextComponent::onTextChanged()
 
 		while(text.size() && size.x() + abbrevSize.x() > mSize.x())
 		{
-			size_t newSize = Font::getPrevCursor(text, text.size());
+			size_t newSize = StringUtil::prevCursor(text, text.size());
 			text.erase(newSize, text.size() - newSize);
 			size = f->sizeText(text);
 		}

--- a/es-core/src/components/TextEditComponent.cpp
+++ b/es-core/src/components/TextEditComponent.cpp
@@ -2,6 +2,7 @@
 
 #include "resources/Font.h"
 #include "Renderer.h"
+#include "StringUtil.h"
 
 #define TEXT_PADDING_HORIZ 10
 #define TEXT_PADDING_VERT 2
@@ -59,7 +60,7 @@ void TextEditComponent::textInput(const char* text)
 		{
 			if(mCursor > 0)
 			{
-				size_t newCursor = Font::getPrevCursor(mText, mCursor);
+				size_t newCursor = StringUtil::prevCursor(mText, mCursor);
 				mText.erase(mText.begin() + newCursor, mText.begin() + mCursor);
 				mCursor = newCursor;
 			}
@@ -190,7 +191,7 @@ void TextEditComponent::updateCursorRepeat(int deltaTime)
 
 void TextEditComponent::moveCursor(int amt)
 {
-	mCursor = Font::moveCursor(mText, mCursor, amt);
+	mCursor = StringUtil::moveCursor(mText, mCursor, amt);
 	onCursorChanged();
 }
 

--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -21,8 +21,6 @@ class TextCache;
 #define FONT_PATH_LIGHT ":/opensans_hebrew_condensed_light.ttf"
 #define FONT_PATH_REGULAR ":/opensans_hebrew_condensed_regular.ttf"
 
-typedef unsigned long UnicodeChar;
-
 enum Alignment
 {
 	ALIGN_LEFT,
@@ -68,12 +66,6 @@ public:
 	size_t getMemUsage() const; // returns an approximation of VRAM used by this font's texture (in bytes)
 	static size_t getTotalMemUsage(); // returns an approximation of total VRAM used by font textures (in bytes)
 
-	// utf8 stuff
-	static size_t getNextCursor(const std::string& str, size_t cursor);
-	static size_t getPrevCursor(const std::string& str, size_t cursor);
-	static size_t moveCursor(const std::string& str, size_t cursor, int moveAmt); // negative moveAmt = move backwards, positive = move forwards
-	static UnicodeChar readUnicodeChar(const std::string& str, size_t& cursor); // reads unicode character at cursor AND moves cursor to the next valid unicode char
-
 private:
 	static FT_Library sLibrary;
 	static std::map< std::pair<std::string, int>, std::weak_ptr<Font> > sFontMap;
@@ -114,7 +106,7 @@ private:
 	void getTextureForNewGlyph(const Vector2i& glyphSize, FontTexture*& tex_out, Vector2i& cursor_out);
 
 	std::map< unsigned int, std::unique_ptr<FontFace> > mFaceCache;
-	FT_Face getFaceForChar(UnicodeChar id);
+	FT_Face getFaceForChar(unsigned int id);
 	void clearFaceCache();
 
 	struct Glyph
@@ -128,9 +120,9 @@ private:
 		Vector2f bearing;
 	};
 
-	std::map<UnicodeChar, Glyph> mGlyphMap;
+	std::map<unsigned int, Glyph> mGlyphMap;
 
-	Glyph* getGlyph(UnicodeChar id);
+	Glyph* getGlyph(unsigned int id);
 
 	int mMaxGlyphHeight;
 	


### PR DESCRIPTION
Moved some functions from Font to StringUtil.h and optimized / improved them where possible

Font::readUnicodeChar -> StringUtil::chars2Unicode
Font::getNextCursor -> StringUtil::nextCursor
Font::getPrevCursor -> StringUtil::prevCursor
Font::moveCursor -> StringUtil::moveCursor

And I added StringUtil::unicode2Chars which takes a unicode hex and turns into into a std::string, @zigurana might want that for https://github.com/RetroPie/EmulationStation/pull/295

All the functions was tested on the VR Virtua Racing and Doom Japanese descriptions provided in https://github.com/RetroPie/EmulationStation/pull/269 and by editing them inside ES and stepping forward / backwards to trigger the nextCursor and prevCursor.

Edit: A little bit to quick, too much code at once, forgot to test this on the pi. Will update once I verify that it works.