### PR TITLE
Argument/Setting to set log path

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -142,6 +142,10 @@ bool parseArgs(int argc, char* argv[])
 		{
 			int maxVRAM = atoi(argv[i + 1]);
 			Settings::getInstance()->setInt("MaxVRAM", maxVRAM);
+		}else if(strcmp(argv[i], "--log-path") == 0)
+		{
+			std::string logPATH = argv[i + 1];
+			Settings::getInstance()->setString("LogPath", logPATH);
 		}
 		else if (strcmp(argv[i], "--force-kiosk") == 0)
 		{
@@ -185,6 +189,7 @@ bool parseArgs(int argc, char* argv[])
 				"--force-kiosk		Force the UI mode to be Kiosk\n"
 				"--force-disable-filters		Force the UI to ignore applied filters in gamelist\n"
 				"--home [path]		Directory to use as home path\n"
+				"--log-path [path]		Directory to use for log\n"
 				"--help, -h			summon a sentient, angry tuba\n\n"
 				"More information available in README.md.\n";
 			return false; //exit after printing help

--- a/es-core/src/Log.cpp
+++ b/es-core/src/Log.cpp
@@ -3,6 +3,7 @@
 #include "utils/FileSystemUtil.h"
 #include "platform.h"
 #include <iostream>
+#include "Settings.cpp"
 
 LogLevel Log::reportingLevel = LogInfo;
 FILE* Log::file = NULL; //fopen(getLogPath().c_str(), "w");
@@ -14,8 +15,13 @@ LogLevel Log::getReportingLevel()
 
 std::string Log::getLogPath()
 {
-	std::string home = Utils::FileSystem::getHomePath();
-	return home + "/.emulationstation/es_log.txt";
+	if (Settings::getInstance()->getString("LogPath") != "") {
+		return Settings::getInstance()->getString("LogPath") + "/es_log.txt";
+	} else {
+		std::string home = Utils::FileSystem::getHomePath();
+		return home + "/.emulationstation/es_log.txt";
+	}
+
 }
 
 void Log::setReportingLevel(LogLevel level)

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -33,7 +33,8 @@ std::vector<const char*> settings_dont_save {
 	{ "ScreenHeight" },
 	{ "ScreenOffsetX" },
 	{ "ScreenOffsetY" },
-	{ "ScreenRotate" }
+	{ "ScreenRotate" },
+	{ "LogPath" }
 };
 
 Settings::Settings()
@@ -160,6 +161,7 @@ void Settings::setDefaults()
 	mIntMap["ScreenOffsetX"] = 0;
 	mIntMap["ScreenOffsetY"] = 0;
 	mIntMap["ScreenRotate"]  = 0;
+	mStringMap["LogPath"] = "";
 }
 
 template <typename K, typename V>


### PR DESCRIPTION
This PR allows to choose the directory where you want to save es_log.txt if none of the options are set it will use the default `$HOME/.emulationstation/es_log.txt`

* Using argument --log-path [path]
* Using es_settings.cfg `<string name="LogPath" value="[path]" />`

As requested on #596