### PR TITLE
Eliminate int drawRect and round all transforms

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -209,7 +209,7 @@ void SystemScreenSaver::renderScreenSaver()
 	{
 		// Render black background
 		Renderer::setMatrix(Transform4x4f::Identity());
-		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), 0x000000FF, 0x000000FF);
+		Renderer::drawRect(0.0f, 0.0f, Renderer::getScreenWidth(), Renderer::getScreenHeight(), 0x000000FF, 0x000000FF);
 
 		// Only render the video if the state requires it
 		if ((int)mState >= STATE_FADE_IN_VIDEO)
@@ -222,7 +222,7 @@ void SystemScreenSaver::renderScreenSaver()
 	{
 		// Render black background
 		Renderer::setMatrix(Transform4x4f::Identity());
-		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), 0x000000FF, 0x000000FF);
+		Renderer::drawRect(0.0f, 0.0f, Renderer::getScreenWidth(), Renderer::getScreenHeight(), 0x000000FF, 0x000000FF);
 
 		// Only render the video if the state requires it
 		if ((int)mState >= STATE_FADE_IN_VIDEO)
@@ -249,7 +249,7 @@ void SystemScreenSaver::renderScreenSaver()
 	{
 		Renderer::setMatrix(Transform4x4f::Identity());
 		unsigned char color = screensaver_behavior == "dim" ? 0x000000A0 : 0x000000FF;
-		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), color, color);
+		Renderer::drawRect(0.0f, 0.0f, Renderer::getScreenWidth(), Renderer::getScreenHeight(), color, color);
 	}
 }
 

--- a/es-app/src/components/AsyncReqComponent.cpp
+++ b/es-app/src/components/AsyncReqComponent.cpp
@@ -42,7 +42,7 @@ void AsyncReqComponent::render(const Transform4x4f& /*parentTrans*/)
 	Renderer::setMatrix(trans);
 
 	Vector3f point(Math::cosf(mTime * 0.01f) * 12, Math::sinf(mTime * 0.01f) * 12, 0);
-	Renderer::drawRect((int)point.x(), (int)point.y(), 8, 8, 0x0000FFFF, 0x0000FFFF);
+	Renderer::drawRect(point.x(), point.y(), 8.0f, 8.0f, 0x0000FFFF, 0x0000FFFF);
 }
 
 std::vector<HelpPrompt> AsyncReqComponent::getHelpPrompts()

--- a/es-app/src/components/RatingComponent.cpp
+++ b/es-app/src/components/RatingComponent.cpp
@@ -76,9 +76,9 @@ void RatingComponent::onSizeChanged()
 void RatingComponent::updateVertices()
 {
 	const float        numStars = NUM_RATING_STARS;
-	const float        h        = Math::round(getSize().y()); // is the same as a single star's width
-	const float        w        = Math::round(h * mValue * numStars);
-	const float        fw       = Math::round(h * numStars);
+	const float        h        = getSize().y(); // is the same as a single star's width
+	const float        w        = getSize().y() * mValue * numStars;
+	const float        fw       = getSize().y() * numStars;
 	const unsigned int color    = Renderer::convertColor(mColorShift);
 
 	mVertices[0] = { { 0.0f, 0.0f }, { 0.0f,              1.0f }, color };
@@ -90,6 +90,10 @@ void RatingComponent::updateVertices()
 	mVertices[5] = { { 0.0f, h    }, { 0.0f,              0.0f }, color };
 	mVertices[6] = { { fw,   0.0f }, { numStars,          1.0f }, color };
 	mVertices[7] = { { fw,   h    }, { numStars,          0.0f }, color };
+
+	// round vertices
+	for(int i = 0; i < 8; ++i)
+		mVertices[i].pos.round();
 }
 
 void RatingComponent::updateColors()

--- a/es-app/src/components/RatingComponent.cpp
+++ b/es-app/src/components/RatingComponent.cpp
@@ -106,7 +106,6 @@ void RatingComponent::render(const Transform4x4f& parentTrans)
 		return;
 
 	Transform4x4f trans = parentTrans * getTransform();
