### PR TITLE
Removing no more used `mameNameToRealName`

### DIFF
--- a/es-app/src/PlatformId.cpp
+++ b/es-app/src/PlatformId.cpp
@@ -2,8 +2,6 @@
 
 #include <string.h>
 
-extern const char* mameNameToRealName[];
-
 namespace PlatformIds
 {
 	const char* PlatformNames[PLATFORM_COUNT + 1] = {


### PR DESCRIPTION
Since commit 3f3e1ceb16cea4186ef378abc33b1f5bbf330232, `mameNameToRealName` is no more used.