### PR TITLE
Add support for --screenrotate

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -70,6 +70,17 @@ bool parseArgs(int argc, char* argv[])
 			i += 2; // skip the argument value
 			Settings::getInstance()->setInt("ScreenOffsetX", x);
 			Settings::getInstance()->setInt("ScreenOffsetY", y);
+		}else if (strcmp(argv[i], "--screenrotate") == 0)
+		{
+			if (i >= argc - 1)
+			{
+				std::cerr << "Invalid screenrotate supplied.";
+				return false;
+			}
+
+			int rotate = atoi(argv[i + 1]);
+			++i; // skip the argument value
+			Settings::getInstance()->setInt("ScreenRotate", rotate);
 		}else if(strcmp(argv[i], "--gamelist-only") == 0)
 		{
 			Settings::getInstance()->setBool("ParseGamelistOnly", true);

--- a/es-core/src/Renderer.h
+++ b/es-core/src/Renderer.h
@@ -24,6 +24,7 @@ namespace Renderer
 	unsigned int getScreenHeight();
 	unsigned int getScreenOffsetX();
 	unsigned int getScreenOffsetY();
+	unsigned int getScreenRotate();
 
 	void buildGLColorArray(GLubyte* ptr, unsigned int color, unsigned int vertCount);
 

--- a/es-core/src/Renderer_draw_gl.cpp
+++ b/es-core/src/Renderer_draw_gl.cpp
@@ -69,7 +69,13 @@ namespace Renderer {
 			box.h = 0;
 
 		clipStack.push(box);
-		glScissor(box.x, box.y, box.w, box.h);
+		switch(Renderer::getScreenRotate())
+		{
+			case 0: { glScissor(box.x,                                       box.y,                                       box.w, box.h); } break;
+			case 1: { glScissor(box.y,                                       Renderer::getScreenWidth()  - box.x - box.w, box.h, box.w); } break;
+			case 2: { glScissor(Renderer::getScreenWidth()  - box.x - box.w, Renderer::getScreenHeight() - box.y - box.h, box.w, box.h); } break;
+			case 3: { glScissor(Renderer::getScreenHeight() - box.y - box.h, box.x,                                       box.h, box.w); } break;
+		}
 		glEnable(GL_SCISSOR_TEST);
 	}
 
@@ -87,7 +93,13 @@ namespace Renderer {
 			glDisable(GL_SCISSOR_TEST);
 		}else{
 			const ClipRect& top = clipStack.top();
-			glScissor(top.x, top.y, top.w, top.h);
+			switch(Renderer::getScreenRotate())
+			{
+				case 0: { glScissor(top.x,                                       top.y,                                       top.w, top.h); } break;
+				case 1: { glScissor(top.y,                                       Renderer::getScreenWidth()  - top.x - top.w, top.h, top.w); } break;
+				case 2: { glScissor(Renderer::getScreenWidth()  - top.x - top.w, Renderer::getScreenHeight() - top.y - top.h, top.w, top.h); } break;
+				case 3: { glScissor(Renderer::getScreenHeight() - top.y - top.h, top.x,                                       top.h, top.w); } break;
+			}
 		}
 	}
 

