### PR TITLE
Update README to reflect Eigen3 dependency removal

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -23,9 +23,9 @@ You probably want to override:
 	`void update(int deltaTime);`
 		`deltaTime` is in milliseconds.
 
-	`void render(const Eigen::Affine3f& parentTrans);`
-		You probably want to do `Eigen::Affine3f trans = parentTrans * getTransform();` to get your final "modelview" matrix.
-		Apply the modelview matrix with `Renderer::setMatrix(const Eigen::Affine3f&)`.
+	`void render(const Transform4x4f& parentTrans);`
+		You probably want to do `Transform4x4f trans = parentTrans * getTransform();` to get your final "modelview" matrix.
+		Apply the modelview matrix with `Renderer::setMatrix(const Transform4x4f&)`.
 		Render any children the component may have with `renderChildren(parentTrans);`.
 
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Building
 
 EmulationStation uses some C++11 code, which means you'll need to use at least g++-4.7 on Linux, or VS2010 on Windows, to compile.
 
-EmulationStation has a few dependencies. For building, you'll need CMake, SDL2, Boost (System, Filesystem, DateTime, Locale), FreeImage, FreeType, Eigen3, and cURL.  You also should probably install the `fonts-droid` package which contains fallback fonts for Chinese/Japanese/Korean characters, but ES will still work fine without it (this package is only used at run-time).
+EmulationStation has a few dependencies. For building, you'll need CMake, SDL2, Boost (System, Filesystem, DateTime, Locale), FreeImage, FreeType, and cURL.  You also should probably install the `fonts-droid` package which contains fallback fonts for Chinese/Japanese/Korean characters, but ES will still work fine without it (this package is only used at run-time).
 
 **On Debian/Ubuntu:**
 All of this be easily installed with apt-get:
 ```bash
 sudo apt-get install libsdl2-dev libboost-system-dev libboost-filesystem-dev libboost-date-time-dev \
-  libboost-locale-dev libfreeimage-dev libfreetype6-dev libeigen3-dev libcurl4-openssl-dev \
+  libboost-locale-dev libfreeimage-dev libfreetype6-dev libcurl4-openssl-dev \
   libasound2-dev libgl1-mesa-dev build-essential cmake fonts-droid \
   libvlc-dev libvlccore-dev vlc-nox
 ```
@@ -48,8 +48,6 @@ Complete Raspberry Pi build instructions at [emulationstation.org](http://emulat
 **On Windows:**
 
 [Boost](http://www.boost.org/users/download/) (you'll need to compile yourself or get the pre-compiled binaries)
-
-[Eigen3](http://eigen.tuxfamily.org/index.php?title=Main_Page) (header-only library)
 
 [FreeImage](http://downloads.sourceforge.net/freeimage/FreeImage3154Win32.zip)
 


### PR DESCRIPTION
I want to preface this PR with the fact that I am not a C++ developer, just an EmulationStation enthusiast.

It seems that the dependency on Eigen3 has been removed as of PR #263, this just cleans up the README and a single documentation file where Eigen was still mentioned.