### PR TITLE
Fixes volume for video snapshots

### DIFF
--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -110,7 +110,8 @@ void VideoPlayerComponent::startVideo()
 				else
 				{
 					float percentVolume = (float)VolumeControl::getInstance()->getVolume();
-					int OMXVolume = (int)((percentVolume-98)*105);
+					// map [0,100] to [-6000,0]
+					int OMXVolume = (int)((percentVolume*6000)/100)*-1;
 					argv[8] = std::to_string(OMXVolume).c_str();
 				}
 


### PR DESCRIPTION
Old calculation doesn't correctly map the ranges - 

(98-98)*105=0=full volume!
(99-98)*105=105=OOR so full volume!
(100-98)*105=210=OOR so full volume!

even setting the system vol to 0 produces
(0-98)*105=-10290=circa 80% volume!