### PR TITLE
Fixing path generation on the Pi for getDirContents

### DIFF
--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -88,7 +88,7 @@ namespace Utils
 						// ignore "." and ".."
 						if((name != ".") && (name != ".."))
 						{
-							std::string fullName(path + "/" + name);
+							std::string fullName(getGenericPath(path + "/" + name));
 							contentList.push_back(fullName);
 
 							if(_recursive && isDirectory(fullName))


### PR DESCRIPTION
Fixing path handling for Collection files after boost extermination on the Pi. The output for `Utils::FileSystem::getDirContent()` was returning the path with two slashes, which resulted in no files being recognized as the format wasn't understood.

@tomaz82 any concerns with this specific change? You had it for Windows as well, so just want to make sure I'm reading things right.

Thanks.

