### PR TITLE
CMakeList.txt: add option to disable libCEC / enabled by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8)
 option(GLES "Set to ON if targeting Embedded OpenGL" ${GLES})
 option(GL "Set to ON if targeting Desktop OpenGL" ${GL})
 option(RPI "Set to ON to enable the Raspberry PI video player (omxplayer)" ${RPI})
+option(CEC "Set to ON to enable CEC" ${CEC})
 
 project(emulationstation-all)
 
@@ -59,7 +60,11 @@ find_package(SDL2 REQUIRED)
 find_package(CURL REQUIRED)
 find_package(VLC REQUIRED)
 find_package(RapidJSON REQUIRED)
-find_package(libCEC)
+
+#add libCEC support
+if(CEC)
+    find_package(libCEC REQUIRED)
+endif()
 
 #add ALSA for Linux
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")


### PR DESCRIPTION
Well I had some trouble with some instabilities & random crashes related to libcec in the past. So I disabled it in a somewhat hacky way by simply patching it out:
```
--- a/CMakeLists.txt	2018-07-22 18:45:34.188603880 +0200
+++ b/CMakeLists.txt	2018-07-22 18:45:57.291577157 +0200
@@ -51,7 +51,6 @@
  find_package(CURL REQUIRED)
 find_package(VLC REQUIRED)
 find_package(RapidJSON REQUIRED)
-find_package(libCEC)
 
 #add ALSA for Linux
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
```

This PR allows to disable libcec by adding `-DUSE_LIBCEC=OFF` to the CMake opts. It is enabled by default but I'm not sure if it should be mandatory or optional. So either:
`find_package(libCEC REQUIRED)`
or
`find_package(libCEC)`
because if the lib is missing on the target system & if it's not disabled build will fail.