### PR TITLE
[GRID 8] Enable the grid view for everyone

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -274,10 +274,7 @@ void GuiMenu::openUISettings()
 	styles.push_back("basic");
 	styles.push_back("detailed");
 	styles.push_back("video");
-
-	// Temporary "hack" so ES don't crash when leaving this menu after he enabled the grid by tweaking config file
-	if (Settings::getInstance()->getString("GamelistViewStyle") == "grid")
-		styles.push_back("grid");
+	styles.push_back("grid");
 
 	for (auto it = styles.cbegin(); it != styles.cend(); it++)
 		gamelist_style->add(*it, *it, Settings::getInstance()->getString("GamelistViewStyle") == *it);


### PR DESCRIPTION
Beside step 7, all the base features are now included in the grid view.

Once step 7 will be done, the grid will be considered stable, reliable and mature enough, to release a  V1, and so to open the door to everyone using emulationstation-dev, by merging this.

This doesn't mean the development is over, I have big plans for the future of the grid view, but those are just embellishments, all the base features are here.

You can check the ![wiki](https://github.com/RetroPie/EmulationStation/wiki/Gridview-Roadmap-and-FAQ#unordered-extra-features) to see what may come after the first grid view release.