### PR TITLE
Fix 'Last Played' collection crash.

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -292,7 +292,7 @@ void CollectionSystemManager::updateCollectionSystem(FileData* file, CollectionS
 void CollectionSystemManager::trimCollectionCount(FileData* rootFolder, int limit)
 {
 	SystemData* curSys = rootFolder->getSystem();
-	while ((int)rootFolder->getChildren().size() > limit)
+	while ((int)rootFolder->getChildrenListToDisplay().size() > limit)
 	{
 		CollectionFileData* gameToRemove = (CollectionFileData*)rootFolder->getChildrenListToDisplay().back();
 		ViewController::get()->getGameListView(curSys).get()->remove(gameToRemove, false);


### PR DESCRIPTION
Emulationstation can crash when `UIMode` is set to Kid/Kiosk when removing entries from the 'Last Played' auto-collection, reported in [the forum](https://retropie.org.uk/forum/topic/22216/).

The crash occurs when the 'recent' list of played games is larger than _LAST_PLAYED_MAX_ (default: 50) and Emulationstation tries to remove from the list. If the filtered list size (i.e. only Kid/Non-hidden games) is less than the # of attempted removals, Emulationstation crashes because `getChildrenListToDisplay()` is practically empty.