### PR TITLE
[GRID FIX] Bad tile position when close to the last row and last row is full

### DIFF
--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -221,9 +221,13 @@ void ImageGridComponent<T>::updateImages()
 
 	int start = (cursorRow - (gridDimension.y() / 2)) * gridDimension.x();
 
-	//if we're at the end put the row as close as we can and no higher
+	// If we are at the end put the row as close as we can and no higher
+	// E nb of entries, X grid x dim (nb column), Y grid y dim (nb line)
+	// start = first tile of last row - nb column * (nb line - 1)
+	//       = (E - 1) / X * X        - X * (Y - 1)
+	//       = X * ((E - 1) / X - Y + 1)
 	if(start + (gridDimension.x() * gridDimension.y()) >= (int)mEntries.size())
-		start = gridDimension.x() * ((int)mEntries.size()/gridDimension.x() - gridDimension.y() + 1);
+		start = gridDimension.x() * (((int)mEntries.size() - 1) / gridDimension.x() - gridDimension.y() + 1);
 
 	if(start < 0)
 		start = 0;


### PR DESCRIPTION
Fix Aloshi's formula to position the tiles correctly when close to the last row.

Basically he just forgot to remove 1 to the number of entries, so when the last row is full then it positioned the tiles like there was an extra last row.

I don't know if that's because my math skill is a bit rusted, but I must admit I had an hard time figuring out how he came up with that formula, so I added some explanations. I can remove them if you find them unneeded.