### PR TITLE
Fixes favorites crashing when removing last entry

### DIFF
--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -111,7 +111,7 @@ void BasicGameListView::remove(FileData *game, bool deleteFile)
 	{
 		std::vector<FileData*> siblings = parent->getChildrenListToDisplay();
 		auto gameIter = std::find(siblings.cbegin(), siblings.cend(), game);
-		unsigned int gamePos = (int)std::distance(siblings.cbegin(), gameIter);
+		int gamePos = (int)std::distance(siblings.cbegin(), gameIter);
 		if (gameIter != siblings.cend())
 		{
 			if ((gamePos + 1) < siblings.size())


### PR DESCRIPTION
Regression somewhere down the line when we explicitly set typecasts here.
Fixes #317.

By the way, sometime between 2.6.0 and now, we've also broken the systemview for empty collections, in that they do not show up even though they're enabled.

I'll try to bisect that.

Should be safe to merge, really.