-	trans.round();
 	Renderer::setMatrix(trans);
 
 	mFilledTexture->bind();

--- a/es-app/src/components/ScraperSearchComponent.cpp
+++ b/es-app/src/components/ScraperSearchComponent.cpp
@@ -359,9 +359,7 @@ void ScraperSearchComponent::render(const Transform4x4f& parentTrans)
 	if(mBlockAccept)
 	{
 		Renderer::setMatrix(trans);
-		Renderer::drawRect(0.f, 0.f, mSize.x(), mSize.y(), 0x00000011, 0x00000011);
-		//Renderer::drawRect((int)mResultList->getPosition().x(), (int)mResultList->getPosition().y(),
-		//	(int)mResultList->getSize().x(), (int)mResultList->getSize().y(), 0x0000011, 0x00000011);
+		Renderer::drawRect(0.0f, 0.0f, mSize.x(), mSize.y(), 0x00000011, 0x00000011);
 
 		mBusyAnim.render(trans);
 	}

--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -173,7 +173,7 @@ void TextListComponent<T>::render(const Transform4x4f& parentTrans)
 			mSelectorImage.render(trans);
 		} else {
 			Renderer::setMatrix(trans);
-			Renderer::drawRect(0.f, (mCursor - startEntry)*entrySize + mSelectorOffsetY, mSize.x(),
+			Renderer::drawRect(0.0f, (mCursor - startEntry)*entrySize + mSelectorOffsetY, mSize.x(),
 					mSelectorHeight, mSelectorColor, mSelectorColorEnd, mSelectorColorGradientHorizontal);
 		}
 	}

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -434,7 +434,7 @@ void SystemView::renderCarousel(const Transform4x4f& trans)
 	Renderer::pushClipRect(Vector2i((int)clipPos.x(), (int)clipPos.y()), Vector2i((int)mCarousel.size.x(), (int)mCarousel.size.y()));
 
 	Renderer::setMatrix(carouselTrans);
