### PR TITLE
Update arrow/fav/knob svg artwork.

### DIFF
--- a/resources/arrow.svg
+++ b/resources/arrow.svg
@@ -1,11 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="12.165px" height="21.921px" viewBox="0 0 12.165 21.921" enable-background="new 0 0 12.165 21.921" xml:space="preserve">
-<g>
-	<path fill="#777777" d="M0.75,21.921c-0.197,0-0.395-0.077-0.542-0.231c-0.287-0.299-0.276-0.773,0.023-1.061l10.098-9.668
-		L0.231,1.292c-0.299-0.286-0.31-0.761-0.023-1.06c0.286-0.3,0.761-0.31,1.06-0.023l10.665,10.211
-		c0.147,0.141,0.231,0.337,0.231,0.542s-0.084,0.4-0.231,0.542L1.269,21.713C1.124,21.852,0.937,21.921,0.75,21.921z"/>
-</g>
-</svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="36" height="64" version="1.1" viewBox="0 0 36 64" xmlns="http://www.w3.org/2000/svg">
+	<path d="m2 2 l32 30 l-32 30" fill="none" stroke="#777" stroke-linejoin="round" stroke-linecap="round" stroke-width="4"/>
+ </svg>

--- a/resources/fav_add.svg
+++ b/resources/fav_add.svg
@@ -1,12 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="21.002px" height="22.002px" viewBox="0 0 21.002 22.002" enable-background="new 0 0 21.002 22.002" xml:space="preserve">
-<g>
-	<rect y="10.251" fill="#777777" width="21.002" height="1.5"/>
-</g>
-<g>
-	<rect x="9.751" fill="#777777" width="1.5" height="22.002"/>
-</g>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="64" version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+	<line stroke-width="4" x1="2" y1="32" x2="62" y2="32" stroke="#777"/>
+	<line stroke-width="4" x1="32" y1="2" x2="32" y2="62" stroke="#777"/>
 </svg>

--- a/resources/fav_remove.svg
+++ b/resources/fav_remove.svg
@@ -1,9 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="21.002px" height="22.002px" viewBox="0 0 21.002 22.002" enable-background="new 0 0 21.002 22.002" xml:space="preserve">
-<g>
-	<rect y="10.251" fill="#777777" width="21.002" height="1.5"/>
-</g>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="64" version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+	<line stroke-width="4" x1="2" y1="32" x2="62" y2="32" stroke="#777"/>
 </svg>

--- a/resources/option_arrow.svg
+++ b/resources/option_arrow.svg
@@ -1,11 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="12.158px" height="21.913px" viewBox="0 0 12.158 21.913" enable-background="new 0 0 12.158 21.913" xml:space="preserve">
-<g>
-	<path fill="#777777" d="M0.75,21.913c-0.1,0-0.2-0.02-0.294-0.061C0.179,21.735,0,21.463,0,21.163V0.75
-		c0-0.3,0.179-0.572,0.456-0.69C0.73-0.057,1.052,0,1.269,0.208l10.658,10.206c0.147,0.141,0.231,0.337,0.231,0.542
-		s-0.084,0.4-0.231,0.542L1.269,21.705C1.126,21.84,0.939,21.913,0.75,21.913z M1.5,2.506v16.899l8.824-8.45L1.5,2.506z"/>
-</g>
-</svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="36" height="64" version="1.1" viewBox="0 0 36 64" xmlns="http://www.w3.org/2000/svg">
+	<path d="m2 2 l32 30 l-32 30 z" fill="none" stroke="#777" stroke-linejoin="round" stroke-width="4"/>
+ </svg>

--- a/resources/slider_knob.svg
+++ b/resources/slider_knob.svg
@@ -1,8 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
-<path fill-rule="evenodd" clip-rule="evenodd" fill="#777777" d="M8,0c4.418,0,8,3.582,8,8c0,4.418-3.582,8-8,8s-8-3.582-8-8
-	C0,3.582,3.583,0,8,0z"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64" height="64" version="1.1" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+	<circle cx="32" cy="32" r="32" fill="#777"/>
 </svg>


### PR DESCRIPTION
Some more cleanup of the existing svg artwork with handcrafted svg files.

It appears that the `fav_add.svg` and `fav_remove.svg` files are unused in Emulationstation. They have been updated anyway, but it may also be possible to remove them instead.