--- a/es-core/src/Renderer_draw_gl.cpp
+++ b/es-core/src/Renderer_draw_gl.cpp
@@ -45,9 +45,21 @@ namespace Renderer {
 		//glScissor starts at the bottom left of the window
 		//so (0, 0, 1, 1) is the bottom left pixel
 		//everything else uses y+ = down, so flip it to be consistent
-		//also take screen height and offset into account
-		box.x = Renderer::getScreenOffsetX() + box.x;
-		box.y = Renderer::getWindowHeight() - Renderer::getScreenOffsetY() - box.y - box.h;
+		switch(Renderer::getScreenRotate())
+		{
+			case 0: { box = ClipRect(box.x,                                         Renderer::getWindowHeight() - (box.y + box.h),                     box.w, box.h); } break;
+			case 1: { box = ClipRect(Renderer::getScreenHeight() - (box.y + box.h), Renderer::getWindowWidth()  - (box.x + box.w),                     box.h, box.w); } break;
+			case 2: { box = ClipRect(Renderer::getScreenWidth()  - (box.x + box.w), Renderer::getWindowHeight() - Renderer::getScreenHeight() + box.y, box.w, box.h); } break;
+			case 3: { box = ClipRect(box.y,                                         Renderer::getWindowWidth()  - Renderer::getScreenWidth()  + box.x, box.h, box.w); } break;
+		}
+
+		switch(Renderer::getScreenRotate())
+		{
+			case 0: { box.x += Renderer::getScreenOffsetX(); box.y -= Renderer::getScreenOffsetY(); } break;
+			case 1: { box.x += Renderer::getScreenOffsetY(); box.y -= Renderer::getScreenOffsetX(); } break;
+			case 2: { box.x += Renderer::getScreenOffsetX(); box.y -= Renderer::getScreenOffsetY(); } break;
+			case 3: { box.x += Renderer::getScreenOffsetY(); box.y -= Renderer::getScreenOffsetX(); } break;
+		}
 
 		//make sure the box fits within clipStack.top(), and clip further accordingly
 		if(clipStack.size())
@@ -69,13 +81,8 @@ namespace Renderer {
 			box.h = 0;
 
 		clipStack.push(box);
-		switch(Renderer::getScreenRotate())
-		{
-			case 0: { glScissor(box.x,                                       box.y,                                       box.w, box.h); } break;
-			case 1: { glScissor(box.y,                                       Renderer::getScreenWidth()  - box.x - box.w, box.h, box.w); } break;
-			case 2: { glScissor(Renderer::getScreenWidth()  - box.x - box.w, Renderer::getScreenHeight() - box.y - box.h, box.w, box.h); } break;
-			case 3: { glScissor(Renderer::getScreenHeight() - box.y - box.h, box.x,                                       box.h, box.w); } break;
-		}
+
+		glScissor(box.x, box.y, box.w, box.h);
 		glEnable(GL_SCISSOR_TEST);
 	}
 
@@ -93,13 +100,7 @@ namespace Renderer {
 			glDisable(GL_SCISSOR_TEST);
 		}else{
 			const ClipRect& top = clipStack.top();
-			switch(Renderer::getScreenRotate())
-			{
-				case 0: { glScissor(top.x,                                       top.y,                                       top.w, top.h); } break;
-				case 1: { glScissor(top.y,                                       Renderer::getScreenWidth()  - top.x - top.w, top.h, top.w); } break;
-				case 2: { glScissor(Renderer::getScreenWidth()  - top.x - top.w, Renderer::getScreenHeight() - top.y - top.h, top.w, top.h); } break;
-				case 3: { glScissor(Renderer::getScreenHeight() - top.y - top.h, top.x,                                       top.h, top.w); } break;
-			}
+			glScissor(top.x, top.y, top.w, top.h);
 		}
 	}
 

--- a/es-core/src/Renderer_init_sdlgl.cpp
+++ b/es-core/src/Renderer_init_sdlgl.cpp
@@ -20,6 +20,7 @@ namespace Renderer
 	unsigned int screenHeight  = 0;
 	unsigned int screenOffsetX = 0;
 	unsigned int screenOffsetY = 0;
+	unsigned int screenRotate  = 0;
 
 	unsigned int getWindowWidth()   { return windowWidth; }
 	unsigned int getWindowHeight()  { return windowHeight; }
@@ -27,6 +28,7 @@ namespace Renderer
 	unsigned int getScreenHeight()  { return screenHeight; }
 	unsigned int getScreenOffsetX() { return screenOffsetX; }
 	unsigned int getScreenOffsetY() { return screenOffsetY; }
+	unsigned int getScreenRotate()  { return screenRotate; }
 
 	SDL_Window* sdlWindow = NULL;
 	SDL_GLContext sdlContext = NULL;
@@ -66,6 +68,7 @@ namespace Renderer
 		screenHeight  = Settings::getInstance()->getInt("ScreenHeight")  ? Settings::getInstance()->getInt("ScreenHeight")  : windowHeight;
 		screenOffsetX = Settings::getInstance()->getInt("ScreenOffsetX") ? Settings::getInstance()->getInt("ScreenOffsetX") : 0;
 		screenOffsetY = Settings::getInstance()->getInt("ScreenOffsetY") ? Settings::getInstance()->getInt("ScreenOffsetY") : 0;
