### PR TITLE
filterTrigger: filter negative trigger axis event after positive axis…

### DIFF
--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -352,16 +352,28 @@ bool GuiInputConfig::filterTrigger(Input input, InputConfig* config, int inputId
 	  ) && InputManager::getInstance()->getAxisCountByDevice(config->getDeviceId()) == 6)
 	{
 		// digital triggers are unwanted
-		if (input.type == TYPE_BUTTON && (input.id == 6 || input.id == 7))
+		if(input.type == TYPE_BUTTON && (input.id == 6 || input.id == 7))
+		{
+			mHoldingInput = false;
 			return true;
+		}
 	}
 
 	// ignore negative pole for axes 2/5 only when triggers are being configured
-	if((mSkipAxis || strstr(GUI_INPUT_CONFIG_LIST[inputId].name, "Trigger") != NULL) \
-	  && input.type == TYPE_AXIS && (input.id == 2 || input.id == 5) && input.value < 0)
+	if(input.type == TYPE_AXIS && (input.id == 2 || input.id == 5))
 	{
-		mSkipAxis = true;
-		return true;
+		if(strstr(GUI_INPUT_CONFIG_LIST[inputId].name, "Trigger") != NULL)
+		{
+			if(input.value == 1)
+				mSkipAxis = true;
+			else if(input.value == -1)
+				return true;
+		}
+		else if(mSkipAxis)
+		{
+			mSkipAxis = false;
+			return true;
+		}
 	}
 #else
 	(void)input;


### PR DESCRIPTION
… detection

If filterTrigger detects a positive axis event on a common trigger axis while also
configuring a trigger, the next input event will be a negative axis press
(as the trigger needs to transition from >0 to rest at -32767).

Filter this negative event or else the next item in the configuration dialog
(typically "left thumb") will erroneously detect this as a separate event.