### PR TITLE
Fix thumbnail and image to be separated

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -565,6 +565,7 @@ void CollectionSystemManager::updateCollectionFolderMetadata(SystemData* sys)
 	std::string genre = "None";
 	std::string video = "";
 	std::string thumbnail = "";
+	std::string image = "";
 
 	std::unordered_map<std::string, FileData*> games = rootFolder->getChildrenByFilename();
 
@@ -608,6 +609,7 @@ void CollectionSystemManager::updateCollectionFolderMetadata(SystemData* sys)
 
 		video = randomGame->getVideoPath();
 		thumbnail = randomGame->getThumbnailPath();
+		image = randomGame->getImagePath();
 	}
 
 
@@ -618,7 +620,8 @@ void CollectionSystemManager::updateCollectionFolderMetadata(SystemData* sys)
 	rootFolder->metadata.set("releasedate", releasedate);
 	rootFolder->metadata.set("developer", developer);
 	rootFolder->metadata.set("video", video);
-	rootFolder->metadata.set("image", thumbnail);
+	rootFolder->metadata.set("thumbnail", thumbnail);
+	rootFolder->metadata.set("image", image);
 }
 
 void CollectionSystemManager::initCustomCollectionSystems()

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -245,7 +245,7 @@ void VideoGameListView::updateInfoPanel()
 
 		mVideo->setImage(file->getThumbnailPath());
 		mMarquee.setImage(file->getMarqueePath());
-		mImage.setImage(file->getThumbnailPath());
+		mImage.setImage(file->getImagePath());
 
 		mDescription.setText(file->metadata.get("desc"));
 		mDescContainer.reset();


### PR DESCRIPTION
Fix thumbnail and image to be separated as I think it was originally meant to be.

The current implementation for VideoViewis that md_video can show a thumbnail before fading to the video.
This is specified with <thumbnail> tag in the metadata, or if that doesn't contain a valid image, it tries with <image>.

Ontop of this a theme can still have the md_image element, which is where I believe the current implementation is broken, because that one will also use thumbnail, where I believe it should only use what's specified in <image>. So that the video thumbnail in md_video, and the actual md_image element, can be 2 different textures. I'm thinking screenshot maybe for the thumbnail, and boxart for the image. Current code would use the screenshot on both elements.

Anyway, long description. This PR fixes that.