### PR TITLE
[GRID 1] Allow quick system swap using left/right shoulder

### DIFF
--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -97,6 +97,16 @@ void BasicGameListView::addPlaceholder()
 	mList.add(placeholder->getName(), placeholder, (placeholder->getType() == PLACEHOLDER));
 }
 
+std::string BasicGameListView::getQuickSystemSelectRightButton()
+{
+	return "right";
+}
+
+std::string BasicGameListView::getQuickSystemSelectLeftButton()
+{
+	return "left";
+}
+
 void BasicGameListView::launch(FileData* game)
 {
 	ViewController::get()->launch(game);

--- a/es-app/src/views/gamelist/BasicGameListView.h
+++ b/es-app/src/views/gamelist/BasicGameListView.h
@@ -24,6 +24,8 @@ public:
 	virtual void launch(FileData* game) override;
 
 protected:
+	virtual std::string getQuickSystemSelectRightButton() override;
+	virtual std::string getQuickSystemSelectLeftButton() override;
 	virtual void populateList(const std::vector<FileData*>& files) override;
 	virtual void remove(FileData* game, bool deleteFile) override;
 	virtual void addPlaceholder();

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -1,6 +1,7 @@
 #include "views/gamelist/GridGameListView.h"
 
 #include "views/ViewController.h"
+#include "Settings.h"
 #include "SystemData.h"
 
 GridGameListView::GridGameListView(Window* window, FileData* root) : ISimpleGameListView(window, root),
@@ -25,6 +26,16 @@ void GridGameListView::setCursor(FileData* file)
 		populateList(file->getParent()->getChildrenListToDisplay());
 		mGrid.setCursor(file);
 	}
+}
+
+std::string GridGameListView::getQuickSystemSelectRightButton()
+{
+	return "pagedown"; //rightshoulder
+}
+
+std::string GridGameListView::getQuickSystemSelectLeftButton()
+{
+	return "pageup"; //leftshoulder
 }
 
 bool GridGameListView::input(InputConfig* config, Input input)
@@ -88,6 +99,12 @@ void GridGameListView::remove(FileData *game, bool deleteFile)
 std::vector<HelpPrompt> GridGameListView::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts;
+
+	if(Settings::getInstance()->getBool("QuickSystemSelect"))
+	{
+		prompts.push_back(HelpPrompt("l", "system"));
+		prompts.push_back(HelpPrompt("r", "system"));
+	}
 	prompts.push_back(HelpPrompt("up/down/left/right", "scroll"));
 	prompts.push_back(HelpPrompt("a", "launch"));
 	prompts.push_back(HelpPrompt("b", "back"));

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -23,6 +23,8 @@ public:
 	virtual void launch(FileData* game) override;
 
 protected:
+	virtual std::string getQuickSystemSelectRightButton() override;
+	virtual std::string getQuickSystemSelectLeftButton() override;
 	virtual void populateList(const std::vector<FileData*>& files) override;
 	virtual void remove(FileData* game, bool deleteFile) override;
 	virtual void addPlaceholder();

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -118,7 +118,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 			}
 
 			return true;
-		}else if(config->isMappedTo("right", input))
+		}else if(config->isMappedTo(getQuickSystemSelectRightButton(), input))
 		{
 			if(Settings::getInstance()->getBool("QuickSystemSelect"))
 			{
@@ -126,7 +126,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 				ViewController::get()->goToNextGameList();
 				return true;
 			}
-		}else if(config->isMappedTo("left", input))
+		}else if(config->isMappedTo(getQuickSystemSelectLeftButton(), input))
 		{
 			if(Settings::getInstance()->getBool("QuickSystemSelect"))
 			{

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -28,6 +28,8 @@ public:
 	virtual void launch(FileData* game) = 0;
 
 protected:
+	virtual std::string getQuickSystemSelectRightButton() = 0;
+	virtual std::string getQuickSystemSelectLeftButton() = 0;
 	virtual void populateList(const std::vector<FileData*>& files) = 0;
 
 	TextComponent mHeaderText;


### PR DESCRIPTION
Point 1 of the gridview's roadmap (1.1 and 1.2 not included) https://github.com/RetroPie/EmulationStation/issues/389

- Allow quick system swap using left/right shoulder in all game view (grid, detailed, basic, video)
- Add left and right shoulder to the help prompt of the grid view

The quick system swap using left/right shoulder is enabled for **all** game views but is only showed up in the help prompt of the grid view.

Help prompt of the Grid view before changes
![grid view help system before changes](https://user-images.githubusercontent.com/24305945/37762344-4b885f1c-2dbc-11e8-9d00-286ebc9f6ce8.png)

Help prompt of the Grid view after changes
![grid view help system after changes](https://user-images.githubusercontent.com/24305945/37762343-4b654298-2dbc-11e8-944c-4a6b6978396e.png)

Help prompt of Basic/Detailed/Video view (no changes)
![basic view help system](https://user-images.githubusercontent.com/24305945/37762352-53a728a4-2dbc-11e8-9dae-5afedb61def6.png)

