### PR TITLE
Collections: make the display of system's name configurable.

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -1032,7 +1032,6 @@ bool CollectionSystemManager::includeFileInAutoCollections(FileData* file)
 	return file->getName() != "kodi" && file->getSystem()->isGameSystem();
 }
 
-
 std::string getCustomCollectionConfigPath(std::string collectionName)
 {
 	return getCollectionsFolder() + "/custom-" + collectionName + ".cfg";

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -348,11 +348,14 @@ void CollectionFileData::refreshMetadata()
 const std::string& CollectionFileData::getName()
 {
 	if (mDirty) {
-		mCollectionFileName  = Utils::String::removeParenthesis(mSourceFileData->metadata.get("name"));
+		mCollectionFileName = Utils::String::removeParenthesis(mSourceFileData->metadata.get("name"));
 		mCollectionFileName += " [" + Utils::String::toUpper(mSourceFileData->getSystem()->getName()) + "]";
 		mDirty = false;
 	}
-	return mCollectionFileName;
+
+	if (Settings::getInstance()->getBool("CollectionShowSystemInfo"))
+		return mCollectionFileName;
+	return mSourceFileData->metadata.get("name");
 }
 
 // returns Sort Type based on a string description

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -75,6 +75,10 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	sortAllSystemsSwitch->setState(Settings::getInstance()->getBool("SortAllSystems"));
 	mMenu.addWithLabel("SORT CUSTOM COLLECTIONS AND SYSTEMS", sortAllSystemsSwitch);
 
+	toggleSystemNameInCollections = std::make_shared<SwitchComponent>(mWindow);
+	toggleSystemNameInCollections->setState(Settings::getInstance()->getBool("CollectionShowSystemInfo"));
+	mMenu.addWithLabel("SHOW SYSTEM NAME IN COLLECTIONS", toggleSystemNameInCollections);
+
 	if(CollectionSystemManager::get()->isEditing())
 	{
 		row.elements.clear();
@@ -170,11 +174,14 @@ void GuiCollectionSystemsOptions::applySettings()
 	bool prevSort = Settings::getInstance()->getBool("SortAllSystems");
 	bool outBundle = bundleCustomCollections->getState();
 	bool prevBundle = Settings::getInstance()->getBool("UseCustomCollectionsSystem");
-	bool needUpdateSettings = prevAuto != outAuto || prevCustom != outCustom || outSort != prevSort || outBundle != prevBundle;
+	bool prevShow = Settings::getInstance()->getBool("CollectionShowSystemInfo");
+	bool outShow = toggleSystemNameInCollections->getState();
+	bool needUpdateSettings = prevAuto != outAuto || prevCustom != outCustom || outSort != prevSort || outBundle != prevBundle || prevShow != outShow ;
 	if (needUpdateSettings)
 	{
 		updateSettings(outAuto, outCustom);
 	}
+
 	delete this;
 }
 
@@ -184,6 +191,7 @@ void GuiCollectionSystemsOptions::updateSettings(std::string newAutoSettings, st
 	Settings::getInstance()->setString("CollectionSystemsCustom", newCustomSettings);
 	Settings::getInstance()->setBool("SortAllSystems", sortAllSystemsSwitch->getState());
 	Settings::getInstance()->setBool("UseCustomCollectionsSystem", bundleCustomCollections->getState());
+	Settings::getInstance()->setBool("CollectionShowSystemInfo", toggleSystemNameInCollections->getState());
 	Settings::getInstance()->saveFile();
 	CollectionSystemManager::get()->loadEnabledListFromSettings();
 	CollectionSystemManager::get()->updateSystemsList();

--- a/es-app/src/guis/GuiCollectionSystemsOptions.h
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.h
@@ -30,6 +30,7 @@ private:
 	std::shared_ptr< OptionListComponent<std::string> > customOptionList;
 	std::shared_ptr<SwitchComponent> sortAllSystemsSwitch;
 	std::shared_ptr<SwitchComponent> bundleCustomCollections;
+	std::shared_ptr<SwitchComponent> toggleSystemNameInCollections;
 	MenuComponent mMenu;
 	SystemData* mSystem;
 };

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -129,6 +129,7 @@ void Settings::setDefaults()
 	mStringMap["OMXAudioDev"] = "both";
 	mStringMap["CollectionSystemsAuto"] = "";
 	mStringMap["CollectionSystemsCustom"] = "";
+	mBoolMap["CollectionShowSystemInfo"] = true;
 	mBoolMap["SortAllSystems"] = false;
 	mBoolMap["UseCustomCollectionsSystem"] = true;
 


### PR DESCRIPTION
* adds a new configuration option ("CollectionShowSystemInfo" = bool). 
Can be toggled in the **Game Collections Settings** GUI - _SHOW SYSTEM NAME IN COLLECTIONS_. Defaults to previous behavior (true).
![gc-show-system-name](https://user-images.githubusercontent.com/31816814/61027811-cb83bc00-a3bf-11e9-8afc-2a7f122ebf43.png)

* reloads the Collections when the configuration is changed (same as with the other Collection settings change).