### PR TITLE
[GRID 2] Enable the grid for developers

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -273,6 +273,11 @@ void GuiMenu::openUISettings()
 	styles.push_back("basic");
 	styles.push_back("detailed");
 	styles.push_back("video");
+
+	// Temporary "hack" so ES don't crash when leaving this menu after he enabled the grid by tweaking config file
+	if (Settings::getInstance()->getString("GamelistViewStyle") == "grid")
+		styles.push_back("grid");
+
 	for (auto it = styles.cbegin(); it != styles.cend(); it++)
 		gamelist_style->add(*it, *it, Settings::getInstance()->getString("GamelistViewStyle") == *it);
 	s->addWithLabel("GAMELIST VIEW STYLE", gamelist_style);

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -7,6 +7,7 @@
 #include "guis/GuiMenu.h"
 #include "views/gamelist/DetailedGameListView.h"
 #include "views/gamelist/IGameListView.h"
+#include "views/gamelist/GridGameListView.h"
 #include "views/gamelist/VideoGameListView.h"
 #include "views/SystemView.h"
 #include "views/UIModeController.h"
@@ -283,6 +284,8 @@ std::shared_ptr<IGameListView> ViewController::getGameListView(SystemData* syste
 		selectedViewType = BASIC;
 	if (viewPreference.compare("detailed") == 0)
 		selectedViewType = DETAILED;
+	if (viewPreference.compare("grid") == 0)
+		selectedViewType = GRID;
 	if (viewPreference.compare("video") == 0)
 		selectedViewType = VIDEO;
 
@@ -313,9 +316,9 @@ std::shared_ptr<IGameListView> ViewController::getGameListView(SystemData* syste
 		case DETAILED:
 			view = std::shared_ptr<IGameListView>(new DetailedGameListView(mWindow, system->getRootFolder()));
 			break;
-		// case GRID placeholder for future implementation.
-		//		view = std::shared_ptr<IGameListView>(new GridGameListView(mWindow, system->getRootFolder()));
-		//		break;
+		case GRID:
+			view = std::shared_ptr<IGameListView>(new GridGameListView(mWindow, system->getRootFolder()));
+			break;
 		case BASIC:
 		default:
 			view = std::shared_ptr<IGameListView>(new BasicGameListView(mWindow, system->getRootFolder()));

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -61,8 +61,8 @@ public:
 		AUTOMATIC,
 		BASIC,
 		DETAILED,
+		GRID,
 		VIDEO
-		// GRID TODO!
 	};
 
 	struct State

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -24,6 +24,8 @@ public:
 
 protected:
 	virtual void populateList(const std::vector<FileData*>& files) override;
+	virtual void remove(FileData* game, bool deleteFile) override;
+	virtual void addPlaceholder();
 
 	ImageGridComponent<FileData*> mGrid;
 };

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -9,7 +9,7 @@
 #include <pugixml/src/pugixml.hpp>
 #include <algorithm>
 
-std::vector<std::string> ThemeData::sSupportedViews { { "system" }, { "basic" }, { "detailed" }, { "video" } };
+std::vector<std::string> ThemeData::sSupportedViews { { "system" }, { "basic" }, { "detailed" }, { "grid" }, { "video" } };
 std::vector<std::string> ThemeData::sSupportedFeatures { { "video" }, { "carousel" }, { "z-index" } };
 
 std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> ThemeData::sElementMap {


### PR DESCRIPTION
Point 2 of the gridview's roadmap https://github.com/RetroPie/EmulationStation/issues/389

The grid view is now enabled but hidden for easier reviews and testing of the next pull requests. To enable it, you need to manually tweak the file es_settings.cfg by changing the value of GamelistViewStyle, using the command below for example : 

```bash
sed 's!<string name=\"GamelistViewStyle\" value=\"[a-zA-Z]*\" />!<string name=\"GamelistViewStyle\" value=\"grid\" />!' ~/.emulationstation/es_settings.cfg -i
```

It does not show yet in the menu (UI settings > Gamelist view style) so you can't set the view type to grid here but you can revert it to basic/detailed/video.

If you enabled the grid view by manually editing the config file and leave the "UI settings" menu without selecting any of this (basic, detailed or video), EmulationStation will crash with the following error message : 
```
emulationstation: /[...]/EmulationStation/es-core/src/components/OptionListComponent.h:235: T OptionListComponent<T>::getSelected() [with T = std::__cxx11::basic_string<char>]: Assertion `selected.size() == 1' failed.
Abandon (core dumped)
```
This is because it don't know about the grid view style yet so the option "Gamelist view style" is empty at this point.