### PR TITLE
Fix double //

### DIFF
--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -62,7 +62,7 @@ namespace Utils
 						// ignore "." and ".."
 						if((name != ".") && (name != ".."))
 						{
-							std::string fullName(path + "/" + name);
+							std::string fullName(getGenericPath(path + "/" + name));
 							contentList.push_back(fullName);
 
 							if(_recursive && isDirectory(fullName))


### PR DESCRIPTION
Fix getDirContent to not have a double //, so filesnames don't come back as "/filename.ext".
This fixes custom collections.