### PR TITLE
Grid fix freeze with big game collections

### DIFF
--- a/es-core/src/components/GridTileComponent.cpp
+++ b/es-core/src/components/GridTileComponent.cpp
@@ -151,6 +151,9 @@ bool GridTileComponent::isSelected() const
 void GridTileComponent::setImage(const std::string& path)
 {
 	mImage->setImage(path);
+
+	// Resize now to prevent flickering images when scrolling
+	resize();
 }
 
 void GridTileComponent::setImage(const std::shared_ptr<TextureResource>& texture)


### PR DESCRIPTION
This fix the infinite freeze with big game collections by storing the texture path instead of loading texture resource.

Sadly this make navigating into the grid a bit laggish at highest scroll speeds with big game collections, I'm looking at different solutions to solve this problem but I think it's out of the scope of this PR.