### PR TITLE
[ScreenSaver] Consume input on cancel

### DIFF
--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -414,34 +414,34 @@ bool Window::isProcessing()
 }
 
 void Window::startScreenSaver()
- {
- 	if (mScreenSaver && !mRenderScreenSaver)
- 	{
- 		// Tell the GUI components the screensaver is starting
- 		for(auto i = mGuiStack.cbegin(); i != mGuiStack.cend(); i++)
- 			(*i)->onScreenSaverActivate();
+{
+	if (mScreenSaver && !mRenderScreenSaver)
+	{
+		// Tell the GUI components the screensaver is starting
+		for(auto i = mGuiStack.cbegin(); i != mGuiStack.cend(); i++)
+			(*i)->onScreenSaverActivate();
 
- 		mScreenSaver->startScreenSaver();
- 		mRenderScreenSaver = true;
- 	}
- }
+		mScreenSaver->startScreenSaver();
+		mRenderScreenSaver = true;
+	}
+}
 
- void Window::cancelScreenSaver()
- {
- 	if (mScreenSaver && mRenderScreenSaver)
- 	{
- 		mScreenSaver->stopScreenSaver();
- 		mRenderScreenSaver = false;
- 		mScreenSaver->resetCounts();
+void Window::cancelScreenSaver()
+{
+	if (mScreenSaver && mRenderScreenSaver)
+	{
+		mScreenSaver->stopScreenSaver();
+		mRenderScreenSaver = false;
+		mScreenSaver->resetCounts();
 
- 		// Tell the GUI components the screensaver has stopped
- 		for(auto i = mGuiStack.cbegin(); i != mGuiStack.cend(); i++)
- 			(*i)->onScreenSaverDeactivate();
- 	}
- }
+		// Tell the GUI components the screensaver has stopped
+		for(auto i = mGuiStack.cbegin(); i != mGuiStack.cend(); i++)
+			(*i)->onScreenSaverDeactivate();
+	}
+}
 
- void Window::renderScreenSaver()
- {
- 	if (mScreenSaver)
- 		mScreenSaver->renderScreenSaver();
- }
+void Window::renderScreenSaver()
+{
+	if (mScreenSaver)
+		mScreenSaver->renderScreenSaver();
+}

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -139,10 +139,6 @@ void Window::input(InputConfig* config, Input input)
 					mSleeping = true;
 				}
 			}
-			/*else if(input.value != 0)
-			{
-				return;
-			}*/
 		}
 	}
 
@@ -157,7 +153,8 @@ void Window::input(InputConfig* config, Input input)
 	}
 
 	mTimeSinceLastInput = 0;
-	cancelScreenSaver();
+	if (cancelScreenSaver())
+		return;
 
 	if(config->getDeviceId() == DEVICE_KEYBOARD && input.value && input.id == SDLK_g && SDL_GetModState() & KMOD_LCTRL && Settings::getInstance()->getBool("Debug"))
 	{
@@ -426,7 +423,7 @@ void Window::startScreenSaver()
 	}
 }
 
-void Window::cancelScreenSaver()
+bool Window::cancelScreenSaver()
 {
 	if (mScreenSaver && mRenderScreenSaver)
 	{
@@ -437,7 +434,11 @@ void Window::cancelScreenSaver()
 		// Tell the GUI components the screensaver has stopped
 		for(auto i = mGuiStack.cbegin(); i != mGuiStack.cend(); i++)
 			(*i)->onScreenSaverDeactivate();
+
+		return true;
 	}
+
+	return false;
 }
 
 void Window::renderScreenSaver()

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -74,7 +74,7 @@ public:
 	inline void stopInfoPopup() { if (mInfoPopup) mInfoPopup->stop(); };
 
 	void startScreenSaver();
-	void cancelScreenSaver();
+	bool cancelScreenSaver();
 	void renderScreenSaver();
 
 private:


### PR DESCRIPTION
**Issue:** When pressing a button to cancel the screen saver, the underlying view would react to the input (A would launch the game, B would go to systems menu, etc.)

**Notes**
- I guess that's what the commented lines (142@145) originally intended to do;
- I noticed an `input` function in `SystemScreenSaver`: should the whole screen saver-handling block from `Window::input` go there instead?
