### PR TITLE
add an option to force the compilation of Raspberry Pi video player bits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 option(GLES "Set to ON if targeting OpenGL ES" ${GLES})
 option(GL "Set to ON if targeting Desktop OpenGL" ${GL})
+option(RPI "Set to ON to enable the Raspberry PI video player (omxplayer)" ${RPI})
 
 project(emulationstation-all)
 
@@ -67,7 +68,7 @@ endif()
 
 #-------------------------------------------------------------------------------
 #set up compiler flags and excutable names
-if(DEFINED BCMHOST)
+if(DEFINED BCMHOST OR RPI)
     add_definitions(-D_RPI_)
 endif()
 


### PR DESCRIPTION
Useful when the VC4 legacy driver is not used for GLES (and OpenGL is used as `${GLSystem}`), but the usage of 'omxplayer' is still desired. It can be used when configuring the build, with:
```
cmake -DRPI:BOOL=On
```
