### PR TITLE
Fix SVG resize issue for option_arrow.svg

### DIFF
--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -143,6 +143,9 @@ public:
 		mText.setHorizontalAlignment(ALIGN_CENTER);
 		addChild(&mText);
 
+		mLeftArrow.setResize(0, mText.getFont()->getLetterHeight());
+		mRightArrow.setResize(0, mText.getFont()->getLetterHeight());
+
 		if(mMultiSelect)
 		{
 			mRightArrow.setImage(":/arrow.svg");


### PR DESCRIPTION
* fixes #447 
* but not #452

The problem is that when the SVG file is loaded, it is first set to the SVG's internal dimensions and *then* to the desired dimensions, stumbling over a possible race condition while doing so. The workaround here is to set the desired dimensions *before* loading the SVG, thus avoiding the intermediate step.