+		screenRotate  = Settings::getInstance()->getInt("ScreenRotate")  ? Settings::getInstance()->getInt("ScreenRotate")  : 0;
 
 		sdlWindow = SDL_CreateWindow("EmulationStation", 
 			SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 
@@ -79,6 +82,21 @@ namespace Renderer
 		}
 
 		LOG(LogInfo) << "Created window successfully.";
+
+		//support screen rotation
+		if((screenRotate == 1) || (screenRotate == 3))
+		{
+			int temp;
+			temp          = windowWidth;
+			windowWidth   = windowHeight;
+			windowHeight  = temp;
+			temp          = screenWidth;
+			screenWidth   = screenHeight;
+			screenHeight  = temp;
+			temp          = screenOffsetX;
+			screenOffsetX = screenOffsetY;
+			screenOffsetY = temp;
+		}
 
 		//set an icon for the window
 		size_t width = 0;
@@ -143,9 +161,47 @@ namespace Renderer
 			return false;
 
 		//gotta flip y since y=0 is at the bottom
-		glViewport(screenOffsetX, windowHeight - screenHeight - screenOffsetY, screenWidth, screenHeight);
-		glMatrixMode(GL_PROJECTION);
-		glOrtho(0, screenWidth, screenHeight, 0, -1.0, 1.0);
+		switch(screenRotate)
+		{
+			case 0:
+			{
+				glViewport(screenOffsetX, windowHeight - screenHeight - screenOffsetY, screenWidth, screenHeight);
+				glMatrixMode(GL_PROJECTION);
+				glOrtho(0, screenWidth, screenHeight, 0, -1.0, 1.0);
+			}
+			break;
+
+			case 1:
+			{
+				glViewport(screenOffsetY, windowWidth - screenWidth - screenOffsetX, screenHeight, screenWidth);
+				glMatrixMode(GL_PROJECTION);
+				glOrtho(0, screenHeight, screenWidth, 0, -1.0, 1.0);
+				glRotatef(90, 0, 0, 1);
+				glTranslatef(0, screenHeight * -1.0f, 0);
+			}
+			break;
+
+			case 2:
+			{
+				glViewport(screenOffsetX, windowHeight - screenHeight - screenOffsetY, screenWidth, screenHeight);
+				glMatrixMode(GL_PROJECTION);
+				glOrtho(0, screenWidth, screenHeight, 0, -1.0, 1.0);
+				glRotatef(180, 0, 0, 1);
+				glTranslatef(screenWidth * -1.0f, screenHeight * -1.0f, 0);
+			}
+			break;
+
+			case 3:
+			{
+				glViewport(screenOffsetY, windowWidth - screenWidth - screenOffsetX, screenHeight, screenWidth);
+				glMatrixMode(GL_PROJECTION);
+				glOrtho(0, screenHeight, screenWidth, 0, -1.0, 1.0);
+				glRotatef(270, 0, 0, 1);
+				glTranslatef(screenWidth * -1.0f, 0, 0);
+			}
+			break;
+		}
+
 		glMatrixMode(GL_MODELVIEW);
 		glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -26,7 +26,8 @@ std::vector<const char*> settings_dont_save {
 	{ "ScreenWidth" },
 	{ "ScreenHeight" },
 	{ "ScreenOffsetX" },
-	{ "ScreenOffsetY" }
+	{ "ScreenOffsetY" },
+	{ "ScreenRotate" }
 };
 
 Settings::Settings()
@@ -140,6 +141,7 @@ void Settings::setDefaults()
 	mIntMap["ScreenHeight"]  = 0;
 	mIntMap["ScreenOffsetX"] = 0;
 	mIntMap["ScreenOffsetY"] = 0;
+	mIntMap["ScreenRotate"]  = 0;
 }
 
 template <typename K, typename V>


### PR DESCRIPTION
Basically does what display_rotate does in config.txt, except doing it for ES only, and without the penalty that comes with doing a 90 or 270 degree rotation using display_rotate. This also works for platforms that doesn't allow to have the OS or whatnot to do the rotation.

It maps the same as display_rotate
--screenrotate 0 == nothing
--screenrotate 1 == 90 degrees
--screenrotate 2 == 180 degrees
--screenrotate 3 == 270 degrees

Only tested with default Carbon theme which looks "ok" but obviously wrong in the case of 1 and 3, will need a theme made for a reversed aspect ratio ( 9/16 instead of 16/9 if using a 16/9 screen )

Thanks to @zanac who did the first part