### PR TITLE
es-core: Loop ComponentList by default.

### DIFF
--- a/es-core/src/components/ComponentList.cpp
+++ b/es-core/src/components/ComponentList.cpp
@@ -4,7 +4,7 @@
 
 #define TOTAL_HORIZONTAL_PADDING_PX 20
 
-ComponentList::ComponentList(Window* window) : IList<ComponentListRow, void*>(window, LIST_SCROLL_STYLE_SLOW, LIST_NEVER_LOOP)
+ComponentList::ComponentList(Window* window) : IList<ComponentListRow, void*>(window, LIST_SCROLL_STYLE_SLOW, LIST_ALWAYS_LOOP)
 {
 	mSelectorBarOffset = 0;
 	mCameraOffset = 0;


### PR DESCRIPTION
This patch makes it possible to press up on the GuiMenu
to get to the last item, instead of pressing down multiple times.

This is especially usable when you want to shut down the system
frequently like on the Freeplay CM3.

Not sure why the less usable option here was the default setting,
since list looping is implemented.

With this patch shutting down the system takes 6 button presses
instead of 13.

If you decide that this behaviour is to invasive by default, I could try to make it just being used in the GuiMenu. But I can't think of any case where prohibiting to loop the menu could be better.
Enlighten me.