### PR TITLE
Limiting Last Played view to the last 50 games you played

### DIFF
--- a/es-app/src/CollectionSystemManager.h
+++ b/es-app/src/CollectionSystemManager.h
@@ -103,6 +103,8 @@ private:
 	std::vector<std::string> getCollectionThemeFolders(bool custom);
 	std::vector<std::string> getUserCollectionThemeFolders();
 
+	void trimCollectionCount(FileData* rootFolder, int limit);
+
 	bool themeFolderExists(std::string folder);
 
 	bool includeFileInAutoCollections(FileData* file);


### PR DESCRIPTION
Quite a bit of feedback had accumulated about the Last Played list not having a limit.

After the discussion over at 

https://retropie.org.uk/forum/topic/16559/last-played-collection-possible-to-limit

I implemented a limit of 50 for the Last Played view, instead of letting it run indefinitely.

I tested it for the most common edge cases I could think of and squashed any apparent bugs, but the usual considerations apply.