### PR TITLE
Remove trailing '/' on paths in getGenericPath

### DIFF
--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -226,6 +226,10 @@ namespace Utils
 			while((offset = path.find("//")) != std::string::npos)
 				path.erase(offset, 1);
 
+			// remove trailing '/'
+			while(path.length() && ((offset = path.find_last_of('/')) == (path.length() - 1)))
+				path.erase(offset, 1);
+
 			// return generic path
 			return path;
 


### PR DESCRIPTION
This should fix https://github.com/RetroPie/EmulationStation/issues/473 and any other issues with path's ending with a /

Only tested on Windows, and I would appreciate if someone could test this on a pi since I currently don't have one