### PR TITLE
InputManager: improve trigger axis calibration

### DIFF
--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -101,7 +101,14 @@ void InputManager::addJoystickByDeviceIndex(int id)
 	// set up the prevAxisValues
 	int numAxes = SDL_JoystickNumAxes(joy);
 	mPrevAxisValues[joyId] = new int[numAxes];
-	std::fill(mPrevAxisValues[joyId], mPrevAxisValues[joyId] + numAxes, 0); //initialize array to 0
+	mInitAxisValues[joyId] = new int[numAxes];
+
+	int axis;
+	for (int i = 0; i< numAxes; i++) {
+		axis = SDL_JoystickGetAxis(joy, i);
+		mInitAxisValues[joyId][i] = axis;
+		mPrevAxisValues[joyId][i] = axis;
+	}
 }
 
 void InputManager::removeJoystickByJoystickID(SDL_JoystickID joyId)
@@ -198,21 +205,28 @@ InputConfig* InputManager::getInputConfigByDevice(int device)
 bool InputManager::parseEvent(const SDL_Event& ev, Window* window)
 {
 	bool causedEvent = false;
+	int axis;
 	switch(ev.type)
 	{
 	case SDL_JOYAXISMOTION:
+		axis = ev.jaxis.value;
+		// Check for ABS_Z/ABS_RZ trigger axes which rest at -32768
+		if ((ev.jaxis.axis == 2 || ev.jaxis.axis == 5) && mInitAxisValues[ev.jaxis.which][ev.jaxis.axis] == -32768)
+		{
+			// shift to 0 - 32767.
+			axis = axis / 2 + 16384;
+		}
 		//if it switched boundaries
-		if((abs(ev.jaxis.value) > DEADZONE) != (abs(mPrevAxisValues[ev.jaxis.which][ev.jaxis.axis]) > DEADZONE))
+		if((abs(axis) > DEADZONE) != (abs(mPrevAxisValues[ev.jaxis.which][ev.jaxis.axis]) > DEADZONE))
 		{
 			int normValue;
-			if(abs(ev.jaxis.value) <= DEADZONE)
+			if(abs(axis) <= DEADZONE)
 				normValue = 0;
 			else
-				if(ev.jaxis.value > 0)
+				if(axis > 0)
 					normValue = 1;
 				else
 					normValue = -1;
-
 			window->input(getInputConfigByDevice(ev.jaxis.which), Input(ev.jaxis.which, TYPE_AXIS, ev.jaxis.axis, normValue, false));
 			causedEvent = true;
 		}

--- a/es-core/src/InputManager.h
+++ b/es-core/src/InputManager.h
@@ -27,6 +27,7 @@ private:
 	InputConfig* mCECInputConfig;
 
 	std::map<SDL_JoystickID, int*> mPrevAxisValues;
+	std::map<SDL_JoystickID, int*> mInitAxisValues;
 
 	bool initialized() const;
 


### PR DESCRIPTION
Some drivers (such as hid-sony) configure analog triggers (L2/R2) as axes
with axis range -32768-32767, but the resting value starts at -32768,
causing an initial or light press to register erroneously as a minus
axis value.

Fix by shifting ABS_Z and ABS_RZ axes that are detected to rest at
-32768 so that they will range from 0-32767 instead.

Patch based on Jools Wills' earlier commit: https://github.com/RetroPie/EmulationStation/pull/58

--

N.B. Keep in mind that the hid-sony driver introduces additional complexity by way of also exporting digital button events for L2/R2. I've addressed that issue by adding a patch to customhidsony via the sixaxis PR: https://github.com/RetroPie/RetroPie-Setup/pull/2263

This PR combined with the sixaxis PR seems to result in everything working properly, but I'm hesitant to say that *this* PR is completely safe. 

Jools - can you recall specifically what went wrong with 8bitdo pads? Your code would have applied axis shifting to any axis that rested at -32768, but I don't think this is desirable; only trigger axes should be shifted, and ABS_Z & ABS_RZ (2, 5) seem to be the common trigger axes for drivers. The deadzone adjustment from your patch also seemed to interfere with proper trigger detection, so I omitted that part as well.