### PR TITLE
Replace the last usage of boost::filesystem::operations

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -11,7 +11,6 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include "ThemeData.h"
-#include <boost/filesystem/operations.hpp>
 #include <pugixml/src/pugixml.hpp>
 #include <fstream>
 
@@ -884,13 +883,14 @@ std::vector<std::string> CollectionSystemManager::getSystemsFromTheme()
 
 	if (Utils::FileSystem::exists(themePath.generic_string()))
 	{
-		boost::filesystem::directory_iterator end_itr; // default construction yields past-the-end
-		for (boost::filesystem::directory_iterator itr(themePath); itr != end_itr; ++itr)
+		Utils::FileSystem::stringList dirContent = Utils::FileSystem::getDirContent(themePath.generic_string());
+
+		for (Utils::FileSystem::stringList::const_iterator it = dirContent.cbegin(); it != dirContent.cend(); ++it)
 		{
-			if (Utils::FileSystem::isDirectory(itr->path().generic_string()))
+			if (Utils::FileSystem::isDirectory(*it))
 			{
 				//... here you have a directory
-				std::string folder = itr->path().string();
+				std::string folder = *it;
 				folder = folder.substr(themePath.string().size()+1);
 
 				if(Utils::FileSystem::exists(set->second.getThemePath(folder).generic_string()))
@@ -944,13 +944,13 @@ std::vector<std::string> CollectionSystemManager::getCollectionsFromConfigFolder
 
 	if (Utils::FileSystem::exists(configPath.generic_string()))
 	{
-		boost::filesystem::directory_iterator end_itr; // default construction yields past-the-end
-		for (boost::filesystem::directory_iterator itr(configPath); itr != end_itr; ++itr)
+		Utils::FileSystem::stringList dirContent = Utils::FileSystem::getDirContent(configPath.generic_string());
+		for (Utils::FileSystem::stringList::const_iterator it = dirContent.cbegin(); it != dirContent.cend(); ++it)
 		{
-			if (Utils::FileSystem::isRegularFile(itr->path().generic_string()))
+			if (Utils::FileSystem::isRegularFile(*it))
 			{
 				// it's a file
-				std::string file = itr->path().string();
+				std::string file = *it;
 				std::string filename = file.substr(configPath.string().size());
 
 				// need to confirm filename matches config format
@@ -1019,7 +1019,7 @@ std::string getCustomCollectionConfigPath(std::string collectionName)
 
 std::string getCollectionsFolder()
 {
-	return getHomePath() + "/.emulationstation/collections/";
+	return Utils::FileSystem::getHomePath() + "/.emulationstation/collections/";
 }
 
 bool systemSort(SystemData* sys1, SystemData* sys2)

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -6,7 +6,6 @@
 #include "Log.h"
 #include "Settings.h"
 #include "SystemData.h"
-#include <boost/filesystem/operations.hpp>
 #include <pugixml/src/pugixml.hpp>
 
 FileData* findOrCreateFile(SystemData* system, const boost::filesystem::path& path, FileType type)
@@ -232,7 +231,7 @@ void updateGamelist(SystemData* system)
 
 				boost::filesystem::path nodePath = Utils::FileSystem::resolveRelativePath(pathNode.text().get(), system->getStartPath(), true);
 				boost::filesystem::path gamePath((*fit)->getPath());
-				if(nodePath == gamePath || (Utils::FileSystem::exists(nodePath.generic_string()) && Utils::FileSystem::exists(gamePath.generic_string()) && boost::filesystem::equivalent(nodePath, gamePath)))
+				if(nodePath == gamePath || (Utils::FileSystem::exists(nodePath.generic_string()) && Utils::FileSystem::exists(gamePath.generic_string()) && Utils::FileSystem::isEquivalent(nodePath.generic_string(), gamePath.generic_string())))
 				{
 					// found it
 					root.remove_child(fileNode);

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -167,7 +167,7 @@ bool parseArgs(int argc, char* argv[])
 bool verifyHomeFolderExists()
 {
 	//make sure the config directory exists
-	std::string home = getHomePath();
+	std::string home = Utils::FileSystem::getHomePath();
 	std::string configDir = home + "/.emulationstation";
 	if(!Utils::FileSystem::exists(configDir))
 	{

--- a/es-app/src/scrapers/Scraper.cpp
+++ b/es-app/src/scrapers/Scraper.cpp
@@ -276,7 +276,7 @@ std::string getSaveAsPath(const ScraperSearchParams& params, const std::string& 
 	const std::string subdirectory = params.system->getName();
 	const std::string name = params.game->getPath().stem().generic_string() + "-" + suffix;
 
-	std::string path = getHomePath() + "/.emulationstation/downloaded_images/";
+	std::string path = Utils::FileSystem::getHomePath() + "/.emulationstation/downloaded_images/";
 
 	if(!Utils::FileSystem::exists(path))
 		Utils::FileSystem::createDirectory(path);

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -432,14 +432,14 @@ void InputManager::doOnFinish()
 
 std::string InputManager::getConfigPath()
 {
-	std::string path = getHomePath();
+	std::string path = Utils::FileSystem::getHomePath();
 	path += "/.emulationstation/es_input.cfg";
 	return path;
 }
 
 std::string InputManager::getTemporaryConfigPath()
 {
-	std::string path = getHomePath();
+	std::string path = Utils::FileSystem::getHomePath();
 	path += "/.emulationstation/es_temporaryinput.cfg";
 	return path;
 }

--- a/es-core/src/Log.cpp
+++ b/es-core/src/Log.cpp
@@ -1,5 +1,6 @@
 #include "Log.h"
 
+#include "utils/FileSystemUtil.h"
 #include "platform.h"
 #include <iostream>
 
@@ -13,7 +14,7 @@ LogLevel Log::getReportingLevel()
 
 std::string Log::getLogPath()
 {
-	std::string home = getHomePath();
+	std::string home = Utils::FileSystem::getHomePath();
 	return home + "/.emulationstation/es_log.txt";
 }
 

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -99,9 +99,9 @@ void Settings::setDefaults()
 
 	mIntMap["ScreenSaverSwapImageTimeout"] = 10000;
 	mBoolMap["SlideshowScreenSaverStretch"] = false;
-	mStringMap["SlideshowScreenSaverBackgroundAudioFile"] = getHomePath() + "/.emulationstation/slideshow/audio/slideshow_bg.wav";
+	mStringMap["SlideshowScreenSaverBackgroundAudioFile"] = Utils::FileSystem::getHomePath() + "/.emulationstation/slideshow/audio/slideshow_bg.wav";
 	mBoolMap["SlideshowScreenSaverCustomImageSource"] = false;
-	mStringMap["SlideshowScreenSaverImageDir"] = getHomePath() + "/.emulationstation/slideshow/image";
+	mStringMap["SlideshowScreenSaverImageDir"] = Utils::FileSystem::getHomePath() + "/.emulationstation/slideshow/image";
 	mStringMap["SlideshowScreenSaverImageFilter"] = ".png,.jpg";
 	mBoolMap["SlideshowScreenSaverRecurse"] = false;
 
@@ -166,7 +166,7 @@ void saveMap(pugi::xml_document& doc, std::map<K, V>& map, const char* type)
 void Settings::saveFile()
 {
 	LOG(LogDebug) << "Settings::saveFile() : Saving Settings to file.";
-	const std::string path = getHomePath() + "/.emulationstation/es_settings.cfg";
+	const std::string path = Utils::FileSystem::getHomePath() + "/.emulationstation/es_settings.cfg";
 
 	pugi::xml_document doc;
 
@@ -187,7 +187,7 @@ void Settings::saveFile()
 
 void Settings::loadFile()
 {
-	const std::string path = getHomePath() + "/.emulationstation/es_settings.cfg";
+	const std::string path = Utils::FileSystem::getHomePath() + "/.emulationstation/es_settings.cfg";
 
 	if(!Utils::FileSystem::exists(path))
 		return;

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -6,7 +6,6 @@
 #include "Log.h"
 #include "platform.h"
 #include "Settings.h"
-#include <boost/filesystem/operations.hpp>
 #include <pugixml/src/pugixml.hpp>
 
 std::vector<std::string> ThemeData::sSupportedViews { { "system" }, { "basic" }, { "detailed" }, { "video" } };
@@ -163,7 +162,7 @@ std::string resolvePath(const char* in, const boost::filesystem::path& relative)
 	// some directories could theoretically start with ~ or .
 	if(*path.begin() == "~")
 	{
-		path = getHomePath() + (in + 1);
+		path = Utils::FileSystem::getHomePath() + (in + 1);
 	}else if(*path.begin() == ".")
 	{
 		path = relPath / (in + 1);
@@ -484,7 +483,7 @@ const std::shared_ptr<ThemeData>& ThemeData::getDefault()
 	{
 		theme = std::shared_ptr<ThemeData>(new ThemeData());
 
-		const std::string path = getHomePath() + "/.emulationstation/es_theme_default.xml";
+		const std::string path = Utils::FileSystem::getHomePath() + "/.emulationstation/es_theme_default.xml";
 		if(Utils::FileSystem::exists(path))
 		{
 			try
@@ -538,19 +537,19 @@ std::map<std::string, ThemeSet> ThemeData::getThemeSets()
 	static const size_t pathCount = 2;
 	boost::filesystem::path paths[pathCount] = { 
 		"/etc/emulationstation/themes", 
-		getHomePath() + "/.emulationstation/themes" 
+		Utils::FileSystem::getHomePath() + "/.emulationstation/themes" 
 	};
-
-	boost::filesystem::directory_iterator end;
 
 	for(size_t i = 0; i < pathCount; i++)
 	{
 		if(!Utils::FileSystem::isDirectory(paths[i].generic_string()))
 			continue;
 
-		for(boost::filesystem::directory_iterator it(paths[i]); it != end; ++it)
+		Utils::FileSystem::stringList dirContent = Utils::FileSystem::getDirContent(paths[i].generic_string());
+
+		for(Utils::FileSystem::stringList::const_iterator it = dirContent.cbegin(); it != dirContent.cend(); ++it)
 		{
-			if(Utils::FileSystem::isDirectory((*it).path().generic_string()))
+			if(Utils::FileSystem::isDirectory(*it))
 			{
 				ThemeSet set = {*it};
 				sets[set.getName()] = set;

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -16,7 +16,7 @@ std::string getTitlePath() {
 }
 
 std::string getTitleFolder() {
-	std::string home = getHomePath();
+	std::string home = Utils::FileSystem::getHomePath();
 	return home + "/.emulationstation/tmp/";
 }
 

--- a/es-core/src/platform.cpp
+++ b/es-core/src/platform.cpp
@@ -1,43 +1,12 @@
 #include "platform.h"
 
-#include <boost/filesystem/path.hpp>
 #include <SDL_events.h>
 #ifdef WIN32
 #include <codecvt>
+#else
+#include <unistd.h>
 #endif
 #include <fcntl.h>
-
-std::string getHomePath()
-{
-	std::string homePath;
-
-	// this should give you something like "/home/YOUR_USERNAME" on Linux and "C:\Users\YOUR_USERNAME\" on Windows
-	const char * envHome = getenv("HOME");
-	if(envHome != nullptr)
-	{
-		homePath = envHome;
-	}
-
-#ifdef WIN32
-	// but does not seem to work for Windows XP or Vista, so try something else
-	if (homePath.empty()) {
-		const char * envDir = getenv("HOMEDRIVE");
-		const char * envPath = getenv("HOMEPATH");
-		if (envDir != nullptr && envPath != nullptr) {
-			homePath = envDir;
-			homePath += envPath;
-
-			for(unsigned int i = 0; i < homePath.length(); i++)
-				if(homePath[i] == '\\')
-					homePath[i] = '/';
-		}
-	}
-#endif
-
-	// convert path to generic directory seperators
-	boost::filesystem::path genericPath(homePath);
-	return genericPath.generic_string();
-}
 
 int runShutdownCommand()
 {

--- a/es-core/src/platform.h
+++ b/es-core/src/platform.h
@@ -21,9 +21,6 @@
 	#define GLHEADER <SDL_opengl.h>
 #endif
 
-std::string getHomePath();
-
-
 int runShutdownCommand(); // shut down the system (returns 0 if successful)
 int runRestartCommand(); // restart the system (returns 0 if successful)
 int runSystemCommand(const std::string& cmd_utf8); // run a utf-8 encoded in the shell (requires wstring conversion on Windows)

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -22,7 +22,7 @@ namespace Utils
 {
 	namespace FileSystem
 	{
-		stringList getDirContent(const std::string& _path)
+		stringList getDirContent(const std::string& _path, const bool _recursive)
 		{
 			std::string path = getGenericPath(_path);
 			stringList  contentList;
@@ -44,7 +44,13 @@ namespace Utils
 
 						// ignore "." and ".."
 						if((name != ".") && (name != ".."))
-							contentList.push_back(name);
+						{
+							std::string fullName(path + "/" + name);
+							contentList.push_back(fullName);
+
+							if(_recursive && isDirectory(fullName))
+								contentList.merge(getDirContent(fullName, true));
+						}
 					}
 					while(FindNextFile(hFind, &findData));
 
@@ -64,7 +70,13 @@ namespace Utils
 
 						// ignore "." and ".."
 						if((name != ".") && (name != ".."))
-							contentList.push_back(name);
+						{
+							std::string fullName(path + "/" + name);
+							contentList.push_back(fullName);
+
+							if(_recursive && isDirectory(fullName))
+								contentList.merge(getDirContent(fullName, true));
+						}
 					}
 
 					closedir(dir);

--- a/es-core/src/utils/FileSystemUtil.h
+++ b/es-core/src/utils/FileSystemUtil.h
@@ -11,7 +11,7 @@ namespace Utils
 	{
 		typedef std::list<std::string> stringList;
 
-		stringList  getDirContent      (const std::string& _path);
+		stringList  getDirContent      (const std::string& _path, const bool _recursive = false);
 		std::string getHomePath        ();
 		std::string getCWDPath         ();
 		std::string getGenericPath     (const std::string& _path);


### PR DESCRIPTION
Replace the last traces of boost::filesystem::operations, this is PR 4 of 5 in the boost::filesystem removal quest