### PR TITLE
Silence warnings

### DIFF
--- a/es-app/src/ScraperCmdLine.cpp
+++ b/es-app/src/ScraperCmdLine.cpp
@@ -13,7 +13,7 @@
 
 std::ostream& out = std::cout;
 
-void handle_interrupt_signal(int p)
+void handle_interrupt_signal(int /*p*/)
 {
 	sleep(50);
 

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -433,7 +433,7 @@ bool SystemData::hasGamelist() const
 
 unsigned int SystemData::getGameCount() const
 {
-	return mRootFolder->getFilesRecursive(GAME).size();
+	return (unsigned int)mRootFolder->getFilesRecursive(GAME).size();
 }
 
 SystemData* SystemData::getRandomSystem()
@@ -447,7 +447,7 @@ SystemData* SystemData::getRandomSystem()
 	}
 
 	// get random number in range
-	int target = (int) Math::round(((double)std::rand() / (double)RAND_MAX) * (total - 1));
+	int target = (int)Math::round((std::rand() / (float)RAND_MAX) * (total - 1));
 	for (auto it = sSystemVector.cbegin(); it != sSystemVector.cend(); it++)
 	{
 		if ((*it)->isGameSystem())
@@ -470,18 +470,18 @@ SystemData* SystemData::getRandomSystem()
 FileData* SystemData::getRandomGame()
 {
 	std::vector<FileData*> list = mRootFolder->getFilesRecursive(GAME, true);
-	unsigned int total = list.size();
+	unsigned int total = (int)list.size();
 	int target = 0;
 	// get random number in range
 	if (total == 0)
 		return NULL;
-	target = (int) Math::round(((double)std::rand() / (double)RAND_MAX) * (total - 1));
+	target = (int)Math::round((std::rand() / (float)RAND_MAX) * (total - 1));
 	return list.at(target);
 }
 
 unsigned int SystemData::getDisplayedGameCount() const
 {
-	return mRootFolder->getFilesRecursive(GAME, true).size();
+	return (unsigned int)mRootFolder->getFilesRecursive(GAME, true).size();
 }
 
 void SystemData::loadTheme()

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -462,7 +462,7 @@ void SystemScreenSaver::pickRandomCustomImage(std::string& path)
 			}
 		}
 
