### PR TITLE
Add "origin" theming element for help prompt

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -729,6 +729,8 @@ EmulationStation borrows the concept of "nine patches" from Android (or "9-Slice
 #### helpsystem
 
 * `pos` - type: NORMALIZED_PAIR.  Default is "0.012 0.9515"
+* `origin` - type: NORMALIZED_PAIR.
+	- Where on the component `pos` refers to. For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the component exactly in the middle of the screen.
 * `textColor` - type: COLOR.  Default is 777777FF.
 * `iconColor` - type: COLOR.  Default is 777777FF.
 * `fontPath` - type: PATH.

--- a/es-core/src/HelpStyle.cpp
+++ b/es-core/src/HelpStyle.cpp
@@ -6,6 +6,7 @@
 HelpStyle::HelpStyle()
 {
 	position = Vector2f(Renderer::getScreenWidth() * 0.012f, Renderer::getScreenHeight() * 0.9515f);
+	origin = Vector2f(0.0f, 0.0f);
 	iconColor = 0x777777FF;
 	textColor = 0x777777FF;
 
@@ -23,6 +24,9 @@ void HelpStyle::applyTheme(const std::shared_ptr<ThemeData>& theme, const std::s
 
 	if(elem->has("pos"))
 		position = elem->get<Vector2f>("pos") * Vector2f((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
+
+	if(elem->has("origin"))
+		origin = elem->get<Vector2f>("origin");
 
 	if(elem->has("textColor"))
 		textColor = elem->get<unsigned int>("textColor");

--- a/es-core/src/HelpStyle.h
+++ b/es-core/src/HelpStyle.h
@@ -12,6 +12,7 @@ class ThemeData;
 struct HelpStyle
 {
 	Vector2f position;
+	Vector2f origin;
 	unsigned int iconColor;
 	unsigned int textColor;
 	std::shared_ptr<Font> font;

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -104,6 +104,7 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "path", PATH } } },
 	{ "helpsystem", {
 		{ "pos", NORMALIZED_PAIR },
+		{ "origin", NORMALIZED_PAIR },
 		{ "textColor", COLOR },
 		{ "iconColor", COLOR },
 		{ "fontPath", PATH },

--- a/es-core/src/components/HelpComponent.cpp
+++ b/es-core/src/components/HelpComponent.cpp
@@ -97,6 +97,7 @@ void HelpComponent::updateGrid()
 
 	mGrid->setPosition(Vector3f(mStyle.position.x(), mStyle.position.y(), 0.0f));
 	//mGrid->setPosition(OFFSET_X, Renderer::getScreenHeight() - mGrid->getSize().y() - OFFSET_Y);
+	mGrid->setOrigin(mStyle.origin);
 }
 
 std::shared_ptr<TextureResource> HelpComponent::getIconTexture(const char* name)


### PR DESCRIPTION
This have been asked multiple times by theme makers on the forum or here #224 