### PR TITLE
Fix crash when changing theme 

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -261,6 +261,7 @@ void GuiMenu::openUISettings()
 			if(needReload)
 			{
 				CollectionSystemManager::get()->updateSystemsList();
+				ViewController::get()->goToStart();
 				ViewController::get()->reloadAll(); // TODO - replace this with some sort of signal-based implementation
 			}
 		});


### PR DESCRIPTION
From within a collection that'll no longer be present at the carousel level.

@tomaz82 can you test if it fixes the issue you reported at the time when changing theme?

Thanks.