### PR TITLE
make install support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ option(CEC "Set to ON to enable CEC" ${CEC})
 
 project(emulationstation-all)
 
+
 # program name to be used as a reference when looking up resources
 set(AppDataName "EmulationStation" CACHE STRING "Internal program name passed to compiler")
 add_definitions(-DAPPDATANAME="${AppDataName}")
@@ -251,6 +252,9 @@ set(dir ${CMAKE_CURRENT_SOURCE_DIR})
 set(EXECUTABLE_OUTPUT_PATH ${dir} CACHE PATH "Build directory" FORCE)
 set(LIBRARY_OUTPUT_PATH ${dir} CACHE PATH "Build directory" FORCE)
 
+# install rules for resources
+include(GNUInstallDirs)
+install(DIRECTORY resources DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/${AppDataName}/resources")
 
 #-------------------------------------------------------------------------------
 # add each component

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ option(CEC "Set to ON to enable CEC" ${CEC})
 
 project(emulationstation-all)
 
+# program name to be used as a reference when looking up resources
+set(AppDataName "EmulationStation" CACHE STRING "Internal program name passed to compiler")
+add_definitions(-DAPPDATANAME="${AppDataName}")
+
 #-------------------------------------------------------------------------------
 #add local find scripts to CMAKE path
 LIST(APPEND CMAKE_MODULE_PATH

--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -142,10 +142,11 @@ endif()
 
 #-------------------------------------------------------------------------------
 # set up CPack install stuff so `make install` does something useful
-
+include(GNUInstallDirs)
 install(TARGETS emulationstation
     RUNTIME
-    DESTINATION bin)
+    DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
 
 INCLUDE(InstallRequiredSystemLibraries)
 

--- a/es-core/src/resources/ResourceManager.cpp
+++ b/es-core/src/resources/ResourceManager.cpp
@@ -3,6 +3,10 @@
 #include "utils/FileSystemUtil.h"
 #include <fstream>
 
+#ifndef APPDATANAME
+#define APPDATANAME "EmulationStation"
+#endif
+
 auto array_deleter = [](unsigned char* p) { delete[] p; };
 auto nop_deleter = [](unsigned char* /*p*/) { };
 
@@ -27,6 +31,20 @@ std::string ResourceManager::getResourcePath(const std::string& path) const
 	{
 		std::string test;
 
+		// check in standard AppData locations
+#if defined(__linux__)
+		test = Utils::FileSystem::getHomePath() + "/.local/share/" + APPDATANAME + "/resources/" + &path[2];
+		if (Utils::FileSystem::exists(test))
+			return test;
+
+		test = std::string("/usr/local/share/") + APPDATANAME + "/resources/" + &path[2];
+		if (Utils::FileSystem::exists(test))
+			return test;
+
+		test = std::string("/usr/share/") + APPDATANAME + "/resources/" + &path[2];
+		if (Utils::FileSystem::exists(test))
+			return test;
+#endif
 		// check in homepath
 		test = Utils::FileSystem::getHomePath() + "/.emulationstation/resources/" + &path[2];
 		if(Utils::FileSystem::exists(test))


### PR DESCRIPTION
Adds better support for "make install".  ResourceManager now does lookups in standard share directories and cmake properly adds the "resources" directory to its install targets.