### PR TITLE
fix 'DateTimeEditComponent' output formatting

### DIFF
--- a/es-core/src/components/DateTimeEditComponent.cpp
+++ b/es-core/src/components/DateTimeEditComponent.cpp
@@ -200,6 +200,8 @@ std::string DateTimeEditComponent::getDisplayString(DisplayMode mode) const
 		fmt = "%m/%d/%Y";
 		break;
 	case DISP_DATE_TIME:
+		if(mTime.getTime() == 0)
+			return "unknown";
 		fmt = "%m/%d/%Y %H:%M:%S";
 		break;
 	case DISP_RELATIVE_TO_NOW:
@@ -226,9 +228,6 @@ std::string DateTimeEditComponent::getDisplayString(DisplayMode mode) const
 		}
 		break;
 	}
-
-	if(mTime.getTime() == 0)
-		return "unknown";
 
 	return Utils::Time::timeToString(mTime, fmt);
 }


### PR DESCRIPTION
If the display mode is `DISP_DATE`, ignore the `mTime` field when calculating the output. This influences the size calculation of the component.

Fixes https://github.com/RetroPie/EmulationStation/issues/385.