### PR TITLE
Add origin support for datetime

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -735,6 +735,8 @@ EmulationStation borrows the concept of "nine patches" from Android (or "9-Slice
 * `pos` - type: NORMALIZED_PAIR.
 * `size` - type: NORMALIZED_PAIR.
 	- You should probably not set this.  Leave it to `fontSize`.
+* `origin` - type: NORMALIZED_PAIR.
+	- Where on the component `pos` refers to.  For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the component exactly in the middle of the screen.  If the "POSITION" and "SIZE" attributes are themable, "ORIGIN" is implied.
 * `color` - type: COLOR.
 * `fontPath` - type: PATH.
 * `fontSize` - type: FLOAT.

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -90,6 +90,7 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 	{ "datetime", {
 		{ "pos", NORMALIZED_PAIR },
 		{ "size", NORMALIZED_PAIR },
+		{ "origin", NORMALIZED_PAIR },
 		{ "color", COLOR },
 		{ "fontPath", PATH },
 		{ "fontSize", FLOAT },


### PR DESCRIPTION
This adds `<origin>` support for the `<datetime>` element