### PR TITLE
added ISSUE_TEMPLATE.md from RetroPie-Setup to direct users to the forum first

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+Please start a topic on the RetroPie forum before opening an issue - https://retropie.org.uk/forum/
+
+This includes edit suggestions for the wiki. There are more people to help on the forum.
+
+Once a problem has been verified on the forum, an issue can be opened here.
+
+Please remove this text before posting.


### PR DESCRIPTION
Same wording as RetroPie-Setup. Wiki bit maybe not directly related to this repo, but both this and RetroPie-Setup repo get tickets that would be best started on the forum where more people can advise (eg. Issues that are due to user set-up).