### PR TITLE
Add Game Info Font Settings to OMX Player

### DIFF
--- a/es-app/src/guis/GuiScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiScreensaverOptions.cpp
@@ -1,5 +1,6 @@
 #include "guis/GuiScreensaverOptions.h"
 
+#include "guis/GuiTextEditPopup.h"
 #include "views/ViewController.h"
 #include "Settings.h"
 #include "SystemData.h"
@@ -66,4 +67,31 @@ std::vector<HelpPrompt> GuiScreensaverOptions::getHelpPrompts()
 	prompts.push_back(HelpPrompt("start", "close"));
 
 	return prompts;
+}
+
+void GuiScreensaverOptions::addEditableTextComponent(ComponentListRow row, const std::string label, std::shared_ptr<GuiComponent> ed, std::string value)
+{
+	row.elements.clear();
+
+	auto lbl = std::make_shared<TextComponent>(mWindow, Utils::String::toUpper(label), Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+	row.addElement(lbl, true); // label
+
+	row.addElement(ed, true);
+
+	auto spacer = std::make_shared<GuiComponent>(mWindow);
+	spacer->setSize(Renderer::getScreenWidth() * 0.005f, 0);
+	row.addElement(spacer, false);
+
+	auto bracket = std::make_shared<ImageComponent>(mWindow);
+	bracket->setImage(":/arrow.svg");
+	bracket->setResize(Vector2f(0, lbl->getFont()->getLetterHeight()));
+	row.addElement(bracket, false);
+
+	auto updateVal = [ed](const std::string& newVal) { ed->setValue(newVal); }; // ok callback (apply new value to ed)
+	row.makeAcceptInputHandler([this, label, ed, updateVal] {
+		mWindow->pushGui(new GuiTextEditPopup(mWindow, label, ed->getValue(), updateVal, false));
+	});
+	assert(ed);
+	addRow(row);
+	ed->setValue(value);
 }

--- a/es-app/src/guis/GuiScreensaverOptions.h
+++ b/es-app/src/guis/GuiScreensaverOptions.h
@@ -15,6 +15,7 @@ public:
 	inline void addRow(const ComponentListRow& row) { mMenu.addRow(row); };
 	inline void addWithLabel(const std::string& label, const std::shared_ptr<GuiComponent>& comp) { mMenu.addWithLabel(label, comp); };
 	inline void addSaveFunc(const std::function<void()>& func) { mSaveFuncs.push_back(func); };
+	void addEditableTextComponent(ComponentListRow row, const std::string label, std::shared_ptr<GuiComponent> ed, std::string value);
 
 	bool input(InputConfig* config, Input input) override;
 	std::vector<HelpPrompt> getHelpPrompts() override;

--- a/es-app/src/guis/GuiSlideshowScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiSlideshowScreensaverOptions.cpp
@@ -80,31 +80,3 @@ void GuiSlideshowScreensaverOptions::addWithLabel(ComponentListRow row, const st
 
 	addRow(row);
 }
-
-void GuiSlideshowScreensaverOptions::addEditableTextComponent(ComponentListRow row, const std::string label, std::shared_ptr<GuiComponent> ed, std::string value)
-{
-	row.elements.clear();
-
-	auto lbl = std::make_shared<TextComponent>(mWindow, Utils::String::toUpper(label), Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-	row.addElement(lbl, true); // label
-
-	row.addElement(ed, true);
-
-	auto spacer = std::make_shared<GuiComponent>(mWindow);
-	spacer->setSize(Renderer::getScreenWidth() * 0.005f, 0);
-	row.addElement(spacer, false);
-
-	auto bracket = std::make_shared<ImageComponent>(mWindow);
-	bracket->setImage(":/arrow.svg");
-	bracket->setResize(Vector2f(0, lbl->getFont()->getLetterHeight()));
-	row.addElement(bracket, false);
-
-	auto updateVal = [ed](const std::string& newVal) { ed->setValue(newVal); }; // ok callback (apply new value to ed)
-	row.makeAcceptInputHandler([this, label, ed, updateVal] {
-		mWindow->pushGui(new GuiTextEditPopup(mWindow, label, ed->getValue(), updateVal, false));
-	});
-
-	assert(ed);
-	addRow(row);
-	ed->setValue(value);
-}

--- a/es-app/src/guis/GuiSlideshowScreensaverOptions.h
+++ b/es-app/src/guis/GuiSlideshowScreensaverOptions.h
@@ -12,7 +12,6 @@ public:
 
 private:
 	void addWithLabel(ComponentListRow row, const std::string label, std::shared_ptr<GuiComponent> component);
-	void addEditableTextComponent(ComponentListRow row, const std::string label, std::shared_ptr<GuiComponent> ed, std::string value);
 };
 
 #endif // ES_APP_GUIS_GUI_SLIDESHOW_SCREENSAVER_OPTIONS_H

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -117,6 +117,11 @@ void Settings::setDefaults()
 	#ifdef _RPI_
 		// we're defaulting to OMX Player for full screen video on the Pi
 		mBoolMap["ScreenSaverOmxPlayer"] = true;
+		// use OMX Player defaults
+		mStringMap["SubtitleFont"] = "/usr/share/fonts/truetype/freefont/FreeSans.ttf";
+		mStringMap["SubtitleItalicFont"] = "/usr/share/fonts/truetype/freefont/FreeSansOblique.ttf";
+		mIntMap["SubtitleSize"] = 55;
+		mStringMap["SubtitleAlignment"] = "left";
 	#else
 		mBoolMap["ScreenSaverOmxPlayer"] = false;
 	#endif

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -156,7 +156,7 @@ void VideoPlayerComponent::startVideo()
 				// We need to specify the layer of 10000 or above to ensure the video is displayed on top
 				// of our SDL display
 
-				const char* argv[] = { "", "--layer", "10010", "--loop", "--no-osd", "--aspect-mode", "letterbox", "--vol", "0", "-o", "both","--win", buf1, "--orientation", buf2, "", "", "", "", NULL };
+				const char* argv[] = { "", "--layer", "10010", "--loop", "--no-osd", "--aspect-mode", "letterbox", "--vol", "0", "-o", "both","--win", buf1, "--orientation", buf2, "", "", "", "", "", "", "", "", "", "", "", NULL };
 
 				// check if we want to mute the audio
 				if (!Settings::getInstance()->getBool("VideoAudio") || (float)VolumeControl::getInstance()->getVolume() == 0)
@@ -187,6 +187,14 @@ void VideoPlayerComponent::startVideo()
 						argv[15] = "--subtitles";
 						argv[16] = subtitlePath.c_str();
 						argv[17] = mPlayingVideoPath.c_str();
+						argv[18] = "--font";
+						argv[19] = Settings::getInstance()->getString("SubtitleFont").c_str();
+						argv[20] = "--italic-font";
+						argv[21] = Settings::getInstance()->getString("SubtitleItalicFont").c_str();
+						argv[22] = "--font-size";
+						argv[23] = std::to_string(Settings::getInstance()->getInt("SubtitleSize")).c_str();
+						argv[24] = "--align";
+						argv[25] = Settings::getInstance()->getString("SubtitleAlignment").c_str();
 					}
 					else
 					{


### PR DESCRIPTION
This branch adds the ability for users to change the following features in OMX Player's subtitles (game info for screen saver).

- font size
- font file path
- italic font file path
- subtitle position

These changes can be made in the GUI menus via the Video Screen Saver menu, or directly in the es_settings.cfg file. Here's an example of the new keys loaded/saved into in the es_settings.cfg file:

- `<int name="SubtitleSize" value="38" />`
- `<string name="SubtitleFont" value="/usr/local/share/fonts/slkscr.ttf" />`
- `<string name="SubtitleItalicFont" value="/usr/local/share/fonts/slkscrb.ttf" />`
- `<string name="SubtitleAlignment" value="center" />`

Additionally safe, OMX Player defaults are hard-coded into EmulationStation application.