-	Renderer::drawRect(0.0, 0.0, mCarousel.size.x(), mCarousel.size.y(), mCarousel.color, mCarousel.colorEnd, mCarousel.colorGradientHorizontal);
+	Renderer::drawRect(0.0f, 0.0f, mCarousel.size.x(), mCarousel.size.y(), mCarousel.color, mCarousel.colorEnd, mCarousel.colorGradientHorizontal);
 
 	// draw logos
 	Vector2f logoSpacing(0.0, 0.0); // NB: logoSpacing will include the size of the logo itself as well!

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -424,7 +424,7 @@ void ViewController::render(const Transform4x4f& parentTrans)
 	{
 		unsigned int fadeColor = 0x00000000 | (unsigned char)(mFadeOpacity * 255);
 		Renderer::setMatrix(parentTrans);
-		Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), fadeColor, fadeColor);
+		Renderer::drawRect(0.0f, 0.0f, Renderer::getScreenWidth(), Renderer::getScreenHeight(), fadeColor, fadeColor);
 	}
 }
 

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -301,7 +301,7 @@ void Window::renderLoadingScreen(std::string text)
 {
 	Transform4x4f trans = Transform4x4f::Identity();
 	Renderer::setMatrix(trans);
-	Renderer::drawRect(0, 0, Renderer::getScreenWidth(), Renderer::getScreenHeight(), 0x000000FF, 0x000000FF);
+	Renderer::drawRect(0.0f, 0.0f, Renderer::getScreenWidth(), Renderer::getScreenHeight(), 0x000000FF, 0x000000FF);
 
 	ImageComponent splash(this, true);
 	splash.setResize(Renderer::getScreenWidth() * 0.6f, 0.0f);

--- a/es-core/src/components/ButtonComponent.cpp
+++ b/es-core/src/components/ButtonComponent.cpp
@@ -86,14 +86,12 @@ void ButtonComponent::updateImage()
 void ButtonComponent::render(const Transform4x4f& parentTrans)
 {
 	Transform4x4f trans = parentTrans * getTransform();
-	trans.round();
 
 	mBox.render(trans);
 
 	if(mTextCache)
 	{
 		Vector3f centerOffset((mSize.x() - mTextCache->metrics.size.x()) / 2, (mSize.y() - mTextCache->metrics.size.y()) / 2, 0);
-		centerOffset.round();
 		trans = trans.translate(centerOffset);
 
 		Renderer::setMatrix(trans);

--- a/es-core/src/components/ComponentList.cpp
+++ b/es-core/src/components/ComponentList.cpp
@@ -161,7 +161,6 @@ void ComponentList::render(const Transform4x4f& parentTrans)
 		return;
 
 	Transform4x4f trans = parentTrans * getTransform();
-	trans.round();
 
 	// clip everything to be inside our bounds
 	Vector3f dim(mSize.x(), mSize.y(), 0);

--- a/es-core/src/components/DateTimeEditComponent.cpp
+++ b/es-core/src/components/DateTimeEditComponent.cpp
@@ -146,7 +146,6 @@ void DateTimeEditComponent::render(const Transform4x4f& parentTrans)
 		// vertically center
 		Vector3f off(0, (mSize.y() - mTextCache->metrics.size.y()) / 2, 0);
 		trans.translate(off);
-		trans.round();
 
 		Renderer::setMatrix(trans);
 
@@ -159,8 +158,8 @@ void DateTimeEditComponent::render(const Transform4x4f& parentTrans)
 		{
 			if(mEditIndex >= 0 && (unsigned int)mEditIndex < mCursorBoxes.size())
 			{
-				Renderer::drawRect((int)mCursorBoxes[mEditIndex][0], (int)mCursorBoxes[mEditIndex][1],
-					(int)mCursorBoxes[mEditIndex][2], (int)mCursorBoxes[mEditIndex][3], 0x00000022, 0x00000022);
+				Renderer::drawRect(mCursorBoxes[mEditIndex][0], mCursorBoxes[mEditIndex][1],
+					mCursorBoxes[mEditIndex][2], mCursorBoxes[mEditIndex][3], 0x00000022, 0x00000022);
 			}
 		}
 	}

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -282,9 +282,8 @@ void ImageComponent::updateVertices()
 
 	// we go through this mess to make sure everything is properly rounded
 	// if we just round vertices at the end, edge cases occur near sizes of 0.5
-	const Vector2f     size        = { Math::round(mSize.x()), Math::round(mSize.y()) };
-	const Vector2f     topLeft     = { size * mTopLeftCrop };
-	const Vector2f     bottomRight = { size * mBottomRightCrop };
+	const Vector2f     topLeft     = { mSize * mTopLeftCrop };
+	const Vector2f     bottomRight = { mSize * mBottomRightCrop };
 	const float        px          = mTexture->isTiled() ? mSize.x() / getTextureSize().x() : 1.0f;
 	const float        py          = mTexture->isTiled() ? mSize.y() / getTextureSize().y() : 1.0f;
 	const unsigned int color       = Renderer::convertColor(mColorShift);
@@ -295,14 +294,19 @@ void ImageComponent::updateVertices()
 	mVertices[2] = { { bottomRight.x(), topLeft.y()     }, { mBottomRightCrop.x() * px, py   - mTopLeftCrop.y()     }, mColorGradientHorizontal ? color : colorEnd };
 	mVertices[3] = { { bottomRight.x(), bottomRight.y() }, { mBottomRightCrop.x() * px, 1.0f - mBottomRightCrop.y() }, color };
 
+	// round vertices
+	for(int i = 0; i < 4; ++i)
+		mVertices[i].pos.round();
+
 	if(mFlipX)
 	{
-		for(int i = 0; i < 4; i++)
+		for(int i = 0; i < 4; ++i)
 			mVertices[i].tex[0] = px - mVertices[i].tex[0];
 	}
+
 	if(mFlipY)
 	{
-		for(int i = 0; i < 4; i++)
+		for(int i = 0; i < 4; ++i)
 			mVertices[i].tex[1] = py - mVertices[i].tex[1];
 	}
 }

--- a/es-core/src/components/NinePatchComponent.cpp
+++ b/es-core/src/components/NinePatchComponent.cpp
@@ -56,10 +56,10 @@ void NinePatchComponent::buildVertices()
 	const float imgPosY[3]  = { 0, imgSizeY[0], imgSizeY[0] + imgSizeY[1]};
 
 	//the "1 +" in posY and "-" in sizeY is to deal with texture coordinates having a bottom left corner origin vs. verticies having a top left origin
-	const float texSizeX[3]       = {  mCornerSize.x() / texSize.x(),  (texSize.x() - mCornerSize.x() * 2) / texSize.x(),  mCornerSize.x() / texSize.x() };
-	const float texSizeY[3]       = { -mCornerSize.y() / texSize.y(), -(texSize.y() - mCornerSize.y() * 2) / texSize.y(), -mCornerSize.y() / texSize.y() };
-	const float texPosX[3]        = {  0,     texSizeX[0],     texSizeX[0] + texSizeX[1] };
-	const float texPosY[3]        = {  1, 1 + texSizeY[0], 1 + texSizeY[0] + texSizeY[1] };
+	const float texSizeX[3] = {  mCornerSize.x() / texSize.x(),  (texSize.x() - mCornerSize.x() * 2) / texSize.x(),  mCornerSize.x() / texSize.x() };
+	const float texSizeY[3] = { -mCornerSize.y() / texSize.y(), -(texSize.y() - mCornerSize.y() * 2) / texSize.y(), -mCornerSize.y() / texSize.y() };
+	const float texPosX[3]  = {  0,     texSizeX[0],     texSizeX[0] + texSizeX[1] };
+	const float texPosY[3]  = {  1, 1 + texSizeY[0], 1 + texSizeY[0] + texSizeY[1] };
 
 	int v = 0;
 	for(int slice = 0; slice < 9; slice++)
@@ -76,17 +76,15 @@ void NinePatchComponent::buildVertices()
 		mVertices[v + 3] = { { imgPos.x() + imgSize.x(), imgPos.y()               }, { texPos.x() + texSize.x(), texPos.y()               }, 0 };
 		mVertices[v + 4] = { { imgPos.x() + imgSize.x(), imgPos.y() + imgSize.y() }, { texPos.x() + texSize.x(), texPos.y() + texSize.y() }, 0 };
 
+		// round vertices
+		for(int i = 1; i < 5; ++i)
+			mVertices[v + i].pos.round();
+
 		// make duplicates of first and last vertex so this can be rendered as a triangle strip
 		mVertices[v + 0] = mVertices[v + 1];
 		mVertices[v + 5] = mVertices[v + 4];
 
 		v += 6;
-	}
-
-	// round vertices
-	for(int i = 0; i < 6*9; i++)
-	{
-		mVertices[i].pos.round();
 	}
 
 	updateColors();

