### PR TITLE
sleep/wake script support

### DIFF
--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -101,6 +101,10 @@ void Settings::setDefaults()
 	mStringMap["SlideshowScreenSaverImageFilter"] = ".png,.jpg";
 	mBoolMap["SlideshowScreenSaverRecurse"] = false;
 
+	// sleep/wake scripts
+	mStringMap["SleepCommand"] = "";
+	mStringMap["WakeCommand"] = "";
+
 	// This setting only applies to raspberry pi but set it for all platforms so
 	// we don't get a warning if we encounter it on a different platform
 	mBoolMap["VideoOmxPlayer"] = false;

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -271,8 +271,12 @@ void Window::render()
 		if (!isProcessing() && mAllowSleep && (!mScreenSaver || mScreenSaver->allowSleep()))
 		{
 			// go to sleep
+			if(!mSleeping)
+			{
+				onSleep();
+			}
+
 			mSleeping = true;
-			onSleep();
 		}
 	}
 }

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -393,11 +393,20 @@ void Window::setHelpPrompts(const std::vector<HelpPrompt>& prompts, const HelpSt
 
 void Window::onSleep()
 {
+	std::string sleepCommand = Settings::getInstance()->getString("SleepCommand");
+	if(!sleepCommand.empty())
+	{
+		runSystemCommand(sleepCommand);
+	}
 }
 
 void Window::onWake()
 {
-
+	std::string wakeCommand = Settings::getInstance()->getString("WakeCommand");
+	if(!wakeCommand.empty())
+	{
+		runSystemCommand(wakeCommand);
+	}
 }
 
 bool Window::isProcessing()


### PR DESCRIPTION
I saw a few other people asking for this on the retropie forums: https://retropie.org.uk/forum/topic/15332/request-for-additional-screen-saver-functionality/5

It's support for running arbitrary scripts on sleep/wake as set in es_settings.cfg. I find it very useful to disconnect my dualshock4 on sleep so as not to kill the battery when ES sleeps.