### PR TITLE
Rewrite NinePatchComponent to handle images of all sizes

### DIFF
--- a/es-core/src/components/NinePatchComponent.h
+++ b/es-core/src/components/NinePatchComponent.h
@@ -37,9 +37,11 @@ public:
 
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
-private:
-	Vector2f getCornerSize() const;
+	const Vector2f& getCornerSize() const;
+	void setCornerSize(int sizeX, int sizeY);
+	inline void setCornerSize(const Vector2f& size) { setCornerSize(size.x(), size.y()); }
 
+private:
 	void buildVertices();
 	void updateColors();
 
@@ -53,6 +55,7 @@ private:
 	GLubyte* mColors;
 
 	std::string mPath;
+	Vector2f mCornerSize;
 	unsigned int mEdgeColor;
 	unsigned int mCenterColor;
 	std::shared_ptr<TextureResource> mTexture;


### PR DESCRIPTION
**Changes**
- Rewrite NinePatchComponent to handle images with a different size than 48x48 px
- It's now possible to change the border sizes using setCornerSize function

**Context**
Since the grid view use the NinePatchComponent for the tile background, it would be nice to be able to use images of different size than 48x48 pixels.

The current code was badly written as the part sizes and coordinates were sometimes calculated using the Vector2f returned by getCornerSize, sometimes using the "Vector2f pieceCoords[9]". It would have taken me more time to update it than rewrite it from scratch, so I did.

**Examples**
Using this image : 
![_unknown2](https://user-images.githubusercontent.com/24305945/39086163-efa7bce4-458d-11e8-842f-e2b4ce491286.png)

The following examples have their borders colored (remember the setEdgeColor) in red so you better see what's going on.

Corner size : 8 8
![sd8](https://user-images.githubusercontent.com/24305945/39086379-bc8636da-4590-11e8-9836-9519a6a02809.png)

Corner size : 16 16
![sd16](https://user-images.githubusercontent.com/24305945/39086380-c1ff8c4c-4590-11e8-87fd-7c67040f793b.png)

Corner size : 32 32
![sd32](https://user-images.githubusercontent.com/24305945/39086382-c36cf88a-4590-11e8-88c8-0d7aad370587.png)

Corner size : 48 48
![sd48](https://user-images.githubusercontent.com/24305945/39086383-c55eba3e-4590-11e8-8aa9-fe9222c536e2.png)

Corner size : 48 48 (without red border)
![sd48nored](https://user-images.githubusercontent.com/24305945/39086384-c716a882-4590-11e8-9ba7-0114af90cf24.png)

Note that funny stuff happen if you set 48 48 corner size on a 48x48 px image.

Example with frame.png
![framenocolor](https://user-images.githubusercontent.com/24305945/39086387-ca3174d4-4590-11e8-8f85-54cbf4cbc3e9.png)

Example with this dirtily colored frame.png
![frame2](https://user-images.githubusercontent.com/24305945/39086390-ce9ca750-4590-11e8-8645-c0e7f179173a.png)

![framecolored](https://user-images.githubusercontent.com/24305945/39086389-cb2ccf14-4590-11e8-9bc6-7ac03a8219d0.png)

I'm not sure anyone will ever use this "bug" as a feature but well ... who am I to judge modern art !