--- a/es-core/src/components/NinePatchComponent.cpp
+++ b/es-core/src/components/NinePatchComponent.cpp
@@ -98,7 +98,6 @@ void NinePatchComponent::render(const Transform4x4f& parentTrans)
 		return;
 
 	Transform4x4f trans = parentTrans * getTransform();
-	trans.round();
 
 	if(mTexture && mVertices != NULL)
 	{

--- a/es-core/src/components/SliderComponent.cpp
+++ b/es-core/src/components/SliderComponent.cpp
@@ -61,7 +61,6 @@ void SliderComponent::update(int deltaTime)
 void SliderComponent::render(const Transform4x4f& parentTrans)
 {
 	Transform4x4f trans = parentTrans * getTransform();
-	trans.round();
 	Renderer::setMatrix(trans);
 
 	// render suffix

--- a/es-core/src/components/TextComponent.cpp
+++ b/es-core/src/components/TextComponent.cpp
@@ -102,7 +102,7 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 	if (mRenderBackground)
 	{
 		Renderer::setMatrix(trans);
-		Renderer::drawRect(0.f, 0.f, mSize.x(), mSize.y(), mBgColor, mBgColor);
+		Renderer::drawRect(0.0f, 0.0f, mSize.x(), mSize.y(), mBgColor, mBgColor);
 	}
 
 	if(mTextCache)
@@ -127,11 +127,10 @@ void TextComponent::render(const Transform4x4f& parentTrans)
 		{
 			// draw the "textbox" area, what we are aligned within
 			Renderer::setMatrix(trans);
-			Renderer::drawRect(0.f, 0.f, mSize.x(), mSize.y(), 0xFF000033, 0xFF000033);
+			Renderer::drawRect(0.0f, 0.0f, mSize.x(), mSize.y(), 0xFF000033, 0xFF000033);
 		}
 
 		trans.translate(off);
-		trans.round();
 		Renderer::setMatrix(trans);
 
 		// draw the text area, where the text actually is going

--- a/es-core/src/components/TextEditComponent.cpp
+++ b/es-core/src/components/TextEditComponent.cpp
@@ -254,8 +254,6 @@ void TextEditComponent::render(const Transform4x4f& parentTrans)
 	Renderer::pushClipRect(clipPos, clipDim);
 
 	trans.translate(Vector3f(-mScrollOffset.x(), -mScrollOffset.y(), 0));
-	trans.round();
-
 	Renderer::setMatrix(trans);
 
 	if(mTextCache)

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -137,7 +137,6 @@ void VideoVlcComponent::render(const Transform4x4f& parentTrans)
 	VideoComponent::render(parentTrans);
 	Transform4x4f trans = parentTrans * getTransform();
 	GuiComponent::renderChildren(trans);
-
 	Renderer::setMatrix(trans);
 
 	if (mIsPlaying && mContext.valid)
@@ -150,6 +149,10 @@ void VideoVlcComponent::render(const Transform4x4f& parentTrans)
 		vertices[1] = { { 0.0f     , mSize.y() }, { 0.0f, 1.0f }, color };
 		vertices[2] = { { mSize.x(), 0.0f      }, { 1.0f, 0.0f }, color };
 		vertices[3] = { { mSize.x(), mSize.y() }, { 1.0f, 1.0f }, color };
+
+		// round vertices
+		for(int i = 0; i < 4; ++i)
+			vertices[i].pos.round();
 
 		// Build a texture for the video frame
 		mTexture->initFromPixels((unsigned char*)mContext.surface->pixels, mContext.surface->w, mContext.surface->h);

--- a/es-core/src/renderers/Renderer.cpp
+++ b/es-core/src/renderers/Renderer.cpp
@@ -238,10 +238,6 @@ namespace Renderer
 
 	void drawRect(const float _x, const float _y, const float _w, const float _h, const unsigned int _color, const unsigned int _colorEnd, bool horizontalGradient, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
 	{
-		const float        x        = Math::round(_x);
-		const float        y        = Math::round(_y);
-		const float        w        = Math::round(_w);
-		const float        h        = Math::round(_h);
 		const unsigned int color    = convertColor(_color);
 		const unsigned int colorEnd = convertColor(_colorEnd);
 		Vertex             vertices[4];
@@ -250,6 +246,10 @@ namespace Renderer
 		vertices[1] = { { _x     ,_y + _h }, { 0.0f, 0.0f }, horizontalGradient ? colorEnd : color };
 		vertices[2] = { { _x + _w,_y      }, { 0.0f, 0.0f }, horizontalGradient ? color : colorEnd };
 		vertices[3] = { { _x + _w,_y + _h }, { 0.0f, 0.0f }, colorEnd };
+
+		// round vertices
+		for(int i = 0; i < 4; ++i)
+			vertices[i].pos.round();
 
 		bindTexture(0);
 		drawTriangleStrips(vertices, 4, _srcBlendFactor, _dstBlendFactor);

--- a/es-core/src/renderers/Renderer.cpp
+++ b/es-core/src/renderers/Renderer.cpp
@@ -238,20 +238,18 @@ namespace Renderer
 
 	void drawRect(const float _x, const float _y, const float _w, const float _h, const unsigned int _color, const unsigned int _colorEnd, bool horizontalGradient, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
 	{
-		drawRect((int)Math::round(_x), (int)Math::round(_y), (int)Math::round(_w), (int)Math::round(_h), _color, _colorEnd, horizontalGradient, _srcBlendFactor, _dstBlendFactor);
-
-	} // drawRect
-
-	void drawRect(const int _x, const int _y, const int _w, const int _h, const unsigned int _color, const unsigned int _colorEnd, bool horizontalGradient, const Blend::Factor _srcBlendFactor, const Blend::Factor _dstBlendFactor)
-	{
+		const float        x        = Math::round(_x);
+		const float        y        = Math::round(_y);
+		const float        w        = Math::round(_w);
+		const float        h        = Math::round(_h);
 		const unsigned int color    = convertColor(_color);
 		const unsigned int colorEnd = convertColor(_colorEnd);
 		Vertex             vertices[4];
 
-		vertices[0] = { { (float)(_x     ), (float)(_y     ) }, { 0.0f, 0.0f }, color };
-		vertices[1] = { { (float)(_x     ), (float)(_y + _h) }, { 0.0f, 0.0f }, horizontalGradient ? colorEnd : color };
-		vertices[2] = { { (float)(_x + _w), (float)(_y     ) }, { 0.0f, 0.0f }, horizontalGradient ? color : colorEnd };
-		vertices[3] = { { (float)(_x + _w), (float)(_y + _h) }, { 0.0f, 0.0f }, colorEnd };
+		vertices[0] = { { _x     ,_y      }, { 0.0f, 0.0f }, color };
+		vertices[1] = { { _x     ,_y + _h }, { 0.0f, 0.0f }, horizontalGradient ? colorEnd : color };
+		vertices[2] = { { _x + _w,_y      }, { 0.0f, 0.0f }, horizontalGradient ? color : colorEnd };
+		vertices[3] = { { _x + _w,_y + _h }, { 0.0f, 0.0f }, colorEnd };
 
 		bindTexture(0);
 		drawTriangleStrips(vertices, 4, _srcBlendFactor, _dstBlendFactor);

--- a/es-core/src/renderers/Renderer.h
+++ b/es-core/src/renderers/Renderer.h
@@ -67,7 +67,6 @@ namespace Renderer
 	void        pushClipRect    (const Vector2i& _pos, const Vector2i& _size);
 	void        popClipRect     ();
 	void        drawRect        (const float _x, const float _y, const float _w, const float _h, const unsigned int _color, const unsigned int _colorEnd, bool horizontalGradient = false, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA);
-	void        drawRect        (const int   _x, const int   _y, const int   _w, const int   _h, const unsigned int _color, const unsigned int _colorEnd, bool horizontalGradient = false, const Blend::Factor _srcBlendFactor = Blend::SRC_ALPHA, const Blend::Factor _dstBlendFactor = Blend::ONE_MINUS_SRC_ALPHA);
 
 	SDL_Window* getSDLWindow    ();
 	int         getWindowWidth  ();

--- a/es-core/src/renderers/Renderer_GL21.cpp
+++ b/es-core/src/renderers/Renderer_GL21.cpp
@@ -1,6 +1,7 @@
 #if defined(USE_OPENGL_21)
 
 #include "renderers/Renderer.h"
+#include "math/Transform4x4f.h"
 #include "Log.h"
 #include "Settings.h"
 
@@ -193,8 +194,10 @@ namespace Renderer
 
 	void setMatrix(const Transform4x4f& _matrix)
 	{
+		Transform4x4f matrix = _matrix;
+		matrix.round();
 		glMatrixMode(GL_MODELVIEW);
-		glLoadMatrixf((GLfloat*)&_matrix);
+		glLoadMatrixf((GLfloat*)&matrix);
 
 	} // setMatrix
 

--- a/es-core/src/renderers/Renderer_GLES10.cpp
+++ b/es-core/src/renderers/Renderer_GLES10.cpp
@@ -193,8 +193,10 @@ namespace Renderer
 
 	void setMatrix(const Transform4x4f& _matrix)
 	{
+		Transform4x4f matrix = _matrix;
+		matrix.round();
 		glMatrixMode(GL_MODELVIEW);
-		glLoadMatrixf((GLfloat*)&_matrix);
+		glLoadMatrixf((GLfloat*)&matrix);
 
 	} // setMatrix
 

--- a/es-core/src/resources/Font.cpp
+++ b/es-core/src/resources/Font.cpp
@@ -604,10 +604,14 @@ TextCache* Font::buildTextCache(const std::string& text, Vector2f offset, unsign
 		const Vector2i&    textureSize    = glyph->texture->textureSize;
 		const unsigned int convertedColor = Renderer::convertColor(color);
 
-		vertices[1] = { { Math::round(glyphStartX                                       ), Math::round(y - glyph->bearing.y()                                         ) }, { glyph->texPos.x(),                      glyph->texPos.y()                      }, convertedColor };
-		vertices[2] = { { Math::round(glyphStartX                                       ), Math::round(y - glyph->bearing.y() + (glyph->texSize.y() * textureSize.y())) }, { glyph->texPos.x(),                      glyph->texPos.y() + glyph->texSize.y() }, convertedColor };
-		vertices[3] = { { Math::round(glyphStartX + glyph->texSize.x() * textureSize.x()), Math::round(y - glyph->bearing.y()                                         ) }, { glyph->texPos.x() + glyph->texSize.x(), glyph->texPos.y()                      }, convertedColor };
-		vertices[4] = { { Math::round(glyphStartX + glyph->texSize.x() * textureSize.x()), Math::round(y - glyph->bearing.y() + (glyph->texSize.y() * textureSize.y())) }, { glyph->texPos.x() + glyph->texSize.x(), glyph->texPos.y() + glyph->texSize.y() }, convertedColor };
+		vertices[1] = { { glyphStartX                                       , y - glyph->bearing.y()                                          }, { glyph->texPos.x(),                      glyph->texPos.y()                      }, convertedColor };
+		vertices[2] = { { glyphStartX                                       , y - glyph->bearing.y() + (glyph->texSize.y() * textureSize.y()) }, { glyph->texPos.x(),                      glyph->texPos.y() + glyph->texSize.y() }, convertedColor };
+		vertices[3] = { { glyphStartX + glyph->texSize.x() * textureSize.x(), y - glyph->bearing.y()                                          }, { glyph->texPos.x() + glyph->texSize.x(), glyph->texPos.y()                      }, convertedColor };
+		vertices[4] = { { glyphStartX + glyph->texSize.x() * textureSize.x(), y - glyph->bearing.y() + (glyph->texSize.y() * textureSize.y()) }, { glyph->texPos.x() + glyph->texSize.x(), glyph->texPos.y() + glyph->texSize.y() }, convertedColor };
+
+		// round vertices
+		for(int i = 1; i < 5; ++i)
+			vertices[i].pos.round();
 
 		// make duplicates of first and last vertex so this can be rendered as a triangle strip
 		vertices[0] = vertices[1];


### PR DESCRIPTION
Eliminate drawRect that takes int's and make sure everything uses the float version properly, this way everything is rounded the same way

Only round the transforms when setting them on the GPU, to make sure everything is rounded the same, but only at the final moment