### PR TITLE
Fix for unset AudioCard setting

### DIFF
--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -134,6 +134,7 @@ void Settings::setDefaults()
 		mStringMap["AudioDevice"] = "Master";
 	#endif
 
+	mStringMap["AudioCard"] = "default";
 	mStringMap["UIMode"] = "Full";
 	mStringMap["UIMode_passkey"] = "uuddlrlrba";
 	mBoolMap["ForceKiosk"] = false;


### PR DESCRIPTION
This adds the default value that was missing from the changes in #460, which avoids a crash when opening the menu and should also ensure that the audio keeps working in an upgrade scenario.