### PR TITLE
Clean IList onCursorChanged behavior

### DIFF
--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -213,8 +213,11 @@ void SystemView::update(int deltaTime)
 	GuiComponent::update(deltaTime);
 }
 
-void SystemView::onCursorChanged(const CursorState& /*state*/)
+void SystemView::onCursorChanged(const CursorState& state)
 {
+	if (state != CURSOR_SCROLLING)
+		return;
+
 	// update help style
 	updateHelpPrompts();
 

--- a/es-core/src/components/ComponentList.cpp
+++ b/es-core/src/components/ComponentList.cpp
@@ -106,6 +106,9 @@ void ComponentList::update(int deltaTime)
 
 void ComponentList::onCursorChanged(const CursorState& state)
 {
+	if (state != CURSOR_SCROLLING)
+		return;
+
 	// update the selector bar position
 	// in the future this might be animated
 	mSelectorBarOffset = 0;

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -276,7 +276,8 @@ void ImageGridComponent<T>::onSizeChanged()
 template<typename T>
 void ImageGridComponent<T>::onCursorChanged(const CursorState& state)
 {
-	updateTiles();
+	if (state == CURSOR_SCROLLING)
+		updateTiles();
 
 	if(mCursorChangedCallback)
 		mCursorChangedCallback(state);


### PR DESCRIPTION
- Fix : When scrolling of only one item, a "scrolling" and then a "stopped" event is now triggered, instead of 2 "stopped"
- Fix : Removed the unneeded call to "onCursorChanged" from "stopScrolling" and "clear", as they both call "listInput" which will already trigger the "onCursorChanged" event. This also prevent the call on onCursorChanged for each game list view on ES startup.
- Add : Manually setting the cursor now trigger a "scrolling" event in addition to the "stopped" event
- Add : TextListComponent, ImageGridComponent, SystemView and ComponentList can now take well-informed decisions depending on cursor state