### PR TITLE
Fixed a quirk in the Clion PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ Makefile
 
 # Clion
 .idea/
-*.cmake
+CPackConfig.cmake
+CPackSourceConfig.cmake
 *.cbp


### PR DESCRIPTION
@Koerty accidentally excluded all .cmake files instead of the specific files that Clion generated, and was getting in my way of developing a new feature... So, I fixed it. BTW, no offence, @Koerty.