### PR TITLE
Fix Kiosk Favorites not registering

### DIFF
--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -146,7 +146,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 				}
 				return true;
 			}
-		}else if (config->isMappedTo("y", input) && UIModeController::getInstance()->isUIModeFull())
+		}else if (config->isMappedTo("y", input) && !UIModeController::getInstance()->isUIModeKid())
 		{
 			if(mRoot->getSystem()->isGameSystem())
 			{


### PR DESCRIPTION
Had been broken a few months back.

Reported here:
https://retropie.org.uk/forum/topic/22564/favorites-in-kiosk-mode-are-not-working/