### PR TITLE
Fix toggling the display of the hold-to-skip message during Input Configuration.

### DIFF
--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -81,7 +81,7 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 	mSubtitle1 = std::make_shared<TextComponent>(mWindow, Utils::String::toUpper(ss.str()), Font::get(FONT_SIZE_MEDIUM), 0x555555FF, ALIGN_CENTER);
 	mGrid.setEntry(mSubtitle1, Vector2i(0, 2), false, true);
 
-	mSubtitle2 = std::make_shared<TextComponent>(mWindow, "HOLD ANY BUTTON TO SKIP", Font::get(FONT_SIZE_SMALL), 0x99999900, ALIGN_CENTER);
+	mSubtitle2 = std::make_shared<TextComponent>(mWindow, "HOLD ANY BUTTON TO SKIP", Font::get(FONT_SIZE_SMALL), 0x999999FF, ALIGN_CENTER);
 	mGrid.setEntry(mSubtitle2, Vector2i(0, 3), false, true);
 
 	// 4 is a spacer row


### PR DESCRIPTION
[2nd attempt after #482, which was obviously wrong]

The Input Configuration dialog should show the 'hold-to-skip' message every time an button/input is considered skippable, instead of just displaying the info message just at the beginning of the Input Mapping. However, because of the way the color for the component was initialized, the `mColorOpacity` would be zero, so toggling the visibility of this TextComponent calls to `setOpacity` did not work.

Started by https://retropie.org.uk/forum/topic/2281/how-do-i-get-passed-the-gamepad-config-screen-with-keyboard/15.