### PR TITLE
[GRID 3] Rewrite the grid view display code

### DIFF
--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -6,8 +6,8 @@
 GridGameListView::GridGameListView(Window* window, FileData* root) : ISimpleGameListView(window, root),
 	mGrid(window)
 {
-	mGrid.setPosition(0, mSize.y() * 0.2f);
-	mGrid.setSize(mSize.x(), mSize.y() * 0.8f);
+	mGrid.setPosition(mSize.x() * 0.1f, mSize.y() * 0.1f);
+//	mGrid.setSize(mSize.x(), mSize.y() * 0.8f);
 	addChild(&mGrid);
 
 	populateList(root->getChildrenListToDisplay());


### PR DESCRIPTION
**Description**
This PR is the Step 3 of the roadmap https://github.com/RetroPie/EmulationStation/wiki/Gridview-Roadmap-and-FAQ#roadmap

It rewrite the display code of the grid view, using a "tileMaxSize" variable as suggested by @jrassa on https://github.com/RetroPie/EmulationStation/issues/206#issuecomment-326809971

**Complete changelog**
- Add 3 new attributes to ImageGridComponent.h : mMargin, mTileMaxSize and mSelectedTileMaxSize, which themes will be able to configure starting at step 6 (see the roadmap)
- Rewrite the tile positioning
- Update the "render" function, so the selected tile is displayed on top of the others (until now the selected tile size wasn't configurable and was = tile size + margin so it couldn't overlap the others)

**Screenshots**
Screenshot of the grid with the following parameters : 
- Screen size 1366x768 px
- Grid size : 0.8 0.8
- Tile size :  0.19 0.19
- Margin : 0.01 0.01
![capture d ecran de 2018-03-26 18-07-42](https://user-images.githubusercontent.com/24305945/37925482-fa2b1c14-3134-11e8-8218-75ad7b26f362.png)
The green area represent the size of the grid.
![grid display code rewrite](https://user-images.githubusercontent.com/24305945/37925472-f466181a-3134-11e8-9d58-cb4e72e5f941.png)
The blue area represent the size of the tiles.