### PR TITLE
save also metadata that have default values. they might not had defau…

### DIFF
--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -217,11 +217,6 @@ void updateGamelist(SystemData* system)
 		{
 			const char* tag = ((*fit)->getType() == GAME) ? "game" : "folder";
 
-			// check if current file has metadata, if no, skip it as it wont be in the gamelist anyway.
-			if ((*fit)->metadata.isDefault()) {
-				continue;
-			}
-
 			// do not touch if it wasn't changed anyway
 			if (!(*fit)->metadata.wasChanged())
 				continue;

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -140,17 +140,6 @@ float MetaDataList::getFloat(const std::string& key) const
 	return (float)atof(get(key).c_str());
 }
 
-bool MetaDataList::isDefault()
-{
-	const std::vector<MetaDataDecl>& mdd = getMDD();
-
-	for (unsigned int i = 1; i < mMap.size(); i++) {
-		if (mMap.at(mdd[i].key) != mdd[i].defaultValue) return false;
-	}
-
-	return true;
-}
-
 bool MetaDataList::wasChanged() const
 {
 	return mWasChanged;

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -55,8 +55,6 @@ public:
 	int getInt(const std::string& key) const;
 	float getFloat(const std::string& key) const;
 
-	bool isDefault();
-
 	bool wasChanged() const;
 	void resetChangedFlag();
 


### PR DESCRIPTION
…lt values on start so they have to be saved

This fixes a bug described here:
https://retropie.org.uk/forum/topic/23329/emulationstation-removed-favorite-does-not-get-saved

I understand why this check I removed in the commit is a problem in the described scenario. But I don't really understand why this check was even there in the first place. Maybe it is legacy. Any toughts?
