### PR TITLE
Add cropping and minSize to ImageComponent

### DIFF
--- a/es-core/src/GuiComponent.h
+++ b/es-core/src/GuiComponent.h
@@ -56,7 +56,7 @@ public:
 	void setRotationOrigin(float originX, float originY);
 	inline void setRotationOrigin(Vector2f origin) { setRotationOrigin(origin.x(), origin.y()); }
 
-	Vector2f getSize() const;
+	virtual Vector2f getSize() const;
     inline void setSize(const Vector2f& size) { setSize(size.x(), size.y()); }
     void setSize(float w, float h);
     virtual void onSizeChanged() {};

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -40,7 +40,19 @@ public:
 	void setMaxSize(float width, float height);
 	inline void setMaxSize(const Vector2f& size) { setMaxSize(size.x(), size.y()); }
 
+	void setMinSize(float width, float height);
+	inline void setMinSize(const Vector2f& size) { setMinSize(size.x(), size.y()); }
+
 	Vector2f getRotationSize() const override;
+
+	// Applied AFTER image positioning and sizing
+	// cropTop(0.2) will crop 20% of the top of the image.
+	void cropLeft(float percent);
+	void cropTop(float percent);
+	void cropRight(float percent);
+	void cropBot(float percent);
+	void crop(float left, float top, float right, float bot);
+	void uncrop();
 
 	// Multiply all pixels in the image by this color when rendering.
 	void setColorShift(unsigned int color);
@@ -53,6 +65,8 @@ public:
 	// Returns the size of the current texture, or (0, 0) if none is loaded.  May be different than drawn size (use getSize() for that).
 	Vector2i getTextureSize() const;
 
+	Vector2f getSize() const override;
+
 	bool hasImage();
 
 	void render(const Transform4x4f& parentTrans) override;
@@ -63,7 +77,7 @@ public:
 private:
 	Vector2f mTargetSize;
 
-	bool mFlipX, mFlipY, mTargetIsMax;
+	bool mFlipX, mFlipY, mTargetIsMax, mTargetIsMin;
 
 	// Calculates the correct mSize from our resizing information (set by setResize/setMaxSize).
 	// Used internally whenever the resizing parameters or texture change.
@@ -86,11 +100,14 @@ private:
 	std::string mDefaultPath;
 
 	std::shared_ptr<TextureResource> mTexture;
-	unsigned char			 mFadeOpacity;
-	bool					 mFading;
-	bool				     mForceLoad;
+	unsigned char			mFadeOpacity;
+	bool					mFading;
+	bool					mForceLoad;
 	bool					mDynamic;
 	bool					mRotateByTargetSize;
+
+	Vector2f mTopLeftCrop;
+	Vector2f mBottomRightCrop;
 };
 
 #endif // ES_CORE_COMPONENTS_IMAGE_COMPONENT_H


### PR DESCRIPTION
This operations will be needed by the grid later on the road so I better submit the changes now in its own pull request.

This add new methods to the class ImageComponent:
```c++
void setMinSize(float width, float height);
void setMinSize(const Vector2f& size);
void cropLeft(float percent);
void cropTop(float percent);
void cropRight(float percent);
void cropBot(float percent);
void crop(float left, float top, float right, float bot);
void uncrop();
```

Usage examples : 
- A call to cropTop(0.2) will crop 20% of the top of the image
- A call to minSize(0.2, 0.2) will resize the image smallest side to 0.2 without breaking aspect ratio, but crop the extra lenght of the biggest side.
- Call minSize(0.2, 0.2) and then uncrop() to define an image size by its smallest side