### PR TITLE
Fix: VLC player not muting audio after first loop

### DIFF
--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -264,6 +264,10 @@ void VideoVlcComponent::handleLooping()
 		libvlc_state_t state = libvlc_media_player_get_state(mMediaPlayer);
 		if (state == libvlc_Ended)
 		{
+			if (!Settings::getInstance()->getBool("VideoAudio"))
+			{
+				libvlc_audio_set_mute(mMediaPlayer, 1);
+			}
 			//libvlc_media_player_set_position(mMediaPlayer, 0.0f);
 			libvlc_media_player_set_media(mMediaPlayer, mMedia);
 			libvlc_media_player_play(mMediaPlayer);


### PR DESCRIPTION
Issue: With `VideoAudio` set to `false` in the es_settings.cfg file, the VLC player was only muting the audio on the first play of the video, but not upon looping.

```
# Linux arcade 4.13.0-21-generic #24-Ubuntu SMP Mon Dec 18 17:29:16 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
libvlc-dev/artful,now 2.2.6-6 amd64
libvlccore-dev/artful,now 2.2.6-6 amd64
```

This fix reapplies the mute setting for each loop.

