### PR TITLE
Fix "getThumbnailPath" ignoring the 'image' tag when 'LocalArt' is not set

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -54,12 +54,12 @@ const std::string FileData::getThumbnailPath() const
 	std::string thumbnail = metadata.get("thumbnail");
 
 	// no thumbnail, try image
-	if(thumbnail.empty() && Settings::getInstance()->getBool("LocalArt"))
+	if(thumbnail.empty())
 	{
 		thumbnail = metadata.get("image");
 
 		// no image, try to use local image
-		if(thumbnail.empty())
+		if(thumbnail.empty() && Settings::getInstance()->getBool("LocalArt"))
 		{
 			const char* extList[2] = { ".png", ".jpg" };
 			for(int i = 0; i < 2; i++)


### PR DESCRIPTION
This seems to fix the problems reported in the forum (https://retropie.org.uk/forum/topic/21216, https://retropie.org.uk/forum/topic/21227/ and I'm sure there's at least another one). 
`getThumbnailPath` returns an empty string when `LocalArt` is not enabled and then the **thumbnail** tage is empty, but it should look at the **image** tag also, regardless of `LocalArt` setting.

I would appreciate some testing, I only tested this on Windows where I don't have videos.