### PR TITLE
Fixing common path detection

### DIFF
--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -454,7 +454,7 @@ namespace Utils
 			std::string common = isDirectory(_common) ? getGenericPath(_common) : getParent(_common);
 
 			// check if path contains common
-			if(path.find_first_of(common) == 0)
+			if(path.find(common) == 0)
 			{
 				_contains = true;
 				return path.substr(common.length() + 1);


### PR DESCRIPTION
@Tomaz82 , just for sanity checking, could you double check that this change does not compromise what the original intention for the function was?

///

Fix for common path detection that was messing up metadata writing.

Reference: http://www.cplusplus.com/reference/string/string/find_first_of/

It was being used to match the entire string, but in reality what it does is "Notice that it is enough for one single character of the sequence to match (not all of them). See string::find for a function that matches entire sequences".