### PR TITLE
Allow to show hidden files on Windows

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -97,6 +97,10 @@ void SystemData::populateFolder(FileData* folder)
 	{
 		filePath = *it;
 
+		// skip hidden files and folders
+		if(!showHidden && Utils::FileSystem::isHidden(filePath))
+			continue;
+
 		//this is a little complicated because we allow a list of extensions to be defined (delimited with a space)
 		//we first get the extension of the file itself:
 		extension = Utils::FileSystem::getExtension(filePath);
@@ -107,10 +111,6 @@ void SystemData::populateFolder(FileData* folder)
 		isGame = false;
 		if(std::find(mEnvData->mSearchExtensions.cbegin(), mEnvData->mSearchExtensions.cend(), extension) != mEnvData->mSearchExtensions.cend())
 		{
-			// skip hidden files
-			if(!showHidden && Utils::FileSystem::isHidden(filePath))
-				continue;
-
 			FileData* newGame = new FileData(GAME, filePath, mEnvData, this);
 			folder->addChild(newGame);
 			isGame = true;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -363,13 +363,11 @@ void GuiMenu::openOtherSettings()
 	s->addWithLabel("PARSE GAMESLISTS ONLY", parse_gamelists);
 	s->addSaveFunc([parse_gamelists] { Settings::getInstance()->setBool("ParseGamelistOnly", parse_gamelists->getState()); });
 
-#ifndef WIN32
 	// hidden files
 	auto hidden_files = std::make_shared<SwitchComponent>(mWindow);
 	hidden_files->setState(Settings::getInstance()->getBool("ShowHiddenFiles"));
 	s->addWithLabel("SHOW HIDDEN FILES", hidden_files);
 	s->addSaveFunc([hidden_files] { Settings::getInstance()->setBool("ShowHiddenFiles", hidden_files->getState()); });
-#endif
 
 #ifdef _RPI_
 	// Video Player - VideoOmxPlayer


### PR DESCRIPTION
This also moves the hidden files skip to happen earlier
Previously it only checked if a file was hidden if it matched the extension for the current system tested, this means that most of the time, it also loops over the media folder, and all the files in that, which for systems like mine, is ALOT, currently 8 media file per rom, and for GBA alone thats over 8000 media files, that it scans and loops over.

With this check moved earlier, I could mark the media folder as hidden ( renamed it .media ) which means it skips the entire folder right away.

Now, on my local SSD this made absolutlely no difference whatsoever, so I decided to test the worst case scenario, having everything on a network storage, ES bootup times went from 340 seconds to 55 with this simple change.