### PR TITLE
implement scripting support

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -10,6 +10,7 @@
 #include "Log.h"
 #include "MameNames.h"
 #include "platform.h"
+#include "Scripting.h"
 #include "SystemData.h"
 #include "VolumeControl.h"
 #include "Window.h"
@@ -282,6 +283,8 @@ void FileData::launchGame(Window* window)
 	command = Utils::String::replace(command, "%BASENAME%", basename);
 	command = Utils::String::replace(command, "%ROM_RAW%", rom_raw);
 
+	Scripting::fireEvent("game-start", rom, basename);
+
 	LOG(LogInfo) << "	" << command;
 	int exitCode = runSystemCommand(command);
 
@@ -289,6 +292,8 @@ void FileData::launchGame(Window* window)
 	{
 		LOG(LogWarning) << "...launch terminated with nonzero exit code " << exitCode << "!";
 	}
+
+	Scripting::fireEvent("game-end");
 
 	window->init();
 	VolumeControl::getInstance()->init();

--- a/es-core/CMakeLists.txt
+++ b/es-core/CMakeLists.txt
@@ -92,6 +92,7 @@ set(CORE_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/PowerSaver.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Renderer_draw_gl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Renderer_init_sdlgl.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/Scripting.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Settings.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/Sound.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/ThemeData.cpp

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -4,6 +4,7 @@
 #include "CECInput.h"
 #include "Log.h"
 #include "platform.h"
+#include "Scripting.h"
 #include "Window.h"
 #include <pugixml/src/pugixml.hpp>
 #include <SDL.h>
@@ -396,6 +397,9 @@ void InputManager::writeDeviceConfig(InputConfig* config)
 
 	config->writeToXML(root);
 	doc.save_file(path.c_str());
+
+	Scripting::fireEvent("config-changed");
+	Scripting::fireEvent("controls-changed");
 	
 	// execute any onFinish commands and re-load the config for changes
 	doOnFinish();

--- a/es-core/src/Scripting.cpp
+++ b/es-core/src/Scripting.cpp
@@ -1,0 +1,36 @@
+#include "Scripting.h"
+#include "Log.h"
+#include "platform.h"
+#include "utils/FileSystemUtil.h"
+
+namespace Scripting
+{
+	void fireEvent(const std::string& eventName, const std::string& arg1, const std::string& arg2)
+	{
+		LOG(LogDebug) << "fireEvent: " << eventName << " " << arg1 << " " << arg2;
+
+        std::list<std::string> scriptDirList;
+        std::string test;
+
+        // check in exepath
+        test = Utils::FileSystem::getExePath() + "/scripts/" + eventName;
+        if(Utils::FileSystem::exists(test))
+            scriptDirList.push_back(test);
+
+        // check in homepath
+        test = Utils::FileSystem::getHomePath() + "/.emulationstation/scripts/" + eventName;
+        if(Utils::FileSystem::exists(test))
+            scriptDirList.push_back(test);
+
+        for(std::list<std::string>::const_iterator dirIt = scriptDirList.cbegin(); dirIt != scriptDirList.cend(); ++dirIt) {
+            std::list<std::string> scripts = Utils::FileSystem::getDirContent(*dirIt);
+            for (std::list<std::string>::const_iterator it = scripts.cbegin(); it != scripts.cend(); ++it) {
+                // append folder to path
+                std::string script = *it + " \"" + arg1 + "\" \"" + arg2 + "\"";
+                LOG(LogDebug) << "  executing: " << script;
+                runSystemCommand(script);
+            }
+        }
+	}
+
+} // Scripting::

--- a/es-core/src/Scripting.h
+++ b/es-core/src/Scripting.h
@@ -1,0 +1,12 @@
+#pragma once
+#ifndef ES_CORE_SCRIPTING_H
+#define ES_CORE_SCRIPTING_H
+
+#include <string>
+
+namespace Scripting
+{
+	void fireEvent(const std::string& eventName, const std::string& arg1="", const std::string& arg2="");
+} // Scripting::
+
+#endif //ES_CORE_SCRIPTING_H

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -2,6 +2,7 @@
 
 #include "utils/FileSystemUtil.h"
 #include "Log.h"
+#include "Scripting.h"
 #include "platform.h"
 #include <pugixml/src/pugixml.hpp>
 #include <algorithm>
@@ -193,6 +194,9 @@ void Settings::saveFile()
 	}
 
 	doc.save_file(path.c_str());
+
+	Scripting::fireEvent("config-changed");
+	Scripting::fireEvent("settings-changed");
 }
 
 void Settings::loadFile()

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -7,6 +7,7 @@
 #include "InputManager.h"
 #include "Log.h"
 #include "Renderer.h"
+#include "Scripting.h"
 #include <algorithm>
 #include <iomanip>
 
@@ -277,8 +278,10 @@ void Window::render()
 		if (!isProcessing() && mAllowSleep && (!mScreenSaver || mScreenSaver->allowSleep()))
 		{
 			// go to sleep
-			mSleeping = true;
-			onSleep();
+			if (mSleeping == false) {
+				mSleeping = true;
+				onSleep();
+			}
 		}
 	}
 }
@@ -401,11 +404,12 @@ void Window::setHelpPrompts(const std::vector<HelpPrompt>& prompts, const HelpSt
 
 void Window::onSleep()
 {
+	Scripting::fireEvent("sleep");
 }
 
 void Window::onWake()
 {
-
+	Scripting::fireEvent("wake");
 }
 
 bool Window::isProcessing()

--- a/es-core/src/platform.cpp
+++ b/es-core/src/platform.cpp
@@ -42,7 +42,8 @@ int runSystemCommand(const std::string& cmd_utf8)
 
 int quitES(const std::string& filename)
 {
-	touch(filename);
+	if (!filename.empty())
+		touch(filename);
 	SDL_Event* quit = new SDL_Event();
 	quit->type = SDL_QUIT;
 	SDL_PushEvent(quit);


### PR DESCRIPTION
This is something I put together a while back and never finished up.  It was inspired by scripting supporting in [Pegasus](http://pegasus-frontend.org/docs/user-guide/scripting/) but with a few additional events that I thought could be useful.

draft wiki documentation for events can be found [here](https://github.com/jrassa/EmulationStation/wiki/Scripting).