### PR TITLE
Fix FilesystemUtil::isEquivalent by eliminating it entirely

### DIFF
--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -237,11 +237,9 @@ void updateGamelist(SystemData* system)
 					continue;
 				}
 
-				std::string nodePath = Utils::FileSystem::resolveRelativePath(pathNode.text().get(), system->getStartPath(), true);
-				std::string gamePath = (*fit)->getPath();
-				if(nodePath == gamePath || (Utils::FileSystem::exists(nodePath) &&
-				                            Utils::FileSystem::exists(gamePath) &&
-				                            Utils::FileSystem::isEquivalent(nodePath, gamePath)))
+				std::string nodePath = Utils::FileSystem::getCanonicalPath(Utils::FileSystem::resolveRelativePath(pathNode.text().get(), system->getStartPath(), true));
+				std::string gamePath = Utils::FileSystem::getCanonicalPath((*fit)->getPath());
+				if(nodePath == gamePath)
 				{
 					// found it
 					root.remove_child(fileNode);

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -652,22 +652,6 @@ namespace Utils
 
 		} // isHidden
 
-		bool isEquivalent(const std::string& _path1, const std::string& _path2)
-		{
-			std::string path1 = getGenericPath(_path1);
-			std::string path2 = getGenericPath(_path2);
-			struct stat64 info1;
-			struct stat64 info2;
-
-			// check if stat64 succeeded
-			if((stat64(path1.c_str(), &info1) != 0) || (stat64(path2.c_str(), &info2) != 0))
-				return false;
-
-			// check if attributes are identical
-			return ((info1.st_dev == info2.st_dev) && (info1.st_ino == info2.st_ino) && (info1.st_size == info2.st_size) && (info1.st_mtime == info2.st_mtime));
-
-		} // isEquivalent
-
 	} // FileSystem::
 
 } // Utils::

--- a/es-core/src/utils/FileSystemUtil.h
+++ b/es-core/src/utils/FileSystemUtil.h
@@ -37,7 +37,6 @@ namespace Utils
 		bool        isDirectory        (const std::string& _path);
 		bool        isSymlink          (const std::string& _path);
 		bool        isHidden           (const std::string& _path);
-		bool        isEquivalent       (const std::string& _path1, const std::string& _path2);
 
 	} // FileSystem::
 


### PR DESCRIPTION
Fixed the bug with iEquivalent by eliminating the need for it entirely, now makes both paths canonical and compares  them