### PR TITLE
[GRID 3.2] Add base theming syntax for the grid

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -277,7 +277,7 @@ You can now change the order in which elements are rendered by setting `zIndex` 
 * `carousel name="systemcarousel"` - 40
 * `text name="systemInfo"` - 50
 
-##### basic, detailed, video
+##### basic, detailed, grid, video
 * `image name="background"` - 0
 * Extra Elements `extra="true"` - 10
 * `textlist name="gamelist"` - 20
@@ -471,6 +471,8 @@ Reference
 	- Displays the name of the system.  Only present if no "logo" image is specified.  Displayed at the top of the screen, centered by default.
 * `image name="logo"` - ALL
 	- A header image.  If a non-empty `path` is specified, `text name="headerText"` will be hidden and this image will be, by default, displayed roughly in its place.
+* `imagegrid name="gamegrid"` - ALL
+	- The gamegrid.
 
 * Metadata
 	* Labels
@@ -564,7 +566,13 @@ Can be created as an extra.
 	- Multiply each pixel's color by this color. For example, an all-white image with `<color>FF0000</color>` would become completely red.  You can also control the transparency of an image with `<color>FFFFFFAA</color>` - keeping all the pixels their normal color and only affecting the alpha channel.
 * `zIndex` - type: FLOAT.
 	- z-index value for component.  Components will be rendered in order of z-index value from low to high.
-	
+
+#### imagegrid
+
+* `pos` - type: NORMALIZED_PAIR.
+* `size` - type: NORMALIZED_PAIR.
+    - The size of the grid. Take care the selected tile can go out of the grid size, so don't position the grid too close to another element or the screen border.
+
 #### video
 
 * `pos` - type: NORMALIZED_PAIR.

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -21,7 +21,6 @@ GridGameListView::GridGameListView(Window* window, FileData* root) :
 	const float padding = 0.01f;
 
 	mGrid.setPosition(mSize.x() * 0.1f, mSize.y() * 0.1f);
-//	mGrid.setSize(mSize.x(), mSize.y() * 0.8f);
 	mGrid.setCursorChangedCallback([&](const CursorState& /*state*/) { updateInfoPanel(); });
 	addChild(&mGrid);
 
@@ -124,6 +123,8 @@ void GridGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 	ISimpleGameListView::onThemeChanged(theme);
 
 	using namespace ThemeFlags;
+
+	mGrid.applyTheme(theme, getName(), "gamegrid", ALL);
 
 	initMDLabels();
 	std::vector<TextComponent*> labels = getMDLabels();

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -25,6 +25,9 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "tile", BOOLEAN },
 		{ "color", COLOR },
 		{ "zIndex", FLOAT } } },
+	{ "imagegrid", {
+		{ "pos", NORMALIZED_PAIR },
+		{ "size", NORMALIZED_PAIR } } },
 	{ "text", {
 		{ "pos", NORMALIZED_PAIR },
 		{ "size", NORMALIZED_PAIR },

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -38,6 +38,7 @@ public:
 	bool input(InputConfig* config, Input input) override;
 	void update(int deltaTime) override;
 	void render(const Transform4x4f& parentTrans) override;
+	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
 	inline void setCursorChangedCallback(const std::function<void(CursorState state)>& func) { mCursorChangedCallback = func; }
 
@@ -74,10 +75,10 @@ ImageGridComponent<T>::ImageGridComponent(Window* window) : IList<ImageGridData,
 
 	mEntriesDirty = true;
 
-	mSize = screen * 0.8f;
+	mSize = screen * 0.79f;
 	mMargin = screen * 0.01f;
 	mTileMaxSize = screen * 0.19f;
-	mSelectedTileMaxSize = mTileMaxSize + mMargin * 3.0f;
+	mSelectedTileMaxSize = mTileMaxSize * 1.15f;
 }
 
 template<typename T>
@@ -171,6 +172,12 @@ void ImageGridComponent<T>::render(const Transform4x4f& parentTrans)
 		selectedImage->render(trans);
 
 	GuiComponent::renderChildren(trans);
+}
+
+template<typename T>
+void ImageGridComponent<T>::applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties)
+{
+	GuiComponent::applyTheme(theme, view, element, properties);
 }
 
 template<typename T>


### PR DESCRIPTION
**Changes**
**EDIT : removed "margin, tileMaxSize, selectedTileMaxSize" for now**
- The themes can now configure following elements : pos, size
- Change some default values for them

**Testing**
You can test by using [my custom test theme](https://github.com/Koerty/es-theme-test-gridview), it had a green border around the grid so you can better see what's going on (like on the screenshots of my [previous PR](https://github.com/RetroPie/EmulationStation/pull/396)).

Or using this modified version of @lilbud Material theme : [here](https://github.com/Koerty/es-theme-material)

Or by creating a new theme.xml from this : 
```xml
<theme>
    <formatVersion>4</formatVersion>
	<view name="grid">
		<imagegrid name="gamegrid">
			<pos>0.1 0.1</pos>
			<size>0.8 0.8</size>
<!-- Removed for now
			<margin>0.01 0.01</margin>
			<tileMaxSize>0.19 0.19</tileMaxSize>
			<selectedTileMaxSize>0.22 0.22</selectedTileMaxSize>
-->
		</imagegrid>
	</view>
</theme>
```

If a native english speaker could check the changes made to the file THEMES.md, it would be nice. I'm not so proud of this sentence for example : 
`
* `size` - type: NORMALIZED_PAIR.
    - The size of the grid. Take care the selected tile can go out of the grid size, so don't position the grid too close to another element or the screen border.
`