### PR TITLE
Add 3 new theming properties to the grid tile background

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -598,12 +598,18 @@ Can be created as an extra.
     - The size of the default gridtile is used to calculate how many tiles can fit in the imagegrid. If not explicitly set, the size of the selected gridtile is equal the size of the default gridtile * 1.2
 * `padding` - type: NORMALIZED_PAIR.
     - The padding around the gridtile content. Default `16 16`. If not explicitly set, the selected tile padding will be equal to the default tile padding.
-* `backgroundImage` - type: PATH.
-    - If not explicitly set, the selected tile background image will be the same as the default tile background image.
 * `imageColor` - type: COLOR.
     - The default tile image color and selected tile image color have no influence on each others.
+* `backgroundImage` - type: PATH.
+    - If not explicitly set, the selected tile background image will be the same as the default tile background image.
+* `backgroundCornerSize` - type: NORMALIZED_PAIR.
+    - The corner size of the ninepatch used for the tile background. Default is `16 16`.
 * `backgroundColor` - type: COLOR.
-    - The default tile background color and selected tile background color have no influence on each others.
+    - A shortcut to define both the center color and edge color at the same time. The default tile background color and selected tile background color have no influence on each others.
+* `backgroundCenterColor` - type: COLOR.
+    - Set the color of the center part of the ninepatch. The default tile background center color and selected tile background center color have no influence on each others.
+* `backgroundEdgeColor` - type: COLOR.
+    - Set the color of the edge parts of the ninepatch. The default tile background edge color and selected tile background edge color have no influence on each others.
 
 #### video
 

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -35,9 +35,12 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 	{ "gridtile", {
 		{ "size", NORMALIZED_PAIR },
 		{ "padding", NORMALIZED_PAIR },
-		{ "backgroundImage", PATH },
 		{ "imageColor", COLOR },
-		{ "backgroundColor", COLOR } } },
+		{ "backgroundImage", PATH },
+		{ "backgroundCornerSize", NORMALIZED_PAIR },
+		{ "backgroundColor", COLOR },
+		{ "backgroundCenterColor", COLOR },
+		{ "backgroundEdgeColor", COLOR } } },
 	{ "text", {
 		{ "pos", NORMALIZED_PAIR },
 		{ "size", NORMALIZED_PAIR },

--- a/es-core/src/components/GridTileComponent.h
+++ b/es-core/src/components/GridTileComponent.h
@@ -9,9 +9,11 @@ struct GridTileProperties
 {
 	Vector2f mSize;
 	Vector2f mPadding;
-	std::string mBackgroundImage;
 	unsigned int mImageColor;
-	unsigned int mBackgroundColor;
+	std::string mBackgroundImage;
+	Vector2f mBackgroundCornerSize;
+	unsigned int mBackgroundCenterColor;
+	unsigned int mBackgroundEdgeColor;
 };
 
 class GridTileComponent : public GuiComponent


### PR DESCRIPTION
Add 3 new theming properties to the grid tile background : 
- backgroundCornerSize
- backgroundCenterColor
- backgroundEdgeColor

@jrassa This is the last step before the release of the V1 of the grid view with PR 418 and 419, the finish line is in sight, stay strong ;)