### PR TITLE
Fix mStaticImage to use setResize

### DIFF
--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -41,7 +41,7 @@ void VideoPlayerComponent::setResize(float width, float height)
 	setSize(width, height);
 	mTargetSize = Vector2f(width, height);
 	mTargetIsMax = false;
-	mStaticImage.setSize(width, height);
+	mStaticImage.setResize(width, height);
 	onSizeChanged();
 }
 


### PR DESCRIPTION
mStaticImage on the OMX player was incorrectly using setSize when it should use setResize

Scenario:
Theme that has md_video setup using `<size>` and not `<maxSize>`
omx player used ( hardware video playback )
using delayed video, or missing video

In this specific scenario the video thumbnail would be displayed using the wrong size