### PR TITLE
Grid display only selected system

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -14,6 +14,7 @@
 #include "VolumeControl.h"
 #include "Window.h"
 #include <assert.h>
+#include <views/ViewController.h>
 
 FileData::FileData(FileType type, const std::string& path, SystemEnvironmentData* envData, SystemData* system)
 	: mType(type), mPath(path), mSystem(system), mEnvData(envData), mSourceFileData(NULL), mParent(NULL), metadata(type == GAME ? GAME_METADATA : FOLDER_METADATA) // metadata is REALLY set in the constructor!
@@ -283,6 +284,7 @@ void FileData::launchGame(Window* window)
 	window->init();
 	VolumeControl::getInstance()->init();
 	window->normalizeNextUpdate();
+	ViewController::get()->getCurrentView()->onShow();
 
 	//update number of times the game has been launched
 

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -38,6 +38,7 @@ public:
 	void goToStart();
 	void ReloadAndGoToStart();
 
+	std::shared_ptr<GuiComponent> getCurrentView() const { return mCurrentView; };
 	void onFileChanged(FileData* file, FileChangeType change);
 
 	// Plays a nice launch effect and launches the game at the end of it.

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -19,6 +19,8 @@ GridGameListView::GridGameListView(Window* window, FileData* root) :
 	mGenre(window), mPlayers(window), mLastPlayed(window), mPlayCount(window),
 	mName(window)
 {
+	mSkipHideEvent = 0;
+
 	const float padding = 0.01f;
 
 	mGrid.setPosition(mSize.x() * 0.1f, mSize.y() * 0.1f);
@@ -299,6 +301,8 @@ void GridGameListView::addPlaceholder()
 
 void GridGameListView::launch(FileData* game)
 {
+	mSkipHideEvent = 2;
+
 	ViewController::get()->launch(game);
 }
 
@@ -378,4 +382,26 @@ std::vector<HelpPrompt> GridGameListView::getHelpPrompts()
 		prompts.push_back(HelpPrompt("y", prompt));
 	}
 	return prompts;
+}
+
+void GridGameListView::onShow()
+{
+	ISimpleGameListView::onShow();
+	mGrid.setVisible(true);
+}
+
+void GridGameListView::onHide()
+{
+	ISimpleGameListView::onHide();
+
+	// Do not hide the grid if we just launched a game from this gamelist
+	/*
+	if (mSkipHideEvent > 0)
+	{
+		mSkipHideEvent--;
+		return;
+	}
+	*/
+
+	mGrid.setVisible(false);
 }

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -25,6 +25,9 @@ public:
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 	virtual void launch(FileData* game) override;
 
+	virtual void onShow() override;
+	virtual void onHide() override;
+
 protected:
 	virtual std::string getQuickSystemSelectRightButton() override;
 	virtual std::string getQuickSystemSelectLeftButton() override;
@@ -57,6 +60,8 @@ private:
 
 	ScrollableContainer mDescContainer;
 	TextComponent mDescription;
+
+	int mSkipHideEvent; // Do not hide the grid if we just launched a game from this gamelist
 };
 
 #endif // ES_APP_VIEWS_GAME_LIST_GRID_GAME_LIST_VIEW_H

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -48,6 +48,7 @@ public:
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
 	void onSizeChanged() override;
+	void setVisible(bool visible);
 	inline void setCursorChangedCallback(const std::function<void(CursorState state)>& func) { mCursorChangedCallback = func; }
 
 protected:
@@ -78,6 +79,7 @@ private:
 	std::vector< std::shared_ptr<GridTileComponent> > mTiles;
 
 	// MISCELLANEOUS
+	bool mVisible;
 	ScrollDirection mScrollDirection;
 	std::function<void(CursorState state)> mCursorChangedCallback;
 };
@@ -96,6 +98,7 @@ ImageGridComponent<T>::ImageGridComponent(Window* window) : IList<ImageGridData,
 	mMargin = screen * 0.07f;
 	mTileSize = GridTileComponent::getDefaultTileSize();
 
+	mVisible = false;
 	mScrollDirection = SCROLL_VERTICALLY;
 }
 
@@ -153,6 +156,9 @@ void ImageGridComponent<T>::update(int deltaTime)
 template<typename T>
 void ImageGridComponent<T>::render(const Transform4x4f& parentTrans)
 {
+	if (!mVisible)
+		return;
+
 	Transform4x4f trans = getTransform() * parentTrans;
 
 	if(mEntriesDirty)
@@ -287,6 +293,12 @@ void ImageGridComponent<T>::onCursorChanged(const CursorState& state)
 
 	if(mCursorChangedCallback)
 		mCursorChangedCallback(state);
+}
+
+template<typename T>
+void ImageGridComponent<T>::setVisible(bool visible)
+{
+	mVisible = visible;
 }
 
 // Create and position tiles (mTiles)


### PR DESCRIPTION
**Do not merge there is a bug atm.** After we launch and quit a game, when we come back to ES, the grid is not displayed. The onShow event on the GridGameListView is not triggered in this situation, and I couldn't find where to add this call in the ViewController. I'm hoping you can help me there @jrassa or @pjft

Full context : https://retropie.org.uk/forum/post/149791
TLDR : This only display the selected system's grid so ES don't try to load the texture of all the systems. This should resolve the ES hang bug on start with the grid view enabled, or when the user switch to the grid game list view style within the menu.