### PR TITLE
Use platform-specific methods for setExePath

### DIFF
--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -194,8 +194,21 @@ namespace Utils
 
 		void setExePath(const std::string& _path)
 		{
-			exePath = getCanonicalPath(_path);
+			constexpr int path_max = 32767;
+#if defined(_WIN32)
+			std::wstring result(path_max, 0);
+			if(GetModuleFileNameW(nullptr, &result[0], path_max) != 0)
+				exePath = convertFromWideString(result);
+#else
+			std::string result(path_max, 0);
+			if(readlink("/proc/self/exe", &result[0], path_max) != -1)
+				exePath = result;
+#endif
+			exePath = getCanonicalPath(exePath);
 
+			// Fallback to argv[0] if everything else fails
+			if (exePath.empty())
+				exePath = getCanonicalPath(_path);
 			if(isRegularFile(exePath))
 				exePath = getParent(exePath);
 


### PR DESCRIPTION
Same as my previous PR except following the same styling.  Also made a small change which uses std::string instead of a char buffer.

Basically uses platform-specific methods to retrieve the proper executable path location.