### PR TITLE
Loading screen: Be more verbose about what is happening.

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -292,6 +292,9 @@ int main(int argc, char* argv[])
 	MameNames::init();
 	window.pushGui(ViewController::get());
 
+	bool splashScreen = Settings::getInstance()->getBool("SplashScreen");
+	bool splashScreenProgress = Settings::getInstance()->getBool("SplashScreenProgress");
+
 	if(!scrape_cmdline)
 	{
 		if(!window.init())
@@ -303,8 +306,13 @@ int main(int argc, char* argv[])
 		std::string glExts = (const char*)glGetString(GL_EXTENSIONS);
 		LOG(LogInfo) << "Checking available OpenGL extensions...";
 		LOG(LogInfo) << " ARB_texture_non_power_of_two: " << (glExts.find("ARB_texture_non_power_of_two") != std::string::npos ? "ok" : "MISSING");
-		if(Settings::getInstance()->getBool("SplashScreen"))
-			window.renderLoadingScreen();
+		if(splashScreen)
+		{
+			std::string progressText = "Loading...";
+			if (splashScreenProgress)
+				progressText = "Loading system config...";
+			window.renderLoadingScreen(progressText);
+		}
 	}
 
 	const char* errorMsg = NULL;
@@ -341,6 +349,9 @@ int main(int argc, char* argv[])
 	// preload what we can right away instead of waiting for the user to select it
 	// this makes for no delays when accessing content, but a longer startup time
 	ViewController::get()->preload();
+
+	if(splashScreen && splashScreenProgress)
+		window.renderLoadingScreen("Done.");
 
 	//choose which GUI to open depending on if an input configuration already exists
 	if(errorMsg == NULL)

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -65,7 +65,7 @@ void ViewController::goToStart()
 
 void ViewController::ReloadAndGoToStart()
 {
-	mWindow->renderLoadingScreen();
+	mWindow->renderLoadingScreen("Loading...");
 	ViewController::get()->reloadAll();
 	ViewController::get()->goToStart();
 }
@@ -429,8 +429,19 @@ void ViewController::render(const Transform4x4f& parentTrans)
 
 void ViewController::preload()
 {
+	uint32_t i = 0;
 	for(auto it = SystemData::sSystemVector.cbegin(); it != SystemData::sSystemVector.cend(); it++)
 	{
+		if(Settings::getInstance()->getBool("SplashScreen") &&
+		   Settings::getInstance()->getBool("SplashScreenProgress"))
+		{
+			i++;
+			char buffer[100];
+			sprintf (buffer, "Loading '%s' (%d/%d)",
+			         (*it)->getFullName().c_str(), i, SystemData::sSystemVector.size());
+			mWindow->renderLoadingScreen(std::string(buffer));
+		}
+
 		(*it)->getIndex()->resetFilters();
 		getGameListView(*it);
 	}

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -22,6 +22,7 @@ std::vector<const char*> settings_dont_save {
 	{ "HideConsole" },
 	{ "ShowExit" },
 	{ "SplashScreen" },
+	{ "SplashScreenProgress" },
 	{ "VSync" },
 	{ "Windowed" },
 	{ "WindowWidth" },
@@ -60,6 +61,7 @@ void Settings::setDefaults()
 	mBoolMap["ShowExit"] = true;
 	mBoolMap["Windowed"] = false;
 	mBoolMap["SplashScreen"] = true;
+	mBoolMap["SplashScreenProgress"] = true;
 	mStringMap["StartupSystem"] = "";
 
 	mBoolMap["VSync"] = true;

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -298,7 +298,7 @@ void Window::setAllowSleep(bool sleep)
 	mAllowSleep = sleep;
 }
 
-void Window::renderLoadingScreen()
+void Window::renderLoadingScreen(std::string text)
 {
 	Transform4x4f trans = Transform4x4f::Identity();
 	Renderer::setMatrix(trans);
@@ -311,9 +311,11 @@ void Window::renderLoadingScreen()
 	splash.render(trans);
 
 	auto& font = mDefaultFonts.at(1);
-	TextCache* cache = font->buildTextCache("LOADING...", 0, 0, 0x656565FF);
-	trans = trans.translate(Vector3f(Math::round((Renderer::getScreenWidth() - cache->metrics.size.x()) / 2.0f),
-		Math::round(Renderer::getScreenHeight() * 0.835f), 0.0f));
+	TextCache* cache = font->buildTextCache(text, 0, 0, 0x656565FF);
+
+	float x = Math::round((Renderer::getScreenWidth() - cache->metrics.size.x()) / 2.0f);
+	float y = Math::round(Renderer::getScreenHeight() * 0.835f);
+	trans = trans.translate(Vector3f(x, y, 0.0f));
 	Renderer::setMatrix(trans);
 	font->renderTextCache(cache);
 	delete cache;

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -63,7 +63,7 @@ public:
 	bool getAllowSleep();
 	void setAllowSleep(bool sleep);
 
-	void renderLoadingScreen();
+	void renderLoadingScreen(std::string text);
 
 	void renderHelpPromptsEarly(); // used to render HelpPrompts before a fade
 	void setHelpPrompts(const std::vector<HelpPrompt>& prompts, const HelpStyle& style);


### PR DESCRIPTION
Starting up emulationstation takes me about 1 minute over the network
with a large collection of 27 systems with images.

This patch uses the loading screen to tell the user about the status
of the startup, with information how many systems are left for view
initialization.

The most beefy part of the startup process is initializing the views,
and preloading images.

This patch extends the `renderLoadingScreen` function to take a string
and uses it in `ViewController::preload`.