### PR TITLE
fix resolvePlaceholders to handle multiple variables in a single string

### DIFF
--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -188,7 +188,7 @@ std::string resolvePlaceholders(const char* in)
 
 	std::string prefix  = inStr.substr(0, variableBegin);
 	std::string replace = inStr.substr(variableBegin + 2, variableEnd - (variableBegin + 2));
-	std::string suffix  = inStr.substr(variableEnd + 1);
+	std::string suffix  = resolvePlaceholders(inStr.substr(variableEnd + 1).c_str());
 
 	return prefix + mVariables[replace] + suffix;
 }


### PR DESCRIPTION
Fixes a bug introduced in #333.  Reported in the [forums](https://retropie.org.uk/forum/topic/7156/variable-support-in-themes-in-emulationstation/79).

Theme variables were only resolving the first variable in a given value.  This was breaking the snes-mini theme.  For the example below only the `${region}` variable was resolved.
```
<path>./art/icons${region}/${system.theme}.png</path>
```

@tomaz82, let me know if you have any suggestions on a better way to implement this.