### PR TITLE
Fix ImageComponent flipY

### DIFF
--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -223,7 +223,7 @@ void ImageComponent::updateVertices()
 	}
 	if(mFlipY)
 	{
-		for(int i = 1; i < 6; i++)
+		for(int i = 0; i < 6; i++)
 			mVertices[i].tex[1] = mVertices[i].tex[1] == py ? 0 : py;
 	}
 }


### PR DESCRIPTION
Fix a small typo which have been here since Aloshi introduced fliping images in October 2012 the 8th, but nobody ever noticed or cared about the poor vertical flip function :')

Bug
![flipybefore](https://user-images.githubusercontent.com/24305945/38174778-013c5228-35d3-11e8-967e-0db26949ca8f.png)

Fix
![flipyafter](https://user-images.githubusercontent.com/24305945/38174779-07faf862-35d3-11e8-859b-0354c26d842b.png)
