### PR TITLE
Fixing kids/unattended mode

### DIFF
--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -154,7 +154,7 @@ std::vector<HelpPrompt> BasicGameListView::getHelpPrompts()
 		prompts.push_back(HelpPrompt("select", "options"));
 	if(mRoot->getSystem()->isGameSystem())
 		prompts.push_back(HelpPrompt("x", "random"));
-	if(mRoot->getSystem()->isGameSystem() && UIModeController::getInstance()->isUIModeFull())
+	if(mRoot->getSystem()->isGameSystem() && !UIModeController::getInstance()->isUIModeKid())
 	{
 		std::string prompt = CollectionSystemManager::get()->getEditingCollection();
 		prompts.push_back(HelpPrompt("y", prompt));

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -18,7 +18,6 @@ std::vector<const char*> settings_dont_save {
 	{ "DebugImage" },
 	{ "ForceKid" },
 	{ "ForceKiosk" },
-	{ "ForceDisableFilters" },
 	{ "IgnoreGamelist" },
 	{ "HideConsole" },
 	{ "ShowExit" },


### PR DESCRIPTION
On PR #435 we've worked to make an unattended (aka arcade) mode, hiding several controls from Kids mode and adding a toggle to force display all games (even the non kid ones).

But, later, some commit changed the BasicView to display again the Favorites controls in Kids mode.

Additionally I've noticed that while working on #435 I've included `ForceDisableFilters` in settings to be not saved, which doesn't make sense.