### PR TITLE
Fixing first favorites not updating index

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -491,6 +491,7 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file)
 		}
 		else
 		{
+			file->getSourceFileData()->getSystem()->getIndex()->removeFromIndex(file);
 			MetaDataList* md = &file->getSourceFileData()->metadata;
 			std::string value = md->get("favorite");
 			if (value == "false")
@@ -502,6 +503,7 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file)
 				adding = false;
 				md->set("favorite", "false");
 			}
+			file->getSourceFileData()->getSystem()->getIndex()->addToIndex(file);
 			refreshCollectionSystems(file->getSourceFileData());
 		}
 		if (adding)


### PR DESCRIPTION
Removing and adding entry to index when adding/removing favorites.
Should fix the case of updating the filters list when there are no favorites and they're added via pressing Y.
Should fix #349 .

The fact that Favorites don't show up when empty is being handled in #325 , together with the rest of the collections.