### PR TITLE
Fix missing / in custom collection path

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -1035,12 +1035,12 @@ bool CollectionSystemManager::includeFileInAutoCollections(FileData* file)
 
 std::string getCustomCollectionConfigPath(std::string collectionName)
 {
-	return getCollectionsFolder() + "custom-" + collectionName + ".cfg";;
+	return getCollectionsFolder() + "/custom-" + collectionName + ".cfg";
 }
 
 std::string getCollectionsFolder()
 {
-	return Utils::FileSystem::getGenericPath(Utils::FileSystem::getHomePath() + "/.emulationstation/collections/");
+	return Utils::FileSystem::getGenericPath(Utils::FileSystem::getHomePath() + "/.emulationstation/collections");
 }
 
 bool systemSort(SystemData* sys1, SystemData* sys2)


### PR DESCRIPTION
The getGenericPath fix broke custom collections, this once again fixes that.