### PR TITLE
CMakeLists.txt: detect common OpenGL ES 1.1 library libGLESv1_CM.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,16 @@ elseif(EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/libMali.so" OR
     EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/arm-linux-gnueabihf/libmali.so")
     MESSAGE("libMali.so found")
     set(GLSystem "Embedded OpenGL" CACHE STRING "The OpenGL system to be used")
+#-------------------------------------------------------------------------------
+#check if we're running on a system which provides a library for OpenGL ES 1.1
+elseif(EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/libGLESv1_CM.so" OR
+    EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/aarch64-linux-gnu/libGLESv1_CM.so" OR
+    EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/arm-linux-gnueabi/libGLESv1_CM.so" OR
+    EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/arm-linux-gnueabihf/libGLESv1_CM.so" OR
+    EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/i386-linux-gnu/libGLESv1_CM.so" OR
+    EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/x86_64-linux-gnu/libGLESv1_CM.so")
+    MESSAGE("Embedded OpenGL: libGLESv1_CM.so found")
+    set(GLSystem "Embedded OpenGL" CACHE STRING "The OpenGL system to be used")
 else()
     set(GLSystem "Desktop OpenGL" CACHE STRING "The OpenGL system to be used")
 endif(GLES)


### PR DESCRIPTION
Based on these [includes](https://github.com/tomaz82/EmulationStation/blob/a02a747c502888ecee5c25efff36ba02d1fcbf3e/es-core/src/renderers/Renderer_GLES10.cpp#L7) I guess the whole OpenGL ES renderer relies on v1.1 which means it depends on `libGLESv1_CM.so`. If you use OpenGL ES libs provided by Mesa 3D instead of any vendor blobs we have to check for this lib too. 

I used this for common paths https://packages.debian.org/search?mode=path&suite=buster&section=all&arch=any&searchon=contents&keywords=libGLESv1_CM.so

Mesa doc:
https://www.mesa3d.org/opengles.html

Arm doc:
http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0511e/BABCJJJG.html