### PR TITLE
Reset "StartupSystem" to "" if the requested system doesn't exist

### DIFF
--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -56,6 +56,9 @@ void ViewController::goToStart()
 				return;
 			}
 		}
+
+		// Requested system doesn't exist
+		Settings::getInstance()->setString("StartupSystem", "");
 	}
 	goToSystemView(SystemData::sSystemVector.at(0));
 }


### PR DESCRIPTION
Fixes https://github.com/RetroPie/EmulationStation/issues/486