### PR TITLE
Fixed rounding.

### DIFF
--- a/es-app/src/VolumeControl.cpp
+++ b/es-app/src/VolumeControl.cpp
@@ -273,7 +273,7 @@ int VolumeControl::getVolume() const
 				rawVolume -= minVolume;
 				if (rawVolume > 0)
 				{
-					volume = (rawVolume * 100) / (maxVolume - minVolume);
+					volume = (rawVolume * 100.0) / (maxVolume - minVolume) + 0.5;
 				}
 				//else volume = 0;
 			}


### PR DESCRIPTION
Stumbled on this while tested other things.

If you open "Sound Settiings" multiple times and do not change the system volume and your audio device has a small range (mine: minVolume 0 to mavVolume 151) the system volume in the dialog gets rounded down each time you open the dialog.