### PR TITLE
Fix Reloadables : Don't reload useless textures that were not loaded at unload time.

### DIFF
--- a/es-core/src/resources/Font.cpp
+++ b/es-core/src/resources/Font.cpp
@@ -75,7 +75,8 @@ size_t Font::getTotalMemUsage()
 Font::Font(int size, const std::string& path) : mSize(size), mPath(path)
 {
 	assert(mSize > 0);
-
+	
+	mLoaded = true;
 	mMaxGlyphHeight = 0;
 
 	if(!sLibrary)
@@ -90,17 +91,28 @@ Font::Font(int size, const std::string& path) : mSize(size), mPath(path)
 
 Font::~Font()
 {
-	unload(ResourceManager::getInstance());
+	unload();
 }
 
-void Font::reload(std::shared_ptr<ResourceManager>& /*rm*/)
+void Font::reload()
 {
+	if (mLoaded)
+		return;
+
 	rebuildTextures();
+	mLoaded = true;
 }
 
-void Font::unload(std::shared_ptr<ResourceManager>& /*rm*/)
+bool Font::unload()
 {
-	unloadTextures();
+	if (mLoaded)
+	{
+		unloadTextures();
+		mLoaded = false;
+		return true;
+	}
+
+	return false;
 }
 
 std::shared_ptr<Font> Font::get(int size, const std::string& path)

--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -53,8 +53,8 @@ public:
 	float getHeight(float lineSpacing = 1.5f) const;
 	float getLetterHeight();
 
-	void unload(std::shared_ptr<ResourceManager>& rm) override;
-	void reload(std::shared_ptr<ResourceManager>& rm) override;
+	bool unload() override;
+	void reload() override;
 
 	int getSize() const;
 	inline const std::string& getPath() const { return mPath; }
@@ -130,6 +130,8 @@ private:
 	const std::string mPath;
 
 	float getNewlineStartOffset(const std::string& text, const unsigned int& charStart, const float& xLen, const Alignment& alignment);
+
+	bool mLoaded;
 
 	friend TextCache;
 };

--- a/es-core/src/resources/ResourceManager.h
+++ b/es-core/src/resources/ResourceManager.h
@@ -20,8 +20,8 @@ class ResourceManager;
 class IReloadable
 {
 public:
-	virtual void unload(std::shared_ptr<ResourceManager>& rm) = 0;
-	virtual void reload(std::shared_ptr<ResourceManager>& rm) = 0;
+	virtual bool unload() = 0;
+	virtual void reload() = 0;
 };
 
 class ResourceManager
@@ -45,7 +45,14 @@ private:
 
 	ResourceData loadFile(const std::string& path) const;
 
-	std::list< std::weak_ptr<IReloadable> > mReloadables;
+	class ReloadableInfo
+	{
+	public:
+		std::weak_ptr<IReloadable> data;
+		bool reload;		
+	};
+
+	std::list<std::shared_ptr<ReloadableInfo>> mReloadables; //  std::weak_ptr<IReloadable> 
 };
 
 #endif // ES_CORE_RESOURCES_RESOURCE_MANAGER_H

--- a/es-core/src/resources/TextureDataManager.cpp
+++ b/es-core/src/resources/TextureDataManager.cpp
@@ -46,7 +46,7 @@ void TextureDataManager::remove(const TextureResource* key)
 	}
 }
 
-std::shared_ptr<TextureData> TextureDataManager::get(const TextureResource* key)
+std::shared_ptr<TextureData> TextureDataManager::get(const TextureResource* key, bool enableLoading)
 {
 	// If it's in the cache then we want to remove it from it's current location and
 	// move it to the top
@@ -63,7 +63,8 @@ std::shared_ptr<TextureData> TextureDataManager::get(const TextureResource* key)
 		mTextureLookup[key] = mTextures.cbegin();
 
 		// Make sure it's loaded or queued for loading
-		load(tex);
+		if (enableLoading && !tex->isLoaded())
+			load(tex);
 	}
 	return tex;
 }

--- a/es-core/src/resources/TextureDataManager.h
+++ b/es-core/src/resources/TextureDataManager.h
@@ -63,7 +63,7 @@ public:
 	// will be deleted when the other thread has finished with it
 	void remove(const TextureResource* key);
 
-	std::shared_ptr<TextureData> get(const TextureResource* key);
+	std::shared_ptr<TextureData> get(const TextureResource* key, bool enableLoading = true);
 	bool bind(const TextureResource* key);
 
 	// Get the total size of all textures managed by this object, loaded and unloaded in bytes

--- a/es-core/src/resources/TextureResource.h
+++ b/es-core/src/resources/TextureResource.h
@@ -37,8 +37,8 @@ public:
 
 protected:
 	TextureResource(const std::string& path, bool tile, bool dynamic);
-	virtual void unload(std::shared_ptr<ResourceManager>& rm);
-	virtual void reload(std::shared_ptr<ResourceManager>& rm);
+	virtual bool unload();
+	virtual void reload();
 
 private:
 	// mTextureData is used for textures that are not loaded from a file - these ones


### PR DESCRIPTION
The reloadable manager reloads every referenced textures even if they have been released to free vram.
This avoids to reloading still referenced textures that were already unloaded.