-		int fileCount = matchingFiles.size();
+		int fileCount = (int)matchingFiles.size();
 		if (fileCount > 0)
 		{
 			// get a random index in the range 0 to fileCount (exclusive)

--- a/es-app/src/VolumeControl.cpp
+++ b/es-app/src/VolumeControl.cpp
@@ -45,6 +45,7 @@ VolumeControl::VolumeControl(const VolumeControl & right):
 	, mixerHandle(nullptr), endpointVolume(nullptr)
 #endif
 {
+	(void)right;
 	sInstance = right.sInstance;
 }
 
@@ -300,7 +301,7 @@ int VolumeControl::getVolume() const
 		mixerControlDetails.cbDetails = sizeof(MIXERCONTROLDETAILS_UNSIGNED);
 		if (mixerGetControlDetails((HMIXEROBJ)mixerHandle, &mixerControlDetails, MIXER_GETCONTROLDETAILSF_VALUE) == MMSYSERR_NOERROR) 
 		{
-			volume = (uint8_t)Math::round((value.dwValue * 100) / 65535);
+			volume = (int)Math::round((value.dwValue * 100) / 65535.0f);
 		}
 		else
 		{
@@ -313,7 +314,7 @@ int VolumeControl::getVolume() const
 		float floatVolume = 0.0f; //0-1
 		if (endpointVolume->GetMasterVolumeLevelScalar(&floatVolume) == S_OK)
 		{
-			volume = (uint8_t)Math::round(floatVolume * 100.0f);
+			volume = (int)Math::round(floatVolume * 100.0f);
 			LOG(LogInfo) << " getting volume as " << volume << " ( from float " << floatVolume << ")";
 		}
 		else

--- a/es-app/src/components/AsyncReqComponent.cpp
+++ b/es-app/src/components/AsyncReqComponent.cpp
@@ -35,13 +35,13 @@ void AsyncReqComponent::update(int deltaTime)
 	mTime += deltaTime;
 }
 
-void AsyncReqComponent::render(const Transform4x4f& parentTrans)
+void AsyncReqComponent::render(const Transform4x4f& /*parentTrans*/)
 {
 	Transform4x4f trans = Transform4x4f::Identity();
 	trans = trans.translate(Vector3f(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f, 0));
 	Renderer::setMatrix(trans);
 
-	Vector3f point(Math::cos(mTime * 0.01f) * 12, Math::sin(mTime * 0.01f) * 12, 0);
+	Vector3f point(Math::cosf(mTime * 0.01f) * 12, Math::sinf(mTime * 0.01f) * 12, 0);
 	Renderer::drawRect((int)point.x(), (int)point.y(), 8, 8, 0x0000FFFF);
 }
 

--- a/es-app/src/components/ScraperSearchComponent.cpp
+++ b/es-app/src/components/ScraperSearchComponent.cpp
@@ -57,7 +57,7 @@ ScraperSearchComponent::ScraperSearchComponent(Window* window, SearchType type) 
 	mMD_Pairs.push_back(MetaDataPair(std::make_shared<TextComponent>(mWindow, "GENRE:", font, mdLblColor), mMD_Genre));
 	mMD_Pairs.push_back(MetaDataPair(std::make_shared<TextComponent>(mWindow, "PLAYERS:", font, mdLblColor), mMD_Players));
 
-	mMD_Grid = std::make_shared<ComponentGrid>(mWindow, Vector2i(2, mMD_Pairs.size()*2 - 1));
+	mMD_Grid = std::make_shared<ComponentGrid>(mWindow, Vector2i(2, (int)mMD_Pairs.size()*2 - 1));
 	unsigned int i = 0;
 	for(auto it = mMD_Pairs.cbegin(); it != mMD_Pairs.cend(); it++)
 	{

--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -63,7 +63,7 @@ public:
 			it->data.textCache.reset();
 	}
 
-	inline void setUppercase(bool uppercase) 
+	inline void setUppercase(bool /*uppercase*/) 
 	{
 		mUppercase = true;
 		for(auto it = mEntries.begin(); it != mEntries.end(); it++)
@@ -78,7 +78,7 @@ public:
 	inline void setLineSpacing(float lineSpacing) { mLineSpacing = lineSpacing; }
 
 protected:
-	virtual void onScroll(int amt) { if(!mScrollSound.empty()) Sound::get(mScrollSound)->play(); }
+	virtual void onScroll(int /*amt*/) { if(!mScrollSound.empty()) Sound::get(mScrollSound)->play(); }
 	virtual void onCursorChanged(const CursorState& state);
 
 private:
@@ -217,7 +217,7 @@ void TextListComponent<T>::render(const Transform4x4f& parentTrans)
 
 		// currently selected item text might be scrolling
 		if((mCursor == i) && (mMarqueeOffset > 0))
-			drawTrans.translate(offset - Vector3f(mMarqueeOffset, 0, 0));
+			drawTrans.translate(offset - Vector3f((float)mMarqueeOffset, 0, 0));
 		else
 			drawTrans.translate(offset);
 
@@ -229,7 +229,7 @@ void TextListComponent<T>::render(const Transform4x4f& parentTrans)
 		if((mCursor == i) && (mMarqueeOffset2 < 0))
 		{
 			drawTrans = trans;
-			drawTrans.translate(offset - Vector3f(mMarqueeOffset2, 0, 0));
+			drawTrans.translate(offset - Vector3f((float)mMarqueeOffset2, 0, 0));
 			Renderer::setMatrix(drawTrans);
 			font->renderTextCache(entry.data.textCache.get());
 		}
@@ -298,28 +298,28 @@ void TextListComponent<T>::update(int deltaTime)
 
 		// if we're not scrolling and this object's text goes outside our size, marquee it!
 		const float textLength = mFont->sizeText(mEntries.at((unsigned int)mCursor).name).x();
-		const int   limit      = mSize.x() - mHorizontalMargin * 2;
+		const float limit      = mSize.x() - mHorizontalMargin * 2;
 
 		if(textLength > limit)
 		{
 			// loop
 			// pixels per second ( based on nes-mini font at 1920x1080 to produce a speed of 200 )
 			const float speed        = mFont->sizeText("ABCDEFGHIJKLMNOPQRSTUVWXYZ").x() * 0.247f;
-			const int   delay        = 3000;
-			const int   scrollLength = textLength;
-			const int   returnLength = (int)(speed * 1.5);
-			const int   scrollTime   = (int)((scrollLength * 1000) / speed);
-			const int   returnTime   = (int)((returnLength * 1000) / speed);
-			const int   maxTime      = (delay + scrollTime + returnTime);
+			const float delay        = 3000;
+			const float scrollLength = textLength;
+			const float returnLength = speed * 1.5f;
+			const float scrollTime   = (scrollLength * 1000) / speed;
+			const float returnTime   = (returnLength * 1000) / speed;
+			const int   maxTime      = (int)(delay + scrollTime + returnTime);
 
 			mMarqueeTime += deltaTime;
 			while(mMarqueeTime > maxTime)
 				mMarqueeTime -= maxTime;
 
-			mMarqueeOffset = Math::Scroll::loop(delay, scrollTime + returnTime, mMarqueeTime, scrollLength + returnLength);
+			mMarqueeOffset = (int)(Math::Scroll::loop(delay, scrollTime + returnTime, (float)mMarqueeTime, scrollLength + returnLength));
 
 			if(mMarqueeOffset > (scrollLength - (limit - returnLength)))
-				mMarqueeOffset2 = mMarqueeOffset - (scrollLength + returnLength);
+				mMarqueeOffset2 = (int)(mMarqueeOffset - (scrollLength + returnLength));
 		}
 	}
 

--- a/es-app/src/guis/GuiFastSelect.cpp
+++ b/es-app/src/guis/GuiFastSelect.cpp
@@ -35,8 +35,8 @@ GuiFastSelect::GuiFastSelect(Window* window, IGameListView* gamelist) : GuiCompo
 	mSortId = 0; // TODO
 	updateSortText();
 
-	mLetterId = LETTERS.find(mGameList->getCursor()->getName()[0]);
-	if(mLetterId == std::string::npos)
+	mLetterId = (int)LETTERS.find(mGameList->getCursor()->getName()[0]);
+	if(mLetterId == (int)std::string::npos)
 		mLetterId = 0;
 
 	mScrollDir = 0;
@@ -80,7 +80,7 @@ bool GuiFastSelect::input(InputConfig* config, Input input)
 	{
 		mSortId--;
 		if(mSortId < 0)
-			mSortId += FileSorts::SortTypes.size();
+			mSortId += (int)FileSorts::SortTypes.size();
 
 		updateSortText();
 		return true;
@@ -115,9 +115,9 @@ void GuiFastSelect::scroll()
 {
 	mLetterId += mScrollDir;
 	if(mLetterId < 0)
-		mLetterId += LETTERS.length();
+		mLetterId += (int)LETTERS.length();
 	else if(mLetterId >= (int)LETTERS.length())
-		mLetterId -= LETTERS.length();
+		mLetterId -= (int)LETTERS.length();
 
 	mLetterText.setText(LETTERS.substr(mLetterId, 1));
 }

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -29,7 +29,7 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 		char startChar = '!';
 		char endChar = '_';
 
-		char curChar = toupper(getGamelist()->getCursor()->getName()[0]);
+		char curChar = (char)toupper(getGamelist()->getCursor()->getName()[0]);
 		if(curChar < startChar || curChar > endChar)
 			curChar = startChar;
 
@@ -40,7 +40,7 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 			const std::vector<FileData*>& files = getGamelist()->getCursor()->getParent()->getChildrenListToDisplay();
 			for (auto file : files)
 			{
-				char candidate = toupper(file->getName()[0]);
+				char candidate = (char)toupper(file->getName()[0]);
 				if (c == candidate)
 				{
 					mJumpToLetterList->add(std::string(1, c), c, c == curChar);
@@ -206,7 +206,7 @@ void GuiGamelistOptions::jumpToLetter()
 	const std::vector<FileData*>& files = gamelist->getCursor()->getParent()->getChildrenListToDisplay();
 
 	long min = 0;
-	long max = files.size() - 1;
+	long max = (long)files.size() - 1;
 	long mid = 0;
 
 	while(max >= min)
@@ -217,7 +217,7 @@ void GuiGamelistOptions::jumpToLetter()
 		if(files.at(mid)->getName().empty())
 			continue;
 
-		char checkLetter = toupper(files.at(mid)->getName()[0]);
+		char checkLetter = (char)toupper(files.at(mid)->getName()[0]);
 
 		if(checkLetter < letter)
 			min = mid + 1;

--- a/es-app/src/guis/GuiInfoPopup.cpp
+++ b/es-app/src/guis/GuiInfoPopup.cpp
@@ -63,7 +63,7 @@ GuiInfoPopup::~GuiInfoPopup()
 
 }
 
-void GuiInfoPopup::render(const Transform4x4f& parentTrans)
+void GuiInfoPopup::render(const Transform4x4f& /*parentTrans*/)
 {
 	// we use identity as we want to render on a specific window position, not on the view
 	Transform4x4f trans = getTransform() * Transform4x4f::Identity();
@@ -108,7 +108,7 @@ bool GuiInfoPopup::updateState()
 	{
 		alpha = ((-(curTime - mStartTime - mDuration)*255)/500);
 	}
-	mGrid->setOpacity(alpha);
+	mGrid->setOpacity((unsigned char)alpha);
 
 	// apply fade in effect to popup frame
 	mFrame->setEdgeColor(0xFFFFFF00 | (unsigned char)(alpha));

--- a/es-app/src/guis/GuiMetaDataEd.cpp
+++ b/es-app/src/guis/GuiMetaDataEd.cpp
@@ -20,7 +20,7 @@
 #include "Window.h"
 
 GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector<MetaDataDecl>& mdd, ScraperSearchParams scraperParams,
-	const std::string& header, std::function<void()> saveCallback, std::function<void()> deleteFunc) : GuiComponent(window),
+	const std::string& /*header*/, std::function<void()> saveCallback, std::function<void()> deleteFunc) : GuiComponent(window),
 	mScraperParams(scraperParams),
 
 	mBackground(window, ":/frame.png"),
@@ -156,7 +156,7 @@ GuiMetaDataEd::GuiMetaDataEd(Window* window, MetaDataList* md, const std::vector
 	mGrid.setEntry(mButtons, Vector2i(0, 2), true, false);
 
 	// resize + center	
-	float width = (float) Math::min(Renderer::getScreenHeight(), (unsigned int) (Renderer::getScreenWidth() * 0.90f));
+	float width = (float)Math::min(Renderer::getScreenHeight(), (int)(Renderer::getScreenWidth() * 0.90f));
 	setSize(width, Renderer::getScreenHeight() * 0.82f);
 	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
 }

--- a/es-app/src/guis/GuiScraperMulti.cpp
+++ b/es-app/src/guis/GuiScraperMulti.cpp
@@ -23,7 +23,7 @@ GuiScraperMulti::GuiScraperMulti(Window* window, const std::queue<ScraperSearchP
 	PowerSaver::pause();
 	mIsProcessing = true;
 
-	mTotalGames = mSearchQueue.size();
+	mTotalGames = (int)mSearchQueue.size();
 	mCurrentGame = 0;
 	mTotalSuccessful = 0;
 	mTotalSkipped = 0;

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -206,7 +206,7 @@ void SystemView::update(int deltaTime)
 	GuiComponent::update(deltaTime);
 }
 
-void SystemView::onCursorChanged(const CursorState& state)
+void SystemView::onCursorChanged(const CursorState& /*state*/)
 {
 	// update help style
 	updateHelpPrompts();
@@ -388,7 +388,7 @@ HelpStyle SystemView::getHelpStyle()
 	return style;
 }
 
-void  SystemView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
+void  SystemView::onThemeChanged(const std::shared_ptr<ThemeData>& /*theme*/)
 {
 	LOG(LogDebug) << "SystemView::onThemeChanged()";
 	mViewNeedsReload = true;
@@ -488,9 +488,9 @@ void SystemView::renderCarousel(const Transform4x4f& trans)
 	{
 		int index = i;
 		while (index < 0)
-			index += mEntries.size();
+			index += (int)mEntries.size();
 		while (index >= (int)mEntries.size())
-			index -= mEntries.size();
+			index -= (int)mEntries.size();
 
 		Transform4x4f logoTrans = carouselTrans;
 		logoTrans.translate(Vector3f(i * logoSpacing[0] + xOff, i * logoSpacing[1] + yOff, 0));
@@ -501,7 +501,7 @@ void SystemView::renderCarousel(const Transform4x4f& trans)
 		scale = Math::min(mCarousel.logoScale, Math::max(1.0f, scale));
 		scale /= mCarousel.logoScale;
 
-		int opacity = (int) Math::round(0x80 + ((0xFF - 0x80) * (1.0f - fabs(distance))));
+		int opacity = (int)Math::round(0x80 + ((0xFF - 0x80) * (1.0f - fabs(distance))));
 		opacity = Math::max((int) 0x80, opacity);
 
 		const std::shared_ptr<GuiComponent> &comp = mEntries.at(index).data.logo;
@@ -510,7 +510,7 @@ void SystemView::renderCarousel(const Transform4x4f& trans)
 			comp->setRotationOrigin(mCarousel.logoRotationOrigin);
 		}
 		comp->setScale(scale);
-		comp->setOpacity(opacity);
+		comp->setOpacity((unsigned char)opacity);
 		comp->render(logoTrans);
 	}
 	Renderer::popClipRect();
@@ -536,9 +536,9 @@ void SystemView::renderExtras(const Transform4x4f& trans, float lower, float upp
 	{
 		int index = i;
 		while (index < 0)
-			index += mEntries.size();
+			index += (int)mEntries.size();
 		while (index >= (int)mEntries.size())
-			index -= mEntries.size();
+			index -= (int)mEntries.size();
 
 		//Only render selected system when not showing
 		if (mShowing || index == mCursor)
@@ -631,7 +631,7 @@ void SystemView::getCarouselFromTheme(const ThemeData::ThemeElement* elem)
 	if (elem->has("logoSize"))
 		mCarousel.logoSize = elem->get<Vector2f>("logoSize") * mSize;
 	if (elem->has("maxLogoCount"))
-		mCarousel.maxLogoCount = (int) Math::round(elem->get<float>("maxLogoCount"));
+		mCarousel.maxLogoCount = (int)Math::round(elem->get<float>("maxLogoCount"));
 	if (elem->has("zIndex"))
 		mCarousel.zIndex = elem->get<float>("zIndex");
 	if (elem->has("logoRotation"))

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -62,7 +62,7 @@ void ViewController::goToStart()
 int ViewController::getSystemId(SystemData* system)
 {
 	std::vector<SystemData*>& sysVec = SystemData::sSystemVector;
-	return std::find(sysVec.cbegin(), sysVec.cend(), system) - sysVec.cbegin();
+	return (int)(std::find(sysVec.cbegin(), sysVec.cend(), system) - sysVec.cbegin());
 }
 
 void ViewController::goToSystemView(SystemData* system)
@@ -177,7 +177,7 @@ void ViewController::playViewTransition()
 	} else {
 		// instant
 		setAnimation(new LambdaAnimation(
-			[this, target](float t)
+			[this, target](float /*t*/)
 		{
 			this->mCamera.translation() = -target;
 		}, 1));
@@ -318,7 +318,7 @@ std::shared_ptr<IGameListView> ViewController::getGameListView(SystemData* syste
 	view->setTheme(system->getTheme());
 
 	std::vector<SystemData*>& sysVec = SystemData::sSystemVector;
-	int id = std::find(sysVec.cbegin(), sysVec.cend(), system) - sysVec.cbegin();
+	int id = (int)(std::find(sysVec.cbegin(), sysVec.cend(), system) - sysVec.cbegin());
 	view->setPosition(id * (float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight() * 2);
 
 	addChild(view.get());

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -110,7 +110,7 @@ void BasicGameListView::remove(FileData *game, bool deleteFile)
 	{
 		std::vector<FileData*> siblings = parent->getChildrenListToDisplay();
 		auto gameIter = std::find(siblings.cbegin(), siblings.cend(), game);
-		unsigned int gamePos = std::distance(siblings.cbegin(), gameIter);
+		unsigned int gamePos = (int)std::distance(siblings.cbegin(), gameIter);
 		if (gameIter != siblings.cend())
 		{
 			if ((gamePos + 1) < siblings.size())

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -21,7 +21,7 @@ DetailedGameListView::DetailedGameListView(Window* window, FileData* root) :
 	mList.setPosition(mSize.x() * (0.50f + padding), mList.getPosition().y());
 	mList.setSize(mSize.x() * (0.50f - padding), mList.getSize().y());
 	mList.setAlignment(TextListComponent<FileData*>::ALIGN_LEFT);
-	mList.setCursorChangedCallback([&](const CursorState& state) { updateInfoPanel(); });
+	mList.setCursorChangedCallback([&](const CursorState& /*state*/) { updateInfoPanel(); });
 
 	// image
 	mImage.setOrigin(0.5f, 0.5f);
@@ -119,7 +119,7 @@ void DetailedGameListView::initMDLabels()
 	std::vector<TextComponent*> components = getMDLabels();
 
 	const unsigned int colCount = 2;
-	const unsigned int rowCount = components.size() / 2;
+	const unsigned int rowCount = (int)(components.size() / 2);
 
 	Vector3f start(mSize.x() * 0.01f, mSize.y() * 0.625f, 0.0f);
 	

--- a/es-app/src/views/gamelist/IGameListView.cpp
+++ b/es-app/src/views/gamelist/IGameListView.cpp
@@ -46,8 +46,8 @@ void IGameListView::render(const Transform4x4f& parentTrans)
 	float scaleX = trans.r0().x();
 	float scaleY = trans.r1().y();
 
-	Vector2i pos(trans.translation()[0], trans.translation()[1]);
-	Vector2i size(mSize.x() * scaleX, mSize.y() * scaleY);
+	Vector2i pos((int)Math::round(trans.translation()[0]), (int)Math::round(trans.translation()[1]));
+	Vector2i size((int)Math::round(mSize.x() * scaleX), (int)Math::round(mSize.y() * scaleY));
 
 	Renderer::pushClipRect(pos, size);
 	renderChildren(trans);

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -59,7 +59,7 @@ void ISimpleGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme
 	}
 }
 
-void ISimpleGameListView::onFileChanged(FileData* file, FileChangeType change)
+void ISimpleGameListView::onFileChanged(FileData* /*file*/, FileChangeType /*change*/)
 {
 	// we could be tricky here to be efficient;
 	// but this shouldn't happen very often so we'll just always repopulate

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -40,7 +40,7 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 	mList.setPosition(mSize.x() * (0.50f + padding), mList.getPosition().y());
 	mList.setSize(mSize.x() * (0.50f - padding), mList.getSize().y());
 	mList.setAlignment(TextListComponent<FileData*>::ALIGN_LEFT);
-	mList.setCursorChangedCallback([&](const CursorState& state) { updateInfoPanel(); });
+	mList.setCursorChangedCallback([&](const CursorState& /*state*/) { updateInfoPanel(); });
 
 	// Marquee
 	mMarquee.setOrigin(0.5f, 0.5f);
@@ -158,7 +158,7 @@ void VideoGameListView::initMDLabels()
 	std::vector<TextComponent*> components = getMDLabels();
 
 	const unsigned int colCount = 2;
-	const unsigned int rowCount = components.size() / 2;
+	const unsigned int rowCount = (int)(components.size() / 2);
 
 	Vector3f start(mSize.x() * 0.01f, mSize.y() * 0.625f, 0.0f);
 

--- a/es-core/src/AudioManager.cpp
+++ b/es-core/src/AudioManager.cpp
@@ -10,7 +10,7 @@ SDL_AudioSpec AudioManager::sAudioFormat;
 std::shared_ptr<AudioManager> AudioManager::sInstance;
 
 
-void AudioManager::mixAudio(void *unused, Uint8 *stream, int len)
+void AudioManager::mixAudio(void* /*unused*/, Uint8 *stream, int len)
 {
 	bool stillPlaying = false;
 

--- a/es-core/src/GuiComponent.cpp
+++ b/es-core/src/GuiComponent.cpp
@@ -209,7 +209,7 @@ void GuiComponent::sortChildren()
 
 unsigned int GuiComponent::getChildCount() const
 {
-	return mChildren.size();
+	return (int)mChildren.size();
 }
 
 GuiComponent* GuiComponent::getChild(unsigned int i) const
@@ -270,7 +270,7 @@ const Transform4x4f& GuiComponent::getTransform()
 	return mTransform;
 }
 
-void GuiComponent::setValue(const std::string& value)
+void GuiComponent::setValue(const std::string& /*value*/)
 {
 }
 

--- a/es-core/src/ImageIO.cpp
+++ b/es-core/src/ImageIO.cpp
@@ -9,7 +9,7 @@ std::vector<unsigned char> ImageIO::loadFromMemoryRGBA32(const unsigned char * d
 	std::vector<unsigned char> rawData;
 	width = 0;
 	height = 0;
-	FIMEMORY * fiMemory = FreeImage_OpenMemory((BYTE *)data, size);
+	FIMEMORY * fiMemory = FreeImage_OpenMemory((BYTE *)data, (DWORD)size);
 	if (fiMemory != nullptr) {
 		//detect the filetype from data
 		FREE_IMAGE_FORMAT format = FreeImage_GetFileTypeFromMemory(fiMemory);
@@ -39,7 +39,7 @@ std::vector<unsigned char> ImageIO::loadFromMemoryRGBA32(const unsigned char * d
 					unsigned char * tempData = new unsigned char[width * height * 4];
 					for (size_t i = 0; i < height; i++)
 					{
-						const BYTE * scanLine = FreeImage_GetScanLine(fiBitmap, i);
+						const BYTE * scanLine = FreeImage_GetScanLine(fiBitmap, (int)i);
 						memcpy(tempData + (i * width * 4), scanLine, width * 4);
 					}
 					//convert from BGRA to RGBA

--- a/es-core/src/InputConfig.cpp
+++ b/es-core/src/InputConfig.cpp
@@ -43,7 +43,7 @@ std::string toLower(std::string str)
 {
 	for(unsigned int i = 0; i < str.length(); i++)
 	{
-		str[i] = tolower(str[i]);
+		str[i] = (char)tolower(str[i]);
 	}
 
 	return str;

--- a/es-core/src/InputConfig.h
+++ b/es-core/src/InputConfig.h
@@ -156,6 +156,8 @@ public:
 			case CEC::CEC_USER_CONTROL_CODE_AN_CHANNELS_LIST:            { return "AN-Channels-List";            } break;
 			default:                                                     { return "UNKNOWN";                     }
 		}
+#else // HAVE_LIBCEC
+		(void)keycode;
 #endif // HAVE_LIBCEC
 
 		return "UNKNOWN";

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -171,7 +171,7 @@ void InputManager::deinit()
 	SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
 }
 
-int InputManager::getNumJoysticks() { return mJoysticks.size(); }
+int InputManager::getNumJoysticks() { return (int)mJoysticks.size(); }
 int InputManager::getButtonCountByDevice(SDL_JoystickID id)
 {
 	if(id == DEVICE_KEYBOARD)

--- a/es-core/src/Renderer_draw_gl.cpp
+++ b/es-core/src/Renderer_draw_gl.cpp
@@ -18,10 +18,10 @@ namespace Renderer {
 
 	void setColor4bArray(GLubyte* array, unsigned int color)
 	{
-		array[0] = (color & 0xff000000) >> 24;
-		array[1] = (color & 0x00ff0000) >> 16;
-		array[2] = (color & 0x0000ff00) >> 8;
-		array[3] = (color & 0x000000ff);
+		array[0] = ((color & 0xff000000) >> 24) & 255;
+		array[1] = ((color & 0x00ff0000) >> 16) & 255;
+		array[2] = ((color & 0x0000ff00) >>  8) & 255;
+		array[3] = ((color & 0x000000ff)      ) & 255;
 	}
 
 	void buildGLColorArray(GLubyte* ptr, unsigned int color, unsigned int vertCount)

--- a/es-core/src/Renderer_init_sdlgl.cpp
+++ b/es-core/src/Renderer_init_sdlgl.cpp
@@ -85,7 +85,7 @@ namespace Renderer
 						Uint32 rmask = 0x000000ff; Uint32 gmask = 0x0000ff00; Uint32 bmask = 0x00ff0000; Uint32 amask = 0xff000000;
 			#endif
 			//try creating SDL surface from logo data
-			SDL_Surface * logoSurface = SDL_CreateRGBSurfaceFrom((void *)rawData.data(), width, height, 32, width * 4, rmask, gmask, bmask, amask);
+			SDL_Surface * logoSurface = SDL_CreateRGBSurfaceFrom((void *)rawData.data(), (int)width, (int)height, 32, (int)(width * 4), rmask, gmask, bmask, amask);
 			if (logoSurface != NULL)
 			{
 				SDL_SetWindowIcon(sdlWindow, logoSurface);

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -405,7 +405,7 @@ void ThemeData::parseElement(const pugi::xml_node& root, const std::map<std::str
 			std::string first = str.substr(0, divider);
 			std::string second = str.substr(divider, std::string::npos);
 
-			Vector2f val(atof(first.c_str()), atof(second.c_str()));
+			Vector2f val((float)atof(first.c_str()), (float)atof(second.c_str()));
 
 			element.properties[node.name()] = val;
 			break;

--- a/es-core/src/Util.cpp
+++ b/es-core/src/Util.cpp
@@ -12,14 +12,14 @@ std::string strToUpper(const char* from)
 {
 	std::string str(from);
 	for(unsigned int i = 0; i < str.size(); i++)
-		str[i] = toupper(from[i]);
+		str[i] = (char)toupper(from[i]);
 	return str;
 }
 
 std::string& strToUpper(std::string& str)
 {
 	for(unsigned int i = 0; i < str.size(); i++)
-		str[i] = toupper(str[i]);
+		str[i] = (char)toupper(str[i]);
 
 	return str;
 }

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -356,7 +356,7 @@ void Window::setHelpPrompts(const std::vector<HelpPrompt>& prompts, const HelpSt
 				}
 			}else{
 				// no, it hasn't!
-				mappedToSeenMap.emplace(it->second, addPrompts.size());
+				mappedToSeenMap.emplace(it->second, (int)addPrompts.size());
 				addPrompts.push_back(*it);
 			}
 		}
@@ -439,7 +439,7 @@ void Window::startScreenSaver()
  		mScreenSaver->renderScreenSaver();
  }
 
-bool Window::PassKeyListener::isUIModeChanged(InputConfig * config, Input input, Window* window)
+bool Window::PassKeyListener::isUIModeChanged(InputConfig * config, Input input, Window* /*window*/)
 {
 	// This function reads the current input to listen for the passkey
 	// sequence to unlock the UI mode. The progress is saved in mPassKeyCounter
@@ -468,7 +468,7 @@ bool Window::PassKeyListener::isUIModeChanged(InputConfig * config, Input input,
 		this->mPassKeyCounter = 0; // current input is incorrect, reset counter
 	}
 
-	if (this->mPassKeyCounter == (this->mPassKeySequence.length()))
+	if (this->mPassKeyCounter == (int)(this->mPassKeySequence.length()))
 	{
 		// When we have reached the end of the list, trigger UI_mode unlock
 		LOG(LogDebug) << " Window::PassKeyListener::isUIModeChanged(): Passkey sequence completed, switching UIMode to full";

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -61,7 +61,7 @@ public:
 	void pushGui(GuiComponent* gui);
 	void removeGui(GuiComponent* gui);
 	GuiComponent* peekGui();
-	inline int getGuiStackSize() { return mGuiStack.size(); }
+	inline int getGuiStackSize() { return (int)mGuiStack.size(); }
 
 	void textInput(const char* text);
 	void input(InputConfig* config, Input input);

--- a/es-core/src/components/AnimatedImageComponent.cpp
+++ b/es-core/src/components/AnimatedImageComponent.cpp
@@ -61,7 +61,7 @@ void AnimatedImageComponent::update(int deltaTime)
 	{
 		mCurrentFrame++;
 
-		if(mCurrentFrame == mFrames.size())
+		if(mCurrentFrame == (int)mFrames.size())
 		{
 			if(mLoop)
 			{

--- a/es-core/src/components/ComponentGrid.cpp
+++ b/es-core/src/components/ComponentGrid.cpp
@@ -195,7 +195,7 @@ void ComponentGrid::updateSeparators()
 	}
 
 	mLineColors.reserve(mLines.size());
-	Renderer::buildGLColorArray((GLubyte*)mLineColors.data(), 0xC6C7C6FF, mLines.size());
+	Renderer::buildGLColorArray((GLubyte*)mLineColors.data(), 0xC6C7C6FF, (unsigned int)mLines.size());
 }
 
 void ComponentGrid::onSizeChanged()
@@ -374,7 +374,7 @@ void ComponentGrid::render(const Transform4x4f& parentTrans)
 		glVertexPointer(2, GL_FLOAT, 0, &mLines[0].x);
 		glColorPointer(4, GL_UNSIGNED_BYTE, 0, mLineColors.data());
 
-		glDrawArrays(GL_LINES, 0, mLines.size());
+		glDrawArrays(GL_LINES, 0, (GLsizei)mLines.size());
 
 		glDisable(GL_BLEND);
 		glDisableClientState(GL_VERTEX_ARRAY);

--- a/es-core/src/components/ComponentList.cpp
+++ b/es-core/src/components/ComponentList.cpp
@@ -28,7 +28,7 @@ void ComponentList::addRow(const ComponentListRow& row, bool setCursorHere)
 
 	if(setCursorHere)
 	{
-		mCursor = mEntries.size() - 1;
+		mCursor = (int)mEntries.size() - 1;
 		onCursorChanged(CURSOR_STOPPED);
 	}
 }

--- a/es-core/src/components/DateTimeComponent.cpp
+++ b/es-core/src/components/DateTimeComponent.cpp
@@ -90,7 +90,7 @@ bool DateTimeComponent::input(InputConfig* config, Input input)
 			}
 
 			//validate day
-			int days_in_month = boost::gregorian::date(new_tm.tm_year + 1900, new_tm.tm_mon + 1, 1).end_of_month().day().as_number();
+			int days_in_month = boost::gregorian::date((unsigned short)new_tm.tm_year + 1900, (unsigned short)new_tm.tm_mon + 1, 1).end_of_month().day().as_number();
 			if(new_tm.tm_mday > days_in_month)
 				new_tm.tm_mday = days_in_month;
 

--- a/es-core/src/components/HelpComponent.cpp
+++ b/es-core/src/components/HelpComponent.cpp
@@ -60,7 +60,7 @@ void HelpComponent::updateGrid()
 
 	std::shared_ptr<Font>& font = mStyle.font;
 
-	mGrid = std::make_shared<ComponentGrid>(mWindow, Vector2i(mPrompts.size() * 4, 1));
+	mGrid = std::make_shared<ComponentGrid>(mWindow, Vector2i((int)mPrompts.size() * 4, 1));
 	// [icon] [spacer1] [text] [spacer2]
 	
 	std::vector< std::shared_ptr<ImageComponent> > icons;

--- a/es-core/src/components/IList.h
+++ b/es-core/src/components/IList.h
@@ -143,7 +143,7 @@ public:
 		{
 			if((*it).object == obj)
 			{
-				mCursor = it - mEntries.cbegin();
+				mCursor = (int)(it - mEntries.cbegin());
 				onCursorChanged(CURSOR_STOPPED);
 				return true;
 			}
@@ -172,7 +172,7 @@ public:
 		return false;
 	}
 
-	inline int size() const { return mEntries.size(); }
+	inline int size() const { return (int)mEntries.size(); }
 
 protected:
 	void remove(typename std::vector<Entry>::const_iterator& it)
@@ -244,7 +244,7 @@ protected:
 			scroll(mScrollVelocity);
 	}
 
-	void listRenderTitleOverlay(const Transform4x4f& trans)
+	void listRenderTitleOverlay(const Transform4x4f& /*trans*/)
 	{
 		if(size() == 0 || !mTitleOverlayFont || mTitleOverlayOpacity == 0)
 			return;
@@ -305,8 +305,8 @@ protected:
 		onCursorChanged((mScrollTier > 0) ? CURSOR_SCROLLING : CURSOR_STOPPED);
 	}
 
-	virtual void onCursorChanged(const CursorState& state) {}
-	virtual void onScroll(int amt) {}
+	virtual void onCursorChanged(const CursorState& /*state*/) {}
+	virtual void onScroll(int /*amt*/) {}
 };
 
 #endif // ES_CORE_COMPONENTS_ILIST_H

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -81,7 +81,7 @@ void ImageComponent::resize()
 		}
 	}
 	// mSize.y() should already be rounded
-	mTexture->rasterizeAt((int)Math::round(mSize.x()), (int)Math::round(mSize.y()));
+	mTexture->rasterizeAt((size_t)Math::round(mSize.x()), (size_t)Math::round(mSize.y()));
 
 	onSizeChanged();
 }

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -77,7 +77,7 @@ private:
 	Vector2i getGridSize() const
 	{
 		Vector2f squareSize = getMaxSquareSize();
-		Vector2i gridSize(mSize.x() / (squareSize.x() + getPadding().x()), mSize.y() / (squareSize.y() + getPadding().y()));
+		Vector2i gridSize((int)(mSize.x() / (squareSize.x() + getPadding().x())), (int)(mSize.y() / (squareSize.y() + getPadding().y())));
 		return gridSize;
 	};
 
@@ -167,7 +167,7 @@ void ImageGridComponent<T>::render(const Transform4x4f& parentTrans)
 }
 
 template<typename T>
-void ImageGridComponent<T>::onCursorChanged(const CursorState& state)
+void ImageGridComponent<T>::onCursorChanged(const CursorState& /*state*/)
 {
 	updateImages();
 }

--- a/es-core/src/components/MenuComponent.cpp
+++ b/es-core/src/components/MenuComponent.cpp
@@ -62,7 +62,7 @@ void MenuComponent::updateSize()
 		}
 	}
 
-	float width = (float) Math::min(Renderer::getScreenHeight(), (unsigned int) (Renderer::getScreenWidth() * 0.90f));
+	float width = (float)Math::min((int)Renderer::getScreenHeight(), (int)(Renderer::getScreenWidth() * 0.90f));
 	setSize(width, height);
 }
 
@@ -105,7 +105,7 @@ std::vector<HelpPrompt> MenuComponent::getHelpPrompts()
 
 std::shared_ptr<ComponentGrid> makeButtonGrid(Window* window, const std::vector< std::shared_ptr<ButtonComponent> >& buttons)
 {
-	std::shared_ptr<ComponentGrid> buttonGrid = std::make_shared<ComponentGrid>(window, Vector2i(buttons.size(), 2));
+	std::shared_ptr<ComponentGrid> buttonGrid = std::make_shared<ComponentGrid>(window, Vector2i((int)buttons.size(), 2));
 
 	float buttonGridWidth = (float)BUTTON_GRID_HORIZ_PADDING * buttons.size(); // initialize to padding
 	for(int i = 0; i < (int)buttons.size(); i++)

--- a/es-core/src/components/NinePatchComponent.cpp
+++ b/es-core/src/components/NinePatchComponent.cpp
@@ -51,7 +51,7 @@ void NinePatchComponent::buildVertices()
 	mColors = new GLubyte[6 * 9 * 4];
 	updateColors();
 
-	const Vector2f ts = Vector2f(mTexture->getSize().x(), mTexture->getSize().y());
+	const Vector2f ts = Vector2f((float)mTexture->getSize().x(), (float)mTexture->getSize().y());
 
 	//coordinates on the image in pixels, top left origin
 	const Vector2f pieceCoords[9] = {

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -193,7 +193,7 @@ public:
 					unsigned int i = getSelectedId();
 					int next = (int)i - 1;
 					if(next < 0)
-						next += mEntries.size();
+						next += (int)mEntries.size();
 
 					mEntries.at(i).selected = false;
 					mEntries.at(next).selected = true;

--- a/es-core/src/components/ScrollableContainer.cpp
+++ b/es-core/src/components/ScrollableContainer.cpp
@@ -18,7 +18,7 @@ void ScrollableContainer::render(const Transform4x4f& parentTrans)
 	Vector2i clipPos((int)trans.translation().x(), (int)trans.translation().y());
 
 	Vector3f dimScaled = trans * Vector3f(mSize.x(), mSize.y(), 0);
-	Vector2i clipDim((int)dimScaled.x() - trans.translation().x(), (int)dimScaled.y() - trans.translation().y());
+	Vector2i clipDim((int)(dimScaled.x() - trans.translation().x()), (int)(dimScaled.y() - trans.translation().y()));
 
 	Renderer::pushClipRect(clipPos, clipDim);
 

--- a/es-core/src/components/TextEditComponent.cpp
+++ b/es-core/src/components/TextEditComponent.cpp
@@ -62,11 +62,11 @@ void TextEditComponent::textInput(const char* text)
 			{
 				size_t newCursor = Utils::String::prevCursor(mText, mCursor);
 				mText.erase(mText.begin() + newCursor, mText.begin() + mCursor);
-				mCursor = newCursor;
+				mCursor = (unsigned int)newCursor;
 			}
 		}else{
 			mText.insert(mCursor, text);
-			mCursor += strlen(text);
+			mCursor += (unsigned int)strlen(text);
 		}
 	}
 
@@ -191,14 +191,14 @@ void TextEditComponent::updateCursorRepeat(int deltaTime)
 
 void TextEditComponent::moveCursor(int amt)
 {
-	mCursor = Utils::String::moveCursor(mText, mCursor, amt);
+	mCursor = (unsigned int)Utils::String::moveCursor(mText, mCursor, amt);
 	onCursorChanged();
 }
 
 void TextEditComponent::setCursor(size_t pos)
 {
 	if(pos == std::string::npos)
-		mCursor = mText.length();
+		mCursor = (unsigned int)mText.length();
 	else
 		mCursor = (int)pos;
 
@@ -211,7 +211,7 @@ void TextEditComponent::onTextChanged()
 	mTextCache = std::unique_ptr<TextCache>(mFont->buildTextCache(wrappedText, 0, 0, 0x77777700 | getOpacity()));
 
 	if(mCursor > (int)mText.length())
-		mCursor = mText.length();
+		mCursor = (unsigned int)mText.length();
 }
 
 void TextEditComponent::onCursorChanged()
@@ -251,7 +251,7 @@ void TextEditComponent::render(const Transform4x4f& parentTrans)
 
 	Vector2i clipPos((int)trans.translation().x(), (int)trans.translation().y());
 	Vector3f dimScaled = trans * Vector3f(getTextAreaSize().x(), getTextAreaSize().y(), 0); // use "text area" size for clipping
-	Vector2i clipDim((int)dimScaled.x() - trans.translation().x(), (int)dimScaled.y() - trans.translation().y());
+	Vector2i clipDim((int)(dimScaled.x() - trans.translation().x()), (int)(dimScaled.y() - trans.translation().y()));
 	Renderer::pushClipRect(clipPos, clipDim);
 
 	trans.translate(Vector3f(-mScrollOffset.x(), -mScrollOffset.y(), 0));

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -23,14 +23,14 @@ static void *lock(void *data, void **p_pixels) {
 }
 
 // VLC just rendered a video frame.
-static void unlock(void *data, void *id, void *const *p_pixels) {
+static void unlock(void *data, void* /*id*/, void *const* /*p_pixels*/) {
 	struct VideoContext *c = (struct VideoContext *)data;
 	SDL_UnlockSurface(c->surface);
 	SDL_UnlockMutex(c->mutex);
 }
 
 // VLC wants to display a video frame.
-static void display(void *data, void *id) {
+static void display(void* /*data*/, void* /*id*/) {
 	//Data to be displayed
 }
 
@@ -73,7 +73,7 @@ void VideoVlcComponent::resize()
 	if(!mTexture)
 		return;
 
-	const Vector2f textureSize(mVideoWidth, mVideoHeight);
+	const Vector2f textureSize((float)mVideoWidth, (float)mVideoHeight);
 
 	if(textureSize == Vector2f::Zero())
 		return;
@@ -123,7 +123,7 @@ void VideoVlcComponent::resize()
 		}
 
 	// mSize.y() should already be rounded
-	mTexture->rasterizeAt((int)Math::round(mSize.x()), (int)Math::round(mSize.y()));
+	mTexture->rasterizeAt((size_t)Math::round(mSize.x()), (size_t)Math::round(mSize.y()));
 
 	onSizeChanged();
 }
@@ -317,7 +317,7 @@ void VideoVlcComponent::startVideo()
 					{
 						if(!Settings::getInstance()->getBool("CaptionsCompatibility")) {
 
-							Vector2f resizeScale((Renderer::getScreenWidth() / mVideoWidth), (Renderer::getScreenHeight() / mVideoHeight));
+							Vector2f resizeScale((Renderer::getScreenWidth() / (float)mVideoWidth), (Renderer::getScreenHeight() / (float)mVideoHeight));
 
 							if(resizeScale.x() < resizeScale.y())
 							{
@@ -327,8 +327,6 @@ void VideoVlcComponent::startVideo()
 								mVideoWidth = (unsigned int) (mVideoWidth * resizeScale.y());
 								mVideoHeight = (unsigned int) (mVideoHeight * resizeScale.y());
 							}
-							mVideoHeight = (unsigned int) Math::round(mVideoHeight);
-							mVideoWidth = (unsigned int) Math::round(mVideoWidth);
 						}
 					}
 #endif

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -248,7 +248,7 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 	}
 
 	// only show "HOLD TO SKIP" if this input is skippable
-	mList->setCursorChangedCallback([this](CursorState state) {
+	mList->setCursorChangedCallback([this](CursorState /*state*/) {
 		bool skippable = inputSkippable[mList->getCursorId()];
 		mSubtitle2->setOpacity(skippable * 255);
 	});
@@ -381,7 +381,7 @@ void GuiInputConfig::setAssignedTo(const std::shared_ptr<TextComponent>& text, I
 	text->setColor(0x777777FF);
 }
 
-void GuiInputConfig::error(const std::shared_ptr<TextComponent>& text, const std::string& msg)
+void GuiInputConfig::error(const std::shared_ptr<TextComponent>& text, const std::string& /*msg*/)
 {
 	text->setText("ALREADY TAKEN");
 	text->setColor(0x656565FF);

--- a/es-core/src/math/Misc.cpp
+++ b/es-core/src/math/Misc.cpp
@@ -5,17 +5,41 @@
 namespace Math
 {
 	// added here to avoid including math.h whenever these are used
-	double cos(const double _num)
+	float cosf(const float _num)
 	{
-		return ::cos(_num);
+		return ::cosf(_num);
 
 	} // Math::cos
 
-	double sin(const double _num)
+	float sinf(const float _num)
 	{
-		return ::sin(_num);
+		return ::sinf(_num);
 
 	} // Math::sin
+
+	float floorf(const float _num)
+	{
+		return ::floorf(_num);
+
+	} // Math::floor
+
+	float ceilf(const float _num)
+	{
+		return ::ceilf(_num);
+
+	} // Math::ceil
+
+	int min(const int _num1, const int _num2)
+	{
+		return (_num1 < _num2) ? _num1 : _num2;
+
+	} // Math::min
+
+	int max(const int _num1, const int _num2)
+	{
+		return (_num1 > _num2) ? _num1 : _num2;
+
+	} // Math::max
 
 	float min(const float _num1, const float _num2)
 	{
@@ -37,7 +61,7 @@ namespace Math
 
 	float round(const float _num)
 	{
-		return (int)(_num + 0.5);
+		return (float)(int)(_num + 0.5);
 
 	} // Math::round
 
@@ -63,7 +87,7 @@ namespace Math
 
 	namespace Scroll
 	{
-		float bounce(const float _delayTime, const float _scrollTime, const float _currentTime, const int _scrollLength)
+		float bounce(const float _delayTime, const float _scrollTime, const float _currentTime, const float _scrollLength)
 		{
 			if(_currentTime < _delayTime)
 			{
@@ -93,7 +117,7 @@ namespace Math
 
 		} // Math::Scroll::bounce
 
-		float loop(const float _delayTime, const float _scrollTime, const float _currentTime, const int _scrollLength)
+		float loop(const float _delayTime, const float _scrollTime, const float _currentTime, const float _scrollLength)
 		{
 			if(_currentTime < _delayTime)
 			{

--- a/es-core/src/math/Misc.h
+++ b/es-core/src/math/Misc.h
@@ -9,9 +9,13 @@
 namespace Math
 {
 	// added here to avoid including math.h whenever these are used
-	double cos(const double _num);
-	double sin(const double _num);
+	float cosf(const float _num);
+	float sinf(const float _num);
+	float floorf(const float _num);
+	float ceilf(const float _num);
 
+	int min(const int _num1, const int _num2);
+	int max(const int _num1, const int _num2);
 	float min(const float _num1, const float _num2);
 	float max(const float _num1, const float _num2);
 	float clamp(const float _num, const float _min, const float _max);
@@ -22,8 +26,8 @@ namespace Math
 	
 	namespace Scroll
 	{
-		float bounce(const float _delayTime, const float _scrollTime, const float _currentTime, const int _scrollLength);
-		float loop(const float _delayTime, const float _scrollTime, const float _currentTime, const int _scrollLength);
+		float bounce(const float _delayTime, const float _scrollTime, const float _currentTime, const float _scrollLength);
+		float loop(const float _delayTime, const float _scrollTime, const float _currentTime, const float _scrollLength);
 
 	} // Math::Scroll::
 

--- a/es-core/src/math/Transform4x4f.cpp
+++ b/es-core/src/math/Transform4x4f.cpp
@@ -138,8 +138,8 @@ Transform4x4f& Transform4x4f::rotate(const float _angle, const Vector3f& _axis)
 {
 	float*       tm      = (float*)this;
 	const float* av      = (float*)&_axis;
-	const float  s       = Math::sin(-_angle);
-	const float  c       = Math::cos(-_angle);
+	const float  s       = Math::sinf(-_angle);
+	const float  c       = Math::cosf(-_angle);
 	const float  t       = 1 - c;
 	const float  x       = av[0];
 	const float  y       = av[1];
@@ -186,8 +186,8 @@ Transform4x4f& Transform4x4f::rotate(const float _angle, const Vector3f& _axis)
 Transform4x4f& Transform4x4f::rotateX(const float _angle)
 {
 	float*      tm      = (float*)this;
-	const float s       = Math::sin(-_angle);
-	const float c       = Math::cos(-_angle);
+	const float s       = Math::sinf(-_angle);
+	const float c       = Math::cosf(-_angle);
 	const float temp[6] = { tm[ 1] *  c + tm[ 2] * s,
 		                    tm[ 1] * -s + tm[ 2] * c,
 		                    tm[ 5] *  c + tm[ 6] * s,
@@ -209,8 +209,8 @@ Transform4x4f& Transform4x4f::rotateX(const float _angle)
 Transform4x4f& Transform4x4f::rotateY(const float _angle)
 {
 	float*      tm      = (float*)this;
-	const float s       = Math::sin(-_angle);
-	const float c       = Math::cos(-_angle);
+	const float s       = Math::sinf(-_angle);
+	const float c       = Math::cosf(-_angle);
 	const float temp[6] = { tm[ 0] * c + tm[ 2] * -s,
 		                    tm[ 0] * s + tm[ 2] *  c,
 		                    tm[ 4] * c + tm[ 6] * -s,
@@ -232,8 +232,8 @@ Transform4x4f& Transform4x4f::rotateY(const float _angle)
 Transform4x4f& Transform4x4f::rotateZ(const float _angle)
 {
 	float*      tm      = (float*)this;
-	const float s       = Math::sin(-_angle);
-	const float c       = Math::cos(-_angle);
+	const float s       = Math::sinf(-_angle);
+	const float c       = Math::cosf(-_angle);
 	const float temp[6] = { tm[ 0] *  c + tm[ 1] * s,
 		                    tm[ 0] * -s + tm[ 1] * c,
 		                    tm[ 4] *  c + tm[ 5] * s,
@@ -269,9 +269,9 @@ Transform4x4f& Transform4x4f::round()
 {
 	float* tm = (float*)this;
 
-	tm[12] = (int)(tm[12] + 0.5f);
-	tm[13] = (int)(tm[13] + 0.5f);
-	tm[14] = (int)(tm[14] + 0.5f);
+	tm[12] = (float)(int)(tm[12] + 0.5f);
+	tm[13] = (float)(int)(tm[13] + 0.5f);
+	tm[14] = (float)(int)(tm[14] + 0.5f);
 
 	return *this;
 

--- a/es-core/src/math/Vector2f.cpp
+++ b/es-core/src/math/Vector2f.cpp
@@ -2,8 +2,8 @@
 
 Vector2f& Vector2f::round()
 {
-	mX = (int)(mX + 0.5f);
-	mY = (int)(mY + 0.5f);
+	mX = (float)(int)(mX + 0.5f);
+	mY = (float)(int)(mY + 0.5f);
 		
 	return *this;
 	

--- a/es-core/src/math/Vector3f.cpp
+++ b/es-core/src/math/Vector3f.cpp
@@ -2,9 +2,9 @@
 
 Vector3f& Vector3f::round()
 {
-	mX = (int)(mX + 0.5f);
-	mY = (int)(mY + 0.5f);
-	mZ = (int)(mZ + 0.5f);
+	mX = (float)(int)(mX + 0.5f);
+	mY = (float)(int)(mY + 0.5f);
+	mZ = (float)(int)(mZ + 0.5f);
 	
 	return *this;
 

--- a/es-core/src/math/Vector4f.cpp
+++ b/es-core/src/math/Vector4f.cpp
@@ -2,10 +2,10 @@
 
 Vector4f& Vector4f::round()
 {
-	mX = (int)(mX + 0.5f);
-	mY = (int)(mY + 0.5f);
-	mZ = (int)(mZ + 0.5f);
-	mW = (int)(mW + 0.5f);
+	mX = (float)(int)(mX + 0.5f);
+	mY = (float)(int)(mY + 0.5f);
+	mZ = (float)(int)(mZ + 0.5f);
+	mW = (float)(int)(mW + 0.5f);
 	
 	return *this;
 

--- a/es-core/src/resources/Font.cpp
+++ b/es-core/src/resources/Font.cpp
@@ -13,7 +13,7 @@ std::map< std::pair<std::string, int>, std::weak_ptr<Font> > Font::sFontMap;
 
 Font::FontFace::FontFace(ResourceData&& d, int size) : data(d)
 {
-	int err = FT_New_Memory_Face(sLibrary, data.ptr.get(), data.length, 0, &face);
+	int err = FT_New_Memory_Face(sLibrary, data.ptr.get(), (FT_Long)data.length, 0, &face);
 	assert(!err);
 	
 	if(!err)
@@ -89,12 +89,12 @@ Font::~Font()
 	unload(ResourceManager::getInstance());
 }
 
-void Font::reload(std::shared_ptr<ResourceManager>& rm)
+void Font::reload(std::shared_ptr<ResourceManager>& /*rm*/)
 {
 	rebuildTextures();
 }
 
-void Font::unload(std::shared_ptr<ResourceManager>& rm)
+void Font::unload(std::shared_ptr<ResourceManager>& /*rm*/)
 {
 	unloadTextures();
 }
@@ -387,8 +387,8 @@ void Font::rebuildTextures()
 		FontTexture* tex = it->second.texture;
 		
 		// find the position/size
-		Vector2i cursor(it->second.texPos.x() * tex->textureSize.x(), it->second.texPos.y() * tex->textureSize.y());
-		Vector2i glyphSize(it->second.texSize.x() * tex->textureSize.x(), it->second.texSize.y() * tex->textureSize.y());
+		Vector2i cursor((int)(it->second.texPos.x() * tex->textureSize.x()), (int)(it->second.texPos.y() * tex->textureSize.y()));
+		Vector2i glyphSize((int)(it->second.texSize.x() * tex->textureSize.x()), (int)(it->second.texSize.y() * tex->textureSize.y()));
 		
 		// upload to texture
 		glBindTexture(GL_TEXTURE_2D, tex->textureId);
@@ -425,7 +425,7 @@ void Font::renderTextCache(TextCache* cache)
 		glTexCoordPointer(2, GL_FLOAT, sizeof(TextCache::Vertex), &it->verts[0].tex);
 		glColorPointer(4, GL_UNSIGNED_BYTE, 0, it->colors.data());
 
-		glDrawArrays(GL_TRIANGLES, 0, it->verts.size());
+		glDrawArrays(GL_TRIANGLES, 0, (GLsizei)(it->verts.size()));
 
 		glDisableClientState(GL_VERTEX_ARRAY);
 		glDisableClientState(GL_TEXTURE_COORD_ARRAY);
@@ -582,12 +582,12 @@ float Font::getNewlineStartOffset(const std::string& text, const unsigned int& c
 		return 0;
 	case ALIGN_CENTER:
 		{
-			unsigned int endChar = text.find('\n', charStart);
+			unsigned int endChar = (unsigned int)text.find('\n', charStart);
 			return (xLen - sizeText(text.substr(charStart, endChar != std::string::npos ? endChar - charStart : endChar)).x()) / 2.0f;
 		}
 	case ALIGN_RIGHT:
 		{
-			unsigned int endChar = text.find('\n', charStart);
+			unsigned int endChar = (unsigned int)text.find('\n', charStart);
 			return xLen - (sizeText(text.substr(charStart, endChar != std::string::npos ? endChar - charStart : endChar)).x());
 		}
 	default:
@@ -619,7 +619,7 @@ TextCache* Font::buildTextCache(const std::string& text, Vector2f offset, unsign
 		if(character == '\n')
 		{
 			y += getHeight(lineSpacing);
-			x = offset[0] + (xLen != 0 ? getNewlineStartOffset(text, cursor /* cursor is already advanced */, xLen, alignment) : 0);
+			x = offset[0] + (xLen != 0 ? getNewlineStartOffset(text, (const unsigned int)cursor /* cursor is already advanced */, xLen, alignment) : 0);
 			continue;
 		}
 
@@ -678,7 +678,7 @@ TextCache* Font::buildTextCache(const std::string& text, Vector2f offset, unsign
 		vertList.verts = it->second;
 
 		vertList.colors.resize(4 * it->second.size());
-		Renderer::buildGLColorArray(vertList.colors.data(), color, it->second.size());
+		Renderer::buildGLColorArray(vertList.colors.data(), color, (unsigned int)(it->second.size()));
 	}
 
 	clearFaceCache();
@@ -694,7 +694,7 @@ TextCache* Font::buildTextCache(const std::string& text, float offsetX, float of
 void TextCache::setColor(unsigned int color)
 {
 	for(auto it = vertexLists.cbegin(); it != vertexLists.cend(); it++)
-		Renderer::buildGLColorArray((GLubyte*)(it->colors.data()), color, it->verts.size());
+		Renderer::buildGLColorArray((GLubyte*)(it->colors.data()), color, (unsigned int)(it->verts.size()));
 }
 
 std::shared_ptr<Font> Font::getFromTheme(const ThemeData::ThemeElement* elem, unsigned int properties, const std::shared_ptr<Font>& orig)

--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -13,10 +13,10 @@
 
 class TextCache;
 
-#define FONT_SIZE_MINI ((unsigned int)(0.030f * Math::min(Renderer::getScreenHeight(), Renderer::getScreenWidth())))
-#define FONT_SIZE_SMALL ((unsigned int)(0.035f * Math::min(Renderer::getScreenHeight(), Renderer::getScreenWidth())))
-#define FONT_SIZE_MEDIUM ((unsigned int)(0.045f * Math::min(Renderer::getScreenHeight(), Renderer::getScreenWidth())))
-#define FONT_SIZE_LARGE ((unsigned int)(0.085f * Math::min(Renderer::getScreenHeight(), Renderer::getScreenWidth())))
+#define FONT_SIZE_MINI ((unsigned int)(0.030f * Math::min((int)Renderer::getScreenHeight(), (int)Renderer::getScreenWidth())))
+#define FONT_SIZE_SMALL ((unsigned int)(0.035f * Math::min((int)Renderer::getScreenHeight(), (int)Renderer::getScreenWidth())))
+#define FONT_SIZE_MEDIUM ((unsigned int)(0.045f * Math::min((int)Renderer::getScreenHeight(), (int)Renderer::getScreenWidth())))
+#define FONT_SIZE_LARGE ((unsigned int)(0.085f * Math::min((int)Renderer::getScreenHeight(), (int)Renderer::getScreenWidth())))
 
 #define FONT_PATH_LIGHT ":/opensans_hebrew_condensed_light.ttf"
 #define FONT_PATH_REGULAR ":/opensans_hebrew_condensed_regular.ttf"

--- a/es-core/src/resources/ResourceManager.cpp
+++ b/es-core/src/resources/ResourceManager.cpp
@@ -7,7 +7,7 @@
 namespace fs = boost::filesystem;
 
 auto array_deleter = [](unsigned char* p) { delete[] p; };
-auto nop_deleter = [](unsigned char* p) { };
+auto nop_deleter = [](unsigned char* /*p*/) { };
 
 std::shared_ptr<ResourceManager> ResourceManager::sInstance = nullptr;
 

--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -79,7 +79,7 @@ bool TextureData::initSVGFromMemory(const unsigned char* fileData, size_t length
 	unsigned char* dataRGBA = new unsigned char[mWidth * mHeight * 4];
 
 	NSVGrasterizer* rast = nsvgCreateRasterizer();
-	nsvgRasterize(rast, svgImage, 0, 0, mHeight / svgImage->height, dataRGBA, mWidth, mHeight, mWidth * 4);
+	nsvgRasterize(rast, svgImage, 0, 0, mHeight / svgImage->height, dataRGBA, (int)mWidth, (int)mHeight, (int)mWidth * 4);
 	nsvgDeleteRasterizer(rast);
 
 	ImageIO::flipPixelsVert(dataRGBA, mWidth, mHeight);
@@ -182,7 +182,7 @@ bool TextureData::uploadAndBind()
 		glGenTextures(1, &mTextureID);
 		glBindTexture(GL_TEXTURE_2D, mTextureID);
 
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mWidth, mHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, mDataRGBA);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei)mWidth, (GLsizei)mHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, mDataRGBA);
 
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/es-core/src/resources/TextureResource.cpp
+++ b/es-core/src/resources/TextureResource.cpp
@@ -31,7 +31,7 @@ TextureResource::TextureResource(const std::string& path, bool tile, bool dynami
 			data->load();
 		}
 
-		mSize = Vector2i(data->width(), data->height());
+		mSize = Vector2i((int)data->width(), (int)data->height());
 		mSourceSize = Vector2f(data->sourceWidth(), data->sourceHeight());
 	}
 	else
@@ -58,7 +58,7 @@ void TextureResource::initFromPixels(const unsigned char* dataRGBA, size_t width
 	mTextureData->releaseRAM();
 	mTextureData->initFromRGBA(dataRGBA, width, height);
 	// Cache the image dimensions
-	mSize = Vector2i(width, height);
+	mSize = Vector2i((int)width, (int)height);
 	mSourceSize = Vector2f(mTextureData->sourceWidth(), mTextureData->sourceHeight());
 }
 
@@ -70,7 +70,7 @@ void TextureResource::initFromMemory(const char* data, size_t length)
 	mTextureData->releaseRAM();
 	mTextureData->initImageFromMemory((const unsigned char*)data, length);
 	// Get the size from the texture data
-	mSize = Vector2i(mTextureData->width(), mTextureData->height());
+	mSize = Vector2i((int)mTextureData->width(), (int)mTextureData->height());
 	mSourceSize = Vector2f(mTextureData->sourceWidth(), mTextureData->sourceHeight());
 }
 
@@ -199,7 +199,7 @@ size_t TextureResource::getTotalTextureSize()
 	return total;
 }
 
-void TextureResource::unload(std::shared_ptr<ResourceManager>& rm)
+void TextureResource::unload(std::shared_ptr<ResourceManager>& /*rm*/)
 {
 	// Release the texture's resources
 	std::shared_ptr<TextureData> data;
@@ -212,7 +212,7 @@ void TextureResource::unload(std::shared_ptr<ResourceManager>& rm)
 	data->releaseRAM();
 }
 
-void TextureResource::reload(std::shared_ptr<ResourceManager>& rm)
+void TextureResource::reload(std::shared_ptr<ResourceManager>& /*rm*/)
 {
 	// For dynamically loaded textures the texture manager will load them on demand.
 	// For manually loaded textures we have to reload them here

--- a/es-core/src/utils/StringUtil.cpp
+++ b/es-core/src/utils/StringUtil.cpp
@@ -51,22 +51,22 @@ namespace Utils
 
 			if(_unicode < 0x80) // one byte character
 			{
-				result += ((_unicode      )       );
+				result += ((_unicode      ) & 0xFF);
 			}
 			else if(_unicode < 0x800) // two byte character
 			{
-				result += ((_unicode >>  6)       ) | 0xC0;
+				result += ((_unicode >>  6) & 0xFF) | 0xC0;
 				result += ((_unicode      ) & 0x3F) | 0x80;
 			}
 			else if(_unicode < 0xFFFF) // three byte character
 			{
-				result += ((_unicode >> 12)       ) | 0xE0;
+				result += ((_unicode >> 12) & 0xFF) | 0xE0;
 				result += ((_unicode >>  6) & 0x3F) | 0x80;
 				result += ((_unicode      ) & 0x3F) | 0x80;
 			}
 			else if(_unicode <= 0x1fffff) // four byte character
 			{
-				result += ((_unicode >> 18)       ) | 0xF0;
+				result += ((_unicode >> 18) & 0xFF) | 0xF0;
 				result += ((_unicode >> 12) & 0x3F) | 0x80;
 				result += ((_unicode >>  6) & 0x3F) | 0x80;
 				result += ((_unicode      ) & 0x3F) | 0x80;


### PR DESCRIPTION
When I saw the output from the failing compile that @jrassa did I got reminded of all the warnings in ES that still wasn't silenced, this patch should silence all but 1 of them ( the last one being about GetVersionEx being deprecated in the Windows 8.1 SDK, so didn't fix that one )