### PR TITLE
Add support for Vero4k

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,12 @@ elseif(EXISTS "/opt/vc/include/bcm_host.h")
     set(BCMHOST found)
     set(GLSystem "OpenGL ES" CACHE STRING "The OpenGL system to be used")
 #-------------------------------------------------------------------------------
+#check if we're running on OSMC Vero4K
+elseif(EXISTS "/opt/vero3/lib/libMali.so")
+    MESSAGE("libMali.so found")
+    set(VERO4K found)
+    set(GLSystem "OpenGL ES" CACHE STRING "The OpenGL system to be used")
+#-------------------------------------------------------------------------------
 #check if we're running on olinuxino / odroid / etc
 elseif(EXISTS "/usr/lib/libMali.so" OR
     EXISTS "/usr/lib/arm-linux-gnueabihf/libMali.so" OR
@@ -67,6 +73,10 @@ endif()
 #set up compiler flags and excutable names
 if(DEFINED BCMHOST)
     add_definitions(-D_RPI_)
+endif()
+
+if(DEFINED VERO4K)
+    add_definitions(-D_VERO4K_)
 endif()
 
 if(DEFINED libCEC_FOUND)
@@ -141,6 +151,11 @@ if(DEFINED BCMHOST)
         "/opt/vc/include/interface/vmcs_host/linux"
         "/opt/vc/include/interface/vcos/pthreads"
     )
+#add include directory for Vero4K
+elseif(DEFINED VERO4K)
+    LIST(APPEND COMMON_INCLUDE_DIRS
+        "/opt/vero3/include"
+    )
 else()
     if(${GLSystem} MATCHES "Desktop OpenGL")
         LIST(APPEND COMMON_INCLUDE_DIRS
@@ -159,6 +174,10 @@ if(DEFINED BCMHOST)
     link_directories(
         ${Boost_LIBRARY_DIRS}
         "/opt/vc/lib"
+    )
+elseif(DEFINED VERO4K)
+    link_directories(
+        "/opt/vero3/lib"
     )
 else()
     link_directories(
@@ -201,6 +220,11 @@ if(DEFINED BCMHOST)
     LIST(APPEND COMMON_LIBRARIES
         bcm_host
         brcmEGL
+        ${OPENGLES_LIBRARIES}
+    )
+elseif(DEFINED VERO4K)
+    LIST(APPEND COMMON_LIBRARIES
+        EGL
         ${OPENGLES_LIBRARIES}
     )
 else()

--- a/es-app/src/VolumeControl.cpp
+++ b/es-app/src/VolumeControl.cpp
@@ -8,7 +8,7 @@
 #endif
 
 #if defined(__linux__)
-    #ifdef _RPI_
+    #if defined(_RPI_) || defined(_VERO4K_)
         const char * VolumeControl::mixerName = "PCM";
     #else
     	const char * VolumeControl::mixerName = "Master";


### PR DESCRIPTION
The Vero4k is the most recent box running OSMC.  Similar to an ODROID-C2 I think, but with it's own quirks and requirements.

Note - this PR is required for my larger commit to Retropie-Setup to work!

I was pushing to Stable here as it's the default for a Core Packages install.  Otherwise I assume installation of emulationstation-dev will be mandatory instead? Seemed tidier this way, but I can always push my master branch to yours instead and make that a conditional thing over in RetroPie-Setup.

Many thanks.
