### PR TITLE
Add automatically generated Clion files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ Makefile
 .cproject
 .project
 .settings/
+
+# Clion
+.idea/
+*.cmake
+*.cbp


### PR DESCRIPTION
When opening this project with Clion, it automatically generate all the following files : 
```
.idea/codeStyles/Project.xml
.idea/EmulationStation.iml
.idea/markdown-exported-files.xml
.idea/markdown-navigator/profiles_settings.xml
.idea/markdown-navigator.xml
.idea/misc.xml
.idea/modules.xml
.idea/.name
.idea/vcs.xml
.idea/workspace.xml

CPackConfig.cmake
CPackSourceConfig.cmake

emulationstation-all.cbp
es-app/emulationstation.cbp
es-core/core.cbp
external/nanosvg/nanosvg.cbp
```

Can you please merge the 3 lines I added to the .gitignore into your fork, this would make my life a lot easier when working on this project.