### PR TITLE
[GRID 7] Dynamic image loader

### DIFF
--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -209,7 +209,7 @@ void Window::update(int deltaTime)
 			// vram
 			float textureVramUsageMb = TextureResource::getTotalMemUsage() / 1000.0f / 1000.0f;
 			float textureTotalUsageMb = TextureResource::getTotalTextureSize() / 1000.0f / 1000.0f;
-			float fontVramUsageMb = Font::getTotalMemUsage() / 1000.0f / 1000.0f;;
+			float fontVramUsageMb = Font::getTotalMemUsage() / 1000.0f / 1000.0f;
 
 			ss << "\nFont VRAM: " << fontVramUsageMb << " Tex VRAM: " << textureVramUsageMb <<
 				  " Tex Max: " << textureTotalUsageMb;


### PR DESCRIPTION
This is a pretty big task, so I created this PR before it's finished so you can take a first look and give me some feedback if you want to. It is not completely stable, as it still have some bugs or unintended behaviors (list at the end of this message), but the base mechanics are already here and working as intended.

I rewrote the dynamic image loader from scratch, trying to make a simpler version than the original one, sadly, it isn't possible, you will understand why very soon.

## Current behavior
The dynamic image loader aim to load just the textures displayed on the screen + 1 extra row on top and on the bottom, so the user is less likely to see the magic happening.

For this, I used 2 var : **target min range** and **target max range**, those are updated every time the grid scrolled up or down (which mean games displayed on screen changed).

This happen "asynchronously", so it don't freeze when loading big amount of images, only one image can be loaded and one can be unloaded by frame (call to the update functions).

For this, 2 other var are used : **current min range** and **current max range**. Once every frame, both the **current min and max range** go one step forward to **target min and max range**, loading or unloading images on their way.

This work pretty good, even if the user scroll down the grid at the highest speed, but it doesn't fit all use case. Sometimes, the range change a lot, for example when the user select a random game and have a big game collection so the current range and the next target range have no image in common.

For this I added a 2nd mod, badly named "emergency mod", when it happen, on the next frame all the currently loaded textures will be unloaded all at the same time, then the **current min and max range** will both be set to **target min range**. At this moment the "emergency mod" is exited and the dynamic image loader will get back to normal behavior, this mean, since the **current max range** is set to **target min range**, it will go back, step by step, to **target max range**, loading the images on its way.

## Known bugs or unintended behaviors
- When the menu is opened by pressing "select", all the images are reseted to default, even if they are not unloaded
- When switching from one system to another, the current range isn't unloaded

## Testing
I left some debug print for now, as it help understanding what's going on.

Also, right now the system try to keep all the displayed images on screen loaded + 1 extra row and top and bottom, this can be changed to "-1 extra row" to better see what's happening, by changing : 
Line 331 : 
`nextTargetRange.min = startPos - mGridDimension.x();`
to
`nextTargetRange.min = startPos + mGridDimension.x();`

Line 336 : 
`nextTargetRange.max = startPos + (mGridDimension.x() + 1) * mGridDimension.y();`
to
`nextTargetRange.max = startPos + (mGridDimension.x() - 1) * mGridDimension.y();`

**Note that doing this may introduce some bugs, but you can better see base behavior.**