### PR TITLE
Avoid too many reloadings of SVGs by fixing SVG size calculations

### DIFF
--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -53,6 +53,9 @@ bool TextureData::initSVGFromMemory(const unsigned char* fileData, size_t length
 		return false;
 	}
 
+	if (svgImage->width == 0 || svgImage->height == 0)
+		return false;
+
 	// We want to rasterise this texture at a specific resolution. If the source size
 	// variables are set then use them otherwise set them from the parsed file
 	if ((mSourceWidth == 0.0f) && (mSourceHeight == 0.0f))
@@ -60,8 +63,11 @@ bool TextureData::initSVGFromMemory(const unsigned char* fileData, size_t length
 		mSourceWidth = svgImage->width;
 		mSourceHeight = svgImage->height;
 	}
-	mWidth = (size_t)Math::round(mSourceWidth);
-	mHeight = (size_t)Math::round(mSourceHeight);
+	else
+		mSourceWidth = (mSourceHeight * svgImage->width) / svgImage->height; // FCA : Always compute width using source aspect ratio
+
+	mWidth = (int) mSourceWidth;
+	mHeight = (int) mSourceHeight;
 
 	if (mWidth == 0)
 	{
@@ -239,8 +245,8 @@ float TextureData::sourceHeight()
 void TextureData::setSourceSize(float width, float height)
 {
 	if (mScalable)
-	{
-		if ((mSourceWidth != width) || (mSourceHeight != height))
+	{	
+		if (mSourceHeight < height)
 		{
 			mSourceWidth = width;
 			mSourceHeight = height;

--- a/es-core/src/resources/TextureDataManager.cpp
+++ b/es-core/src/resources/TextureDataManager.cpp
@@ -46,7 +46,7 @@ void TextureDataManager::remove(const TextureResource* key)
 	}
 }
 
-std::shared_ptr<TextureData> TextureDataManager::get(const TextureResource* key)
+std::shared_ptr<TextureData> TextureDataManager::get(const TextureResource* key, bool enableLoading)
 {
 	// If it's in the cache then we want to remove it from it's current location and
 	// move it to the top
@@ -63,8 +63,10 @@ std::shared_ptr<TextureData> TextureDataManager::get(const TextureResource* key)
 		mTextureLookup[key] = mTextures.cbegin();
 
 		// Make sure it's loaded or queued for loading
-		load(tex);
+		if (enableLoading && !tex->isLoaded())
+			load(tex);
 	}
+
 	return tex;
 }
 

--- a/es-core/src/resources/TextureDataManager.h
+++ b/es-core/src/resources/TextureDataManager.h
@@ -63,7 +63,7 @@ public:
 	// will be deleted when the other thread has finished with it
 	void remove(const TextureResource* key);
 
-	std::shared_ptr<TextureData> get(const TextureResource* key);
+	std::shared_ptr<TextureData> get(const TextureResource* key, bool enableLoading = true);
 	bool bind(const TextureResource* key);
 
 	// Get the total size of all textures managed by this object, loaded and unloaded in bytes

--- a/es-core/src/resources/TextureResource.cpp
+++ b/es-core/src/resources/TextureResource.cpp
@@ -83,7 +83,8 @@ bool TextureResource::isTiled() const
 {
 	if (mTextureData != nullptr)
 		return mTextureData->tiled();
-	std::shared_ptr<TextureData> data = sTextureDataManager.get(this);
+
+	std::shared_ptr<TextureData> data = sTextureDataManager.get(this, false);
 	return data->tiled();
 }
 
@@ -94,10 +95,8 @@ bool TextureResource::bind()
 		mTextureData->uploadAndBind();
 		return true;
 	}
-	else
-	{
-		return sTextureDataManager.bind(this);
-	}
+
+	return sTextureDataManager.bind(this);	
 }
 
 std::shared_ptr<TextureResource> TextureResource::get(const std::string& path, bool tile, bool forceLoad, bool dynamic)
@@ -125,13 +124,8 @@ std::shared_ptr<TextureResource> TextureResource::get(const std::string& path, b
 	tex = std::shared_ptr<TextureResource>(new TextureResource(key.first, tile, dynamic));
 	std::shared_ptr<TextureData> data = sTextureDataManager.get(tex.get());
 
-	// is it an SVG?
-	if(key.first.substr(key.first.size() - 4, std::string::npos) != ".svg")
-	{
-		// Probably not. Add it to our map. We don't add SVGs because 2 svgs might be rasterized at different sizes
-		sTextureMap[key] = std::weak_ptr<TextureResource>(tex);
-	}
-
+	sTextureMap[key] = std::weak_ptr<TextureResource>(tex);
+	
 	// Add it to the reloadable list
 	rm->addReloadable(tex);
 
@@ -139,7 +133,9 @@ std::shared_ptr<TextureResource> TextureResource::get(const std::string& path, b
 	if (forceLoad)
 	{
 		tex->mForceLoad = forceLoad;
-		data->load();
+
+		if (data != nullptr && !data->isLoaded())
+			data->load();
 	}
 
 	return tex;
@@ -148,15 +144,22 @@ std::shared_ptr<TextureResource> TextureResource::get(const std::string& path, b
 // For scalable source images in textures we want to set the resolution to rasterize at
 void TextureResource::rasterizeAt(size_t width, size_t height)
 {
+	// Avoids crashing if a theme (in grids) defines negative sizes
+	if (width < 0) width = -width;
+	if (height < 0) height = -height;
+
 	std::shared_ptr<TextureData> data;
 	if (mTextureData != nullptr)
 		data = mTextureData;
 	else
 		data = sTextureDataManager.get(this);
+
 	mSourceSize = Vector2f((float)width, (float)height);
 	data->setSourceSize((float)width, (float)height);
+
 	if (mForceLoad || (mTextureData != nullptr))
-		data->load();
+		if (!data->isLoaded())
+			data->load();
 }
 
 Vector2f TextureResource::getSourceImageSize() const


### PR DESCRIPTION
Avoid too many reloadings of SVGs by fixing SVG size calculation, always based on height -> Doing this, loaded SVG proportion is always good.

As a consequence : SVGs reloaded everytime another instance with a different size had to be displayed, Now it reloads only if new height > prev height.
