### PR TITLE
Fix ScreenScraper search by filename

### DIFF
--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -125,11 +125,7 @@ void screenscraper_generate_scraper_requests(const ScraperSearchParams& params,
 
 	ScreenScraperRequest::ScreenScraperConfig ssConfig;
 
-	std::string cleanName = params.nameOverride;
-	if (cleanName.empty())
-		cleanName = params.game->getCleanName();
-
-	path = ssConfig.getGameSearchUrl(cleanName);
+	path = ssConfig.getGameSearchUrl(params.game->getFileName());
 	auto& platforms = params.system->getPlatformIds();
 
 	for (auto platformIt = platforms.cbegin(); platformIt != platforms.cend(); platformIt++)


### PR DESCRIPTION
Seems searching by game name is not working reliably - anymore -, use the full filename until we add checksum to the search.

Sorry for not catching this sooner.