### PR TITLE
Add BigBen kid's PS3 gamepad 146b:0902 to filterTrigger()

### DIFF
--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -339,11 +339,17 @@ void GuiInputConfig::clearAssignment(int inputId)
 bool GuiInputConfig::filterTrigger(Input input, InputConfig* config, int inputId)
 {
 #if defined(__linux__)
-	// match PlayStation joystick with 6 axes only
-	if((strstr(config->getDeviceName().c_str(), "PLAYSTATION") != NULL \
-	  || strstr(config->getDeviceName().c_str(), "PS3 Ga") != NULL \
-	  || strstr(config->getDeviceName().c_str(), "PS(R) Ga") != NULL) \
-	  && InputManager::getInstance()->getAxisCountByDevice(config->getDeviceId()) == 6)
+	// on Linux, some gamepads return both an analog axis and a digital button for the trigger;
+	// we want the analog axis only, so this function removes the button press event
+
+	if((
+	  // match PlayStation joystick with 6 axes only
+	  strstr(config->getDeviceName().c_str(), "PLAYSTATION") != NULL
+	  || strstr(config->getDeviceName().c_str(), "PS3 Ga") != NULL
+	  || strstr(config->getDeviceName().c_str(), "PS(R) Ga") != NULL
+	  // BigBen kid's PS3 gamepad 146b:0902, matched on SDL GUID because its name "Bigben Interactive Bigben Game Pad" may be too generic
+	  || strcmp(config->getDeviceGUIDString().c_str(), "030000006b1400000209000011010000") == 0
+	  ) && InputManager::getInstance()->getAxisCountByDevice(config->getDeviceId()) == 6)
 	{
 		// digital triggers are unwanted
 		if (input.type == TYPE_BUTTON && (input.id == 6 || input.id == 7))


### PR DESCRIPTION
So here's my fix for getting the proper configuration for the BigBen kid's PS3 #568.

I'm rather unsure that the HID name of the device is specific enough, so this patch uses the SDL GUID instead, which is supposedly unique for a hardware device type.

closes #568