### PR TITLE
Fix getHomePath crash when the environment variable isn't set

### DIFF
--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -143,21 +143,24 @@ namespace Utils
 			if(!path.length())
 			{
 				// this should give us something like "/home/YOUR_USERNAME" on Linux and "C:/Users/YOUR_USERNAME/" on Windows
-				std::string envHome(getenv("HOME"));
-				if(envHome.length())
+				char* envHome = getenv("HOME");
+				if(envHome)
 					path = getGenericPath(envHome);
 
 #if defined(_WIN32)
 				// but does not seem to work for Windows XP or Vista, so try something else
 				if(!path.length())
 				{
-					std::string envDir(getenv("HOMEDRIVE"));
-					std::string envPath(getenv("HOMEPATH"));
-					if(envDir.length() && envPath.length())
-						path = getGenericPath(envDir + "/" + envPath);
+					char* envHomeDrive = getenv("HOMEDRIVE");
+					char* envHomePath  = getenv("HOMEPATH");
+					if(envHomeDrive && envHomePath)
+						path = getGenericPath(std::string(envHomeDrive) + "/" + envHomePath);
 				}
 #endif // _WIN32
 
+				// no homepath found, fall back to current working directory
+				if(!path.length())
+					path = getCWDPath();
 			}
 
 			// return constructed homepath


### PR DESCRIPTION
Similar fix to what jrassa suggested in https://github.com/RetroPie/EmulationStation/pull/378
This also adds the fallback to use current working directory if no homepath is found.