### PR TITLE
boost::filesystem replacement, step 1

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -1,6 +1,7 @@
 #include "CollectionSystemManager.h"
 
 #include "guis/GuiInfoPopup.h"
+#include "utils/FileSystemUtil.h"
 #include "utils/StringUtil.h"
 #include "views/gamelist/IGameListView.h"
 #include "views/ViewController.h"
@@ -50,8 +51,8 @@ CollectionSystemManager::CollectionSystemManager(Window* window) : mWindow(windo
 	mCollectionEnvData->mPlatformIds = allPlatformIds;
 
 	std::string path = getCollectionsFolder();
-	if(!boost::filesystem::exists(path))
-		boost::filesystem::create_directory(path);
+	if(!Utils::FileSystem::exists(path))
+		Utils::FileSystem::createDirectory(path);
 
 	mIsEditingCustom = false;
 	mEditingCollection = "Favorites";
@@ -332,7 +333,7 @@ bool CollectionSystemManager::isThemeCustomCollectionCompatible(std::vector<std:
 	if(set != themeSets.cend())
 	{
 		std::string defaultThemeFilePath = set->second.path.string() + "/theme.xml";
-		if (boost::filesystem::exists(defaultThemeFilePath))
+		if (Utils::FileSystem::exists(defaultThemeFilePath))
 		{
 			return true;
 		}
@@ -722,7 +723,7 @@ void CollectionSystemManager::populateCustomCollection(CollectionSystemData* sys
 	CollectionSystemDecl sysDecl = sysData->decl;
 	std::string path = getCustomCollectionConfigPath(newSys->getName());
 
-	if(!boost::filesystem::exists(path))
+	if(!Utils::FileSystem::exists(path))
 	{
 		LOG(LogInfo) << "Couldn't find custom collection config file at " << path;
 		return;
@@ -829,7 +830,7 @@ std::vector<std::string> CollectionSystemManager::getSystemsFromConfig()
 	std::vector<std::string> systems;
 	std::string path = SystemData::getConfigPath(false);
 
-	if(!boost::filesystem::exists(path))
+	if(!Utils::FileSystem::exists(path))
 	{
 		return systems;
 	}
@@ -882,18 +883,18 @@ std::vector<std::string> CollectionSystemManager::getSystemsFromTheme()
 
 	boost::filesystem::path themePath = set->second.path;
 
-	if (boost::filesystem::exists(themePath))
+	if (Utils::FileSystem::exists(themePath.generic_string()))
 	{
 		boost::filesystem::directory_iterator end_itr; // default construction yields past-the-end
 		for (boost::filesystem::directory_iterator itr(themePath); itr != end_itr; ++itr)
 		{
-			if (boost::filesystem::is_directory(itr->status()))
+			if (Utils::FileSystem::isDirectory(itr->path().generic_string()))
 			{
 				//... here you have a directory
 				std::string folder = itr->path().string();
 				folder = folder.substr(themePath.string().size()+1);
 
-				if(boost::filesystem::exists(set->second.getThemePath(folder)))
+				if(Utils::FileSystem::exists(set->second.getThemePath(folder).generic_string()))
 				{
 					systems.push_back(folder);
 				}
@@ -942,12 +943,12 @@ std::vector<std::string> CollectionSystemManager::getCollectionsFromConfigFolder
 	std::vector<std::string> systems;
 	boost::filesystem::path configPath = getCollectionsFolder();
 
-	if (boost::filesystem::exists(configPath))
+	if (Utils::FileSystem::exists(configPath.generic_string()))
 	{
 		boost::filesystem::directory_iterator end_itr; // default construction yields past-the-end
 		for (boost::filesystem::directory_iterator itr(configPath); itr != end_itr; ++itr)
 		{
-			if (boost::filesystem::is_regular_file(itr->status()))
+			if (Utils::FileSystem::isRegularFile(itr->path().generic_string()))
 			{
 				// it's a file
 				std::string file = itr->path().string();

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -1,5 +1,6 @@
 #include "FileData.h"
 
+#include "utils/FileSystemUtil.h"
 #include "utils/StringUtil.h"
 #include "utils/TimeUtil.h"
 #include "AudioManager.h"
@@ -12,7 +13,6 @@
 #include "Util.h"
 #include "VolumeControl.h"
 #include "Window.h"
-#include <boost/filesystem/operations.hpp>
 
 FileData::FileData(FileType type, const boost::filesystem::path& path, SystemEnvironmentData* envData, SystemData* system)
 	: mType(type), mPath(path), mSystem(system), mEnvData(envData), mSourceFileData(NULL), mParent(NULL), metadata(type == GAME ? GAME_METADATA : FOLDER_METADATA) // metadata is REALLY set in the constructor!
@@ -66,7 +66,7 @@ const std::string FileData::getThumbnailPath() const
 				if(thumbnail.empty())
 				{
 					std::string path = mEnvData->mStartPath + "/images/" + getDisplayName() + "-image" + extList[i];
-					if(boost::filesystem::exists(path))
+					if(Utils::FileSystem::exists(path))
 						thumbnail = path;
 				}
 			}
@@ -109,7 +109,7 @@ const std::string FileData::getVideoPath() const
 	if(video.empty())
 	{
 		std::string path = mEnvData->mStartPath + "/images/" + getDisplayName() + "-video.mp4";
-		if(boost::filesystem::exists(path))
+		if(Utils::FileSystem::exists(path))
 			video = path;
 	}
 
@@ -129,7 +129,7 @@ const std::string FileData::getMarqueePath() const
 			if(marquee.empty())
 			{
 				std::string path = mEnvData->mStartPath + "/images/" + getDisplayName() + "-marquee" + extList[i];
-				if(boost::filesystem::exists(path))
+				if(Utils::FileSystem::exists(path))
 					marquee = path;
 			}
 		}
@@ -151,7 +151,7 @@ const std::string FileData::getImagePath() const
 			if(image.empty())
 			{
 				std::string path = mEnvData->mStartPath + "/images/" + getDisplayName() + "-image" + extList[i];
-				if(boost::filesystem::exists(path))
+				if(Utils::FileSystem::exists(path))
 					image = path;
 			}
 		}

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -1,5 +1,6 @@
 #include "Gamelist.h"
 
+#include "utils/FileSystemUtil.h"
 #include "FileData.h"
 #include "FileFilterIndex.h"
 #include "Log.h"
@@ -87,7 +88,7 @@ void parseGamelist(SystemData* system)
 	bool trustGamelist = Settings::getInstance()->getBool("ParseGamelistOnly");
 	std::string xmlpath = system->getGamelistPath(false);
 
-	if(!boost::filesystem::exists(xmlpath))
+	if(!Utils::FileSystem::exists(xmlpath))
 		return;
 
 	LOG(LogInfo) << "Parsing XML file \"" << xmlpath << "\"...";
@@ -120,7 +121,7 @@ void parseGamelist(SystemData* system)
 		{
 			boost::filesystem::path path = resolvePath(fileNode.child("path").text().get(), relativeTo, false);
 
-			if(!trustGamelist && !boost::filesystem::exists(path))
+			if(!trustGamelist && !Utils::FileSystem::exists(path.generic_string()))
 			{
 				LOG(LogWarning) << "File \"" << path << "\" does not exist! Ignoring.";
 				continue;
@@ -183,7 +184,7 @@ void updateGamelist(SystemData* system)
 	pugi::xml_node root;
 	std::string xmlReadPath = system->getGamelistPath(false);
 
-	if(boost::filesystem::exists(xmlReadPath))
+	if(Utils::FileSystem::exists(xmlReadPath))
 	{
 		//parse an existing file first
 		pugi::xml_parse_result result = doc.load_file(xmlReadPath.c_str());
@@ -241,7 +242,7 @@ void updateGamelist(SystemData* system)
 
 				boost::filesystem::path nodePath = resolvePath(pathNode.text().get(), system->getStartPath(), true);
 				boost::filesystem::path gamePath((*fit)->getPath());
-				if(nodePath == gamePath || (boost::filesystem::exists(nodePath) && boost::filesystem::exists(gamePath) && boost::filesystem::equivalent(nodePath, gamePath)))
+				if(nodePath == gamePath || (Utils::FileSystem::exists(nodePath.generic_string()) && Utils::FileSystem::exists(gamePath.generic_string()) && boost::filesystem::equivalent(nodePath, gamePath)))
 				{
 					// found it
 					root.remove_child(fileNode);
@@ -259,7 +260,7 @@ void updateGamelist(SystemData* system)
 		if (numUpdated > 0) {
 			//make sure the folders leading up to this path exist (or the write will fail)
 			boost::filesystem::path xmlWritePath(system->getGamelistPath(true));
-			boost::filesystem::create_directories(xmlWritePath.parent_path());
+			Utils::FileSystem::createDirectory(xmlWritePath.parent_path().generic_string());
 
 			LOG(LogInfo) << "Added/Updated " << numUpdated << " entities in '" << xmlReadPath << "'";
 

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -4,6 +4,7 @@
 #include "components/VideoPlayerComponent.h"
 #endif
 #include "components/VideoVlcComponent.h"
+#include "utils/FileSystemUtil.h"
 #include "views/gamelist/IGameListView.h"
 #include "views/ViewController.h"
 #include "FileData.h"
@@ -38,8 +39,8 @@ SystemScreenSaver::SystemScreenSaver(Window* window) :
 {
 	mWindow->setScreenSaver(this);
 	std::string path = getTitleFolder();
-	if(!boost::filesystem::exists(path))
-		boost::filesystem::create_directory(path);
+	if(!Utils::FileSystem::exists(path))
+		Utils::FileSystem::createDirectory(path);
 	srand((unsigned int)time(NULL));
 	mVideoChangeTime = 30000;
 }
@@ -81,13 +82,13 @@ void SystemScreenSaver::startScreenSaver()
 		pickRandomVideo(path);
 
 		int retry = 200;
-		while(retry > 0 && ((path.empty() || !boost::filesystem::exists(path)) || mCurrentGame == NULL))
+		while(retry > 0 && ((path.empty() || !Utils::FileSystem::exists(path)) || mCurrentGame == NULL))
 		{
 			retry--;
 			pickRandomVideo(path);
 		}
 
-		if (!path.empty() && boost::filesystem::exists(path))
+		if (!path.empty() && Utils::FileSystem::exists(path))
 		{
 #ifdef _RPI_
 			// Create the correct type of video component
@@ -164,7 +165,7 @@ void SystemScreenSaver::startScreenSaver()
 		std::string bg_audio_file = Settings::getInstance()->getString("SlideshowScreenSaverBackgroundAudioFile");
 		if ((!mBackgroundAudio) && (bg_audio_file != ""))
 		{
-			if (boost::filesystem::exists(bg_audio_file))
+			if (Utils::FileSystem::exists(bg_audio_file))
 			{
 				// paused PS so that the background audio keeps playing
 				PowerSaver::pause();
@@ -269,7 +270,7 @@ unsigned long SystemScreenSaver::countGameListNodes(const char *nodeName)
 			pugi::xml_node root;
 			std::string xmlReadPath = (*it)->getGamelistPath(false);
 
-			if(boost::filesystem::exists(xmlReadPath))
+			if(Utils::FileSystem::exists(xmlReadPath))
 			{
 				pugi::xml_parse_result result = doc.load_file(xmlReadPath.c_str());
 				if (!result)
@@ -321,7 +322,7 @@ void SystemScreenSaver::pickGameListNode(unsigned long index, const char *nodeNa
 
 		std::string xmlReadPath = (*it)->getGamelistPath(false);
 
-		if(boost::filesystem::exists(xmlReadPath))
+		if(Utils::FileSystem::exists(xmlReadPath))
 		{
 			pugi::xml_parse_result result = doc.load_file(xmlReadPath.c_str());
 			if (!result)
@@ -416,7 +417,7 @@ void SystemScreenSaver::pickRandomGameListImage(std::string& path)
 void SystemScreenSaver::pickRandomCustomImage(std::string& path)
 {
 	std::string imageDir = Settings::getInstance()->getString("SlideshowScreenSaverImageDir");
-	if ((imageDir != "") && (boost::filesystem::exists(imageDir)))
+	if ((imageDir != "") && (Utils::FileSystem::exists(imageDir)))
 	{
 		std::string imageFilter = Settings::getInstance()->getString("SlideshowScreenSaverImageFilter");
 
@@ -430,7 +431,7 @@ void SystemScreenSaver::pickRandomCustomImage(std::string& path)
 			// TODO: Figure out how to remove this duplication in the else block
 			for (iter; iter != end_iter; ++iter)
 			{
-				if (boost::filesystem::is_regular_file(iter->status()))
+				if (Utils::FileSystem::isRegularFile(iter->path().generic_string()))
 				{
 					// If the image filter is empty, or the file extension is in the filter string,
 					//  add it to the matching files list
@@ -449,7 +450,7 @@ void SystemScreenSaver::pickRandomCustomImage(std::string& path)
 
 			for (iter; iter != end_iter; ++iter)
 			{
-				if (boost::filesystem::is_regular_file(iter->status()))
+				if (Utils::FileSystem::isRegularFile(iter->path().generic_string()))
 				{
 					// If the image filter is empty, or the file extension is in the filter string,
 					//  add it to the matching files list

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -3,6 +3,7 @@
 
 #include "guis/GuiDetectDevice.h"
 #include "guis/GuiMsgBox.h"
+#include "utils/FileSystemUtil.h"
 #include "views/ViewController.h"
 #include "CollectionSystemManager.h"
 #include "EmulationStation.h"
@@ -14,7 +15,6 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include "SystemScreenSaver.h"
-#include <boost/filesystem/operations.hpp>
 #include <SDL_events.h>
 #include <SDL_main.h>
 #include <SDL_timer.h>
@@ -169,11 +169,11 @@ bool verifyHomeFolderExists()
 	//make sure the config directory exists
 	std::string home = getHomePath();
 	std::string configDir = home + "/.emulationstation";
-	if(!boost::filesystem::exists(configDir))
+	if(!Utils::FileSystem::exists(configDir))
 	{
 		std::cout << "Creating config directory \"" << configDir << "\"\n";
-		boost::filesystem::create_directory(configDir);
-		if(!boost::filesystem::exists(configDir))
+		Utils::FileSystem::createDirectory(configDir);
+		if(!Utils::FileSystem::exists(configDir))
 		{
 			std::cerr << "Config directory could not be created!\n";
 			return false;
@@ -335,7 +335,7 @@ int main(int argc, char* argv[])
 	//choose which GUI to open depending on if an input configuration already exists
 	if(errorMsg == NULL)
 	{
-		if(boost::filesystem::exists(InputManager::getConfigPath()) && InputManager::getInstance()->getNumConfiguredDevices() > 0)
+		if(Utils::FileSystem::exists(InputManager::getConfigPath()) && InputManager::getInstance()->getNumConfiguredDevices() > 0)
 		{
 			ViewController::get()->goToStart();
 		}else{

--- a/es-app/src/scrapers/Scraper.cpp
+++ b/es-app/src/scrapers/Scraper.cpp
@@ -1,12 +1,12 @@
 #include "scrapers/Scraper.h"
 
+#include "utils/FileSystemUtil.h"
 #include "FileData.h"
 #include "GamesDBScraper.h"
 #include "Log.h"
 #include "platform.h"
 #include "Settings.h"
 #include "SystemData.h"
-#include <boost/filesystem/operations.hpp>
 #include <FreeImage.h>
 #include <fstream>
 
@@ -278,13 +278,13 @@ std::string getSaveAsPath(const ScraperSearchParams& params, const std::string& 
 
 	std::string path = getHomePath() + "/.emulationstation/downloaded_images/";
 
-	if(!boost::filesystem::exists(path))
-		boost::filesystem::create_directory(path);
+	if(!Utils::FileSystem::exists(path))
+		Utils::FileSystem::createDirectory(path);
 
 	path += subdirectory + "/";
 
-	if(!boost::filesystem::exists(path))
-		boost::filesystem::create_directory(path);
+	if(!Utils::FileSystem::exists(path))
+		Utils::FileSystem::createDirectory(path);
 
 	size_t dot = url.find_last_of('.');
 	std::string ext;

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -1,11 +1,11 @@
 #include "views/gamelist/BasicGameListView.h"
 
+#include "utils/FileSystemUtil.h"
 #include "views/UIModeController.h"
 #include "views/ViewController.h"
 #include "CollectionSystemManager.h"
 #include "Settings.h"
 #include "SystemData.h"
-#include <boost/filesystem/operations.hpp>
 
 BasicGameListView::BasicGameListView(Window* window, FileData* root)
 	: ISimpleGameListView(window, root), mList(window)
@@ -105,7 +105,7 @@ void BasicGameListView::launch(FileData* game)
 void BasicGameListView::remove(FileData *game, bool deleteFile)
 {
 	if (deleteFile)
-		boost::filesystem::remove(game->getPath());  // actually delete the file on the filesystem
+		Utils::FileSystem::removeFile(game->getPath().generic_string());  // actually delete the file on the filesystem
 	FileData* parent = game->getParent();
 	if (getCursor() == game)                     // Select next element in list, or prev if none
 	{

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -5,11 +5,11 @@
 #include "components/VideoPlayerComponent.h"
 #endif
 #include "components/VideoVlcComponent.h"
+#include "utils/FileSystemUtil.h"
 #include "views/ViewController.h"
 #ifdef _RPI_
 #include "Settings.h"
 #endif
-#include <boost/filesystem/operations.hpp>
 
 VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 	BasicGameListView(window, root),
@@ -224,7 +224,7 @@ void VideoGameListView::updateInfoPanel()
 {
 	FileData* file = (mList.size() == 0 || mList.isScrolling()) ? NULL : mList.getSelected();
 
-	boost::filesystem::remove(getTitlePath().c_str());
+	Utils::FileSystem::removeFile(getTitlePath());
 
 	bool fadingOut;
 	if(file == NULL)

--- a/es-core/src/HttpReq.cpp
+++ b/es-core/src/HttpReq.cpp
@@ -1,7 +1,8 @@
 #include "HttpReq.h"
 
+#include "utils/FileSystemUtil.h"
 #include "Log.h"
-#include <boost/filesystem/operations.hpp>
+#include <assert.h>
 
 CURLM* HttpReq::s_multi_handle = curl_multi_init();
 
@@ -32,7 +33,7 @@ std::string HttpReq::urlEncode(const std::string &s)
 bool HttpReq::isUrl(const std::string& str)
 {
 	//the worst guess
-	return (!str.empty() && !boost::filesystem::exists(str) && 
+	return (!str.empty() && !Utils::FileSystem::exists(str) && 
 		(str.find("http://") != std::string::npos || str.find("https://") != std::string::npos || str.find("www.") != std::string::npos));
 }
 

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -1,10 +1,10 @@
 #include "InputManager.h"
 
+#include "utils/FileSystemUtil.h"
 #include "CECInput.h"
 #include "Log.h"
 #include "platform.h"
 #include "Window.h"
-#include <boost/filesystem/operations.hpp>
 #include <pugixml/src/pugixml.hpp>
 #include <SDL.h>
 #include <iostream>
@@ -278,7 +278,7 @@ bool InputManager::parseEvent(const SDL_Event& ev, Window* window)
 bool InputManager::loadInputConfig(InputConfig* config)
 {
 	std::string path = getConfigPath();
-	if(!boost::filesystem::exists(path))
+	if(!Utils::FileSystem::exists(path))
 		return false;
 	
 	pugi::xml_document doc;
@@ -333,7 +333,7 @@ void InputManager::writeDeviceConfig(InputConfig* config)
 
 	pugi::xml_document doc;
 
-	if(boost::filesystem::exists(path))
+	if(Utils::FileSystem::exists(path))
 	{
 		// merge files
 		pugi::xml_parse_result result = doc.load_file(path.c_str());
@@ -394,7 +394,7 @@ void InputManager::doOnFinish()
 	std::string path = getConfigPath();
 	pugi::xml_document doc;
 
-	if(boost::filesystem::exists(path))
+	if(Utils::FileSystem::exists(path))
 	{
 		pugi::xml_parse_result result = doc.load_file(path.c_str());
 		if(!result)

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -1,9 +1,11 @@
 #include "Settings.h"
 
+#include "utils/FileSystemUtil.h"
 #include "Log.h"
 #include "platform.h"
-#include <boost/filesystem/operations.hpp>
 #include <pugixml/src/pugixml.hpp>
+#include <algorithm>
+#include <vector>
 
 Settings* Settings::sInstance = NULL;
 
@@ -185,7 +187,7 @@ void Settings::loadFile()
 {
 	const std::string path = getHomePath() + "/.emulationstation/es_settings.cfg";
 
-	if(!boost::filesystem::exists(path))
+	if(!Utils::FileSystem::exists(path))
 		return;
 
 	pugi::xml_document doc;

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -2,6 +2,7 @@
 
 #include "components/ImageComponent.h"
 #include "components/TextComponent.h"
+#include "utils/FileSystemUtil.h"
 #include "Log.h"
 #include "platform.h"
 #include "Settings.h"
@@ -205,7 +206,7 @@ void ThemeData::loadFile(std::map<std::string, std::string> sysDataMap, const st
 	ThemeException error;
 	error.setFiles(mPaths);
 
-	if(!boost::filesystem::exists(path))
+	if(!Utils::FileSystem::exists(path))
 		throw error << "File does not exist!";
 
 	mVersion = 0;
@@ -484,7 +485,7 @@ const std::shared_ptr<ThemeData>& ThemeData::getDefault()
 		theme = std::shared_ptr<ThemeData>(new ThemeData());
 
 		const std::string path = getHomePath() + "/.emulationstation/es_theme_default.xml";
-		if(boost::filesystem::exists(path))
+		if(Utils::FileSystem::exists(path))
 		{
 			try
 			{
@@ -544,12 +545,12 @@ std::map<std::string, ThemeSet> ThemeData::getThemeSets()
 
 	for(size_t i = 0; i < pathCount; i++)
 	{
-		if(!boost::filesystem::is_directory(paths[i]))
+		if(!Utils::FileSystem::isDirectory(paths[i].generic_string()))
 			continue;
 
 		for(boost::filesystem::directory_iterator it(paths[i]); it != end; ++it)
 		{
-			if(boost::filesystem::is_directory(*it))
+			if(Utils::FileSystem::isDirectory((*it).path().generic_string()))
 			{
 				ThemeSet set = {*it};
 				sets[set.getName()] = set;

--- a/es-core/src/Util.cpp
+++ b/es-core/src/Util.cpp
@@ -1,5 +1,6 @@
 #include "Util.h"
 
+#include "utils/FileSystemUtil.h"
 #include "platform.h"
 #include <boost/filesystem/operations.hpp>
 
@@ -27,7 +28,7 @@ std::string strToUpper(const std::string& str)
 // embedded resources, e.g. ":/font.ttf", need to be properly handled too
 std::string getCanonicalPath(const std::string& path)
 {
-	if(path.empty() || !boost::filesystem::exists(path))
+	if(path.empty() || !Utils::FileSystem::exists(path))
 		return path;
 
 	return boost::filesystem::canonical(path).generic_string();
@@ -83,14 +84,14 @@ boost::filesystem::path removeCommonPathUsingStrings(const boost::filesystem::pa
 boost::filesystem::path removeCommonPath(const boost::filesystem::path& path, const boost::filesystem::path& relativeTo, bool& contains)
 {
 	// if either of these doesn't exist, boost::filesystem::canonical() is going to throw an error
-	if(!boost::filesystem::exists(path) || !boost::filesystem::exists(relativeTo))
+	if(!Utils::FileSystem::exists(path.generic_string()) || !Utils::FileSystem::exists(relativeTo.generic_string()))
 	{
 		contains = false;
 		return path;
 	}
 
 	// if it's a symlink we don't want to apply boost::filesystem::canonical on it, otherwise we'll lose the current parent_path
-	boost::filesystem::path p = (boost::filesystem::is_symlink(path) ? boost::filesystem::canonical(path.parent_path()) / path.filename() : boost::filesystem::canonical(path));
+	boost::filesystem::path p = (Utils::FileSystem::isSymlink(path.generic_string()) ? boost::filesystem::canonical(path.parent_path()) / path.filename() : boost::filesystem::canonical(path));
 	boost::filesystem::path r = boost::filesystem::canonical(relativeTo);
 
 	if(p.root_path() != r.root_path())

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -1,12 +1,12 @@
 #include "components/VideoComponent.h"
 
 #include "resources/ResourceManager.h"
+#include "utils/FileSystemUtil.h"
 #include "PowerSaver.h"
 #include "Renderer.h"
 #include "ThemeData.h"
 #include "Util.h"
 #include "Window.h"
-#include <boost/filesystem/operations.hpp>
 #include <SDL_timer.h>
 
 #define FADE_TIME_MS	200
@@ -75,8 +75,8 @@ VideoComponent::VideoComponent(Window* window) :
 	}
 
 	std::string path = getTitleFolder();
-	if(!boost::filesystem::exists(path))
-		boost::filesystem::create_directory(path);
+	if(!Utils::FileSystem::exists(path))
+		Utils::FileSystem::createDirectory(path);
 }
 
 VideoComponent::~VideoComponent()

--- a/es-core/src/guis/GuiDetectDevice.cpp
+++ b/es-core/src/guis/GuiDetectDevice.cpp
@@ -2,12 +2,12 @@
 
 #include "components/TextComponent.h"
 #include "guis/GuiInputConfig.h"
+#include "utils/FileSystemUtil.h"
 #include "InputManager.h"
 #include "PowerSaver.h"
 #include "Renderer.h"
 #include "Util.h"
 #include "Window.h"
-#include <boost/filesystem/operations.hpp>
 
 #define HOLD_TIME 1000
 
@@ -102,7 +102,7 @@ void GuiDetectDevice::update(int deltaTime)
 	if(mHoldingConfig)
 	{
 		// If ES starts and if a known device is connected after startup skip controller configuration
-		if(mFirstRun && boost::filesystem::exists(InputManager::getConfigPath()) && InputManager::getInstance()->getNumConfiguredDevices() > 0)
+		if(mFirstRun && Utils::FileSystem::exists(InputManager::getConfigPath()) && InputManager::getInstance()->getNumConfiguredDevices() > 0)
 		{
 			if(mDoneCallback)
 				mDoneCallback();

--- a/es-core/src/resources/ResourceManager.cpp
+++ b/es-core/src/resources/ResourceManager.cpp
@@ -1,7 +1,7 @@
 #include "ResourceManager.h"
 
 #include "../data/Resources.h"
-#include <boost/filesystem/operations.hpp>
+#include "utils/FileSystemUtil.h"
 #include <fstream>
 
 auto array_deleter = [](unsigned char* p) { delete[] p; };
@@ -37,7 +37,7 @@ const ResourceData ResourceManager::getFileData(const std::string& path) const
 	}
 
 	//it's not embedded; load the file
-	if(!boost::filesystem::exists(path))
+	if(!Utils::FileSystem::exists(path))
 	{
 		//if the file doesn't exist, return an "empty" ResourceData
 		ResourceData data = {NULL, 0};
@@ -71,7 +71,7 @@ bool ResourceManager::fileExists(const std::string& path) const
 	if(res2hMap.find(path) != res2hMap.cend())
 		return true;
 
-	return boost::filesystem::exists(path);
+	return Utils::FileSystem::exists(path);
 }
 
 void ResourceManager::unloadAll()

--- a/es-core/src/utils/FileSystemUtil.h
+++ b/es-core/src/utils/FileSystemUtil.h
@@ -11,28 +11,30 @@ namespace Utils
 	{
 		typedef std::list<std::string> stringList;
 
-		stringList  getDirContent  (const std::string& _path);
-		std::string getHomePath    ();
-		std::string getCWDPath     ();
-		std::string genericPath    (const std::string& _path);
-		std::string escapedPath    (const std::string& _path);
-		std::string canonicalPath  (const std::string& _path);
-		std::string absolutePath   (const std::string& _path, const std::string& _base = getCWDPath());
-		std::string resolvePath    (const std::string& _path, const std::string& _relativeTo, const bool _allowHome);
-		std::string resolveSymlink (const std::string& _path);
-		std::string getParent      (const std::string& _path);
-		std::string getFileName    (const std::string& _path);
-		std::string getStem        (const std::string& _path);
-		std::string getExtension   (const std::string& _path);
-		bool        removeFile     (const std::string& _path);
-		bool        createDirectory(const std::string& _path);
-		bool        exists         (const std::string& _path);
-		bool        isAbsolute     (const std::string& _path);
-		bool        isRegularFile  (const std::string& _path);
-		bool        isDirectory    (const std::string& _path);
-		bool        isSymlink      (const std::string& _path);
-		bool        isHidden       (const std::string& _path);
-		bool        isEquivalent   (const std::string& _path1, const std::string& _path2);
+		stringList  getDirContent      (const std::string& _path);
+		std::string getHomePath        ();
+		std::string getCWDPath         ();
+		std::string getGenericPath     (const std::string& _path);
+		std::string getEscapedPath     (const std::string& _path);
+		std::string getCanonicalPath   (const std::string& _path);
+		std::string getAbsolutePath    (const std::string& _path, const std::string& _base = getCWDPath());
+		std::string getParent          (const std::string& _path);
+		std::string getFileName        (const std::string& _path);
+		std::string getStem            (const std::string& _path);
+		std::string getExtension       (const std::string& _path);
+		std::string resolveRelativePath(const std::string& _path, const std::string& _relativeTo, const bool _allowHome);
+		std::string createRelativePath (const std::string& _path, const std::string& _relativeTo, const bool _allowHome);
+		std::string removeCommonPath   (const std::string& _path, const std::string& _common, bool& _contains);
+		std::string resolveSymlink     (const std::string& _path);
+		bool        removeFile         (const std::string& _path);
+		bool        createDirectory    (const std::string& _path);
+		bool        exists             (const std::string& _path);
+		bool        isAbsolute         (const std::string& _path);
+		bool        isRegularFile      (const std::string& _path);
+		bool        isDirectory        (const std::string& _path);
+		bool        isSymlink          (const std::string& _path);
+		bool        isHidden           (const std::string& _path);
+		bool        isEquivalent       (const std::string& _path1, const std::string& _path2);
 
 	} // FileSystem::
 


### PR DESCRIPTION
Replace some boost functionality with Utils::FileSystem, this is just step 1 of many to eliminate boost::filesystem