### PR TITLE
Change handling of screensaver to FileData only

### DIFF
--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -25,6 +25,7 @@ public:
 
 	virtual FileData* getCurrentGame();
 	virtual void launchGame();
+	inline virtual void resetCounts() { mVideosCounted = false; mImagesCounted = false; };
 
 private:
 	unsigned long countGameListNodes(const char *nodeName);

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -432,6 +432,7 @@ void Window::startScreenSaver()
  	{
  		mScreenSaver->stopScreenSaver();
  		mRenderScreenSaver = false;
+ 		mScreenSaver->resetCounts();
 
  		// Tell the GUI components the screensaver has stopped
  		for(auto i = mGuiStack.cbegin(); i != mGuiStack.cend(); i++)

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -32,6 +32,7 @@ public:
 		virtual bool isScreenSaverActive() = 0;
 		virtual FileData* getCurrentGame() = 0;
 		virtual void launchGame() = 0;
+		virtual void resetCounts() = 0;
 	};
 
 	class InfoPopup {
@@ -82,7 +83,7 @@ private:
 
 	// Returns true if at least one component on the stack is processing
 	bool isProcessing();
-	
+
 	HelpComponent* mHelp;
 	ImageComponent* mBackgroundOverlay;
 	ScreenSaver*	mScreenSaver;


### PR DESCRIPTION
Change screensaver handling (counting and choosing) to use FileData data (i.e. games that actually exist and are loaded) rather than gamelist data (and XML).

Performance is improved (well, not really noticeable).

Tested image and video screensaver.