### PR TITLE
Fix calcGridDimension being called before mScrollDirection

### DIFF
--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -85,9 +85,9 @@ ImageGridComponent<T>::ImageGridComponent(Window* window) : IList<ImageGridData,
 	mMargin = screen * 0.07f;
 	mTileSize = GridTileComponent::getDefaultTileSize();
 
-	calcGridDimension();
-
 	mScrollDirection = SCROLL_VERTICALLY;
+
+	calcGridDimension();
 }
 
 template<typename T>


### PR DESCRIPTION
The function calcGridDimension should be called **after** mScrollDirection is set (because it rely on it).

This is a small issue I overlooked when I rebased #411 after #408 got merged.