### PR TITLE
[GRID FIX] Update the populateList function of the GridGameListView

### DIFF
--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -38,9 +38,17 @@ bool GridGameListView::input(InputConfig* config, Input input)
 void GridGameListView::populateList(const std::vector<FileData*>& files)
 {
 	mGrid.clear();
-	for(auto it = files.cbegin(); it != files.cend(); it++)
+	mHeaderText.setText(mRoot->getSystem()->getFullName());
+	if (files.size() > 0)
 	{
-		mGrid.add((*it)->getName(), (*it)->getThumbnailPath(), *it);
+		for (auto it = files.cbegin(); it != files.cend(); it++)
+		{
+			mGrid.add((*it)->getName(), (*it)->getThumbnailPath(), *it);
+		}
+	}
+	else
+	{
+		addPlaceholder();
 	}
 }
 


### PR DESCRIPTION
Update the populateList function of the GridGameListView to mimic the changes made by @pjft in BasicGameListView when he introduced custom game collections : 
- Call the addPlaceholder function if grid is empty
- Set the header text (system name)