### PR TITLE
Implement filterTrigger for PS3 controllers

### DIFF
--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -171,6 +171,12 @@ void InputManager::deinit()
 }
 
 int InputManager::getNumJoysticks() { return (int)mJoysticks.size(); }
+
+int InputManager::getAxisCountByDevice(SDL_JoystickID id)
+{
+	return SDL_JoystickNumAxes(mJoysticks[id]);
+}
+
 int InputManager::getButtonCountByDevice(SDL_JoystickID id)
 {
 	if(id == DEVICE_KEYBOARD)

--- a/es-core/src/InputManager.h
+++ b/es-core/src/InputManager.h
@@ -48,6 +48,7 @@ public:
 	void deinit();
 
 	int getNumJoysticks();
+	int getAxisCountByDevice(int deviceId);
 	int getButtonCountByDevice(int deviceId);
 	int getNumConfiguredDevices();
 

--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -133,6 +133,11 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 				return false;
 			}
 
+
+			// filter for input quirks specific to Sony DualShock 3
+			if(filterTrigger(input, config))
+				return false;
+
 			// we are configuring
 			if(input.value != 0)
 			{
@@ -330,4 +335,25 @@ bool GuiInputConfig::assign(Input input, int inputId)
 void GuiInputConfig::clearAssignment(int inputId)
 {
 	mTargetConfig->unmapInput(GUI_INPUT_CONFIG_LIST[inputId].name);
+}
+
+bool GuiInputConfig::filterTrigger(Input input, InputConfig* config)
+{
+#if defined(__linux__)
+	// match PlayStation joystick with 6 axes only
+	if((strstr(config->getDeviceName().c_str(), "PLAYSTATION") != NULL \
+	  || strstr(config->getDeviceName().c_str(), "PS3 Game") != NULL \
+	  || strstr(config->getDeviceName().c_str(), "PS(R) Game") != NULL) \
+	  && InputManager::getInstance()->getAxisCountByDevice(config->getDeviceId()) == 6)
+	{
+		// digital triggers are unwanted
+		if (input.type == TYPE_BUTTON && (input.id == 6 || input.id == 7))
+			return true;
+		// ignore analog values < 0
+		if (input.type == TYPE_AXIS && (input.id == 2 || input.id == 5) && input.value < 0)
+			return true;
+	}
+#endif
+
+	return false;
 }

--- a/es-core/src/guis/GuiInputConfig.h
+++ b/es-core/src/guis/GuiInputConfig.h
@@ -28,6 +28,7 @@ private:
 
 	bool assign(Input input, int inputId);
 	void clearAssignment(int inputId);
+	bool filterTrigger(Input input, InputConfig* config);
 
 	void rowDone();
 


### PR DESCRIPTION
The hid-sony driver has both analog and digital buttons for the triggers,
and the analog values range from -32767 to 32767, which can cause two unwanted
input events (digital button and negative axis) per press.

Implement a function to filter out unwanted input events during configuration,
but isolate detection to known PS3 controllers with 6 axes so that older versions
of hid-sony and the sixad driver (which use 25+ axes) are not impacted negatively.