### PR TITLE
filterTrigger: generalize for more controllers

### DIFF
--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -133,9 +133,8 @@ GuiInputConfig::GuiInputConfig(Window* window, InputConfig* target, bool reconfi
 				return false;
 			}
 
-
-			// filter for input quirks specific to Sony DualShock 3
-			if(filterTrigger(input, config))
+			// apply filtering for quirks related to trigger mapping
+			if(filterTrigger(input, config, i))
 				return false;
 
 			// we are configuring
@@ -337,21 +336,26 @@ void GuiInputConfig::clearAssignment(int inputId)
 	mTargetConfig->unmapInput(GUI_INPUT_CONFIG_LIST[inputId].name);
 }
 
-bool GuiInputConfig::filterTrigger(Input input, InputConfig* config)
+bool GuiInputConfig::filterTrigger(Input input, InputConfig* config, int inputId)
 {
 #if defined(__linux__)
 	// match PlayStation joystick with 6 axes only
 	if((strstr(config->getDeviceName().c_str(), "PLAYSTATION") != NULL \
-	  || strstr(config->getDeviceName().c_str(), "PS3 Game") != NULL \
-	  || strstr(config->getDeviceName().c_str(), "PS(R) Game") != NULL) \
+	  || strstr(config->getDeviceName().c_str(), "PS3 Ga") != NULL \
+	  || strstr(config->getDeviceName().c_str(), "PS(R) Ga") != NULL) \
 	  && InputManager::getInstance()->getAxisCountByDevice(config->getDeviceId()) == 6)
 	{
 		// digital triggers are unwanted
 		if (input.type == TYPE_BUTTON && (input.id == 6 || input.id == 7))
 			return true;
-		// ignore analog values < 0
-		if (input.type == TYPE_AXIS && (input.id == 2 || input.id == 5) && input.value < 0)
-			return true;
+	}
+
+	// ignore negative pole for axes 2/5 only when triggers are being configured
+	if((mSkipAxis || strstr(GUI_INPUT_CONFIG_LIST[inputId].name, "Trigger") != NULL) \
+	  && input.type == TYPE_AXIS && (input.id == 2 || input.id == 5) && input.value < 0)
+	{
+		mSkipAxis = true;
+		return true;
 	}
 #endif
 

--- a/es-core/src/guis/GuiInputConfig.h
+++ b/es-core/src/guis/GuiInputConfig.h
@@ -28,7 +28,7 @@ private:
 
 	bool assign(Input input, int inputId);
 	void clearAssignment(int inputId);
-	bool filterTrigger(Input input, InputConfig* config);
+	bool filterTrigger(Input input, InputConfig* config, int inputId);
 
 	void rowDone();
 
@@ -50,6 +50,7 @@ private:
 	Input mHeldInput;
 	int mHeldTime;
 	int mHeldInputId;
+	bool mSkipAxis;
 
 	BusyComponent mBusyAnim;	
 };


### PR DESCRIPTION
* Filter axes 2/5 for all devices, but only if LeftTrigger or RightTrigger is being configured. This should fix compatibility with XBox 360 and other generic controllers that use these axes for triggers, but won't affect other controllers using these axes for analog sticks, etc.
* Improve third-party PS3 detection (some Shanwan controllers have a grave accent in place of 'm' for 'Gamepad').