### PR TITLE
Fix Kiosk mode filters applying also to Kid mode

### DIFF
--- a/es-app/src/FileFilterIndex.cpp
+++ b/es-app/src/FileFilterIndex.cpp
@@ -248,7 +248,7 @@ void FileFilterIndex::resetFilters()
 void FileFilterIndex::setUIModeFilters()
 {
 	if(!Settings::getInstance()->getBool("ForceDisableFilters")){
-		if (!UIModeController::getInstance()->isUIModeFull())
+		if (UIModeController::getInstance()->isUIModeKiosk())
 		{
 			filterByHidden = true;
 			std::vector<std::string> val = { "FALSE" };
@@ -259,7 +259,7 @@ void FileFilterIndex::setUIModeFilters()
 			filterByKidGame = true;
 			std::vector<std::string> val = { "TRUE" };
 			setFilter(KIDGAME_FILTER, &val);
-		}		
+		}
 	}
 }
 

--- a/es-app/src/views/UIModeController.cpp
+++ b/es-app/src/views/UIModeController.cpp
@@ -94,6 +94,12 @@ bool UIModeController::isUIModeKid()
 		((mCurrentUIMode == "Kid") && !Settings::getInstance()->getBool("ForceKiosk")));
 }
 
+bool UIModeController::isUIModeKiosk()
+{
+	return (Settings::getInstance()->getBool("ForceKiosk") ||
+		((mCurrentUIMode == "Kiosk") && !Settings::getInstance()->getBool("ForceKid")));
+}
+
 std::string UIModeController::getFormattedPassKeyStr()
 {
 	// supported sequence-inputs: u (up), d (down), l (left), r (right), a, b, x, y

--- a/es-app/src/views/UIModeController.h
+++ b/es-app/src/views/UIModeController.h
@@ -26,6 +26,7 @@ public:
 
 	bool isUIModeFull();
 	bool isUIModeKid();
+	bool isUIModeKiosk();
 	inline std::vector<std::string> getUIModes() { return mUIModes; };
 private:
 	UIModeController();


### PR DESCRIPTION
This fixes games marked both as hidden and kid not being shown in Kid mode.

Reported in https://retropie.org.uk/forum/topic/20867 (original discussion on Reddit [here](https://old.reddit.com/r/RetroPie/comments/agp78y)).