### PR TITLE
Fix the TextComponent 'setOpacity' method

### DIFF
--- a/es-core/src/components/TextComponent.cpp
+++ b/es-core/src/components/TextComponent.cpp
@@ -73,6 +73,10 @@ void TextComponent::setOpacity(unsigned char opacity)
 
 	onColorChanged();
 
+	// Save the opacity values
+	mColorOpacity = opacity;
+	mBgColorOpacity = opacity;
+
 	GuiComponent::setOpacity(opacity);
 }
 


### PR DESCRIPTION
The `setOpacity` method would not save the opacity for Color/Background, so calling this method repeatedly would produce the same result.

The method (for this Class) is used AFAICT only in [GuiInputConfig](https://github.com/RetroPie/EmulationStation/blob/811e2cefdcd0de6149f0f5682d7b2a7492eadddf/es-core/src/guis/GuiInputConfig.cpp#L168), so it shouldn't have any side effects.

As an aside, the Input Configuration dialog will not show the 'hold-to-skip' message every time an button/input is considered [skippable](https://github.com/RetroPie/EmulationStation/blob/811e2cefdcd0de6149f0f5682d7b2a7492eadddf/es-core/src/guis/GuiInputConfig.cpp#L19), instead of just displaying the info message at the beginning. It seems this was the intended behavior, but didn't work because `setOpacity` would make the message fade out and it stayed this way.

Started by https://retropie.org.uk/forum/topic/2281/how-do-i-get-passed-the-gamepad-config-screen-with-keyboard/15.