### PR TITLE
cmake: define _DEBUG for Debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,10 @@ else()
     add_definitions(-DUSE_OPENGLES_10)
 endif()
 
+# Enable additional defines for the Debug build configuration
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -D_DEBUG")
+
 #-------------------------------------------------------------------------------
 #add include directories
 set(COMMON_INCLUDE_DIRS

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ cmake .
 make
 ```
 
+NOTE: to generate a `Debug` build on Unix/Linux, run the Makefile generation step as:
+```bash
+cmake -DCMAKE_BUILD_TYPE=Debug .
+```
+
 **On the Raspberry Pi:**
 
 Complete Raspberry Pi build instructions at [emulationstation.org](http://emulationstation.org/gettingstarted.html#install_rpi_standalone).


### PR DESCRIPTION
Added the `_DEBUG` preprocessor define when generating a Debug build and updated the instructions for how to produce such build on Unix/Linux. 
Note that when the `cmake` generator supports multiple build profiles (like the MSVC generators), the _Debug_ profile will include the define automatically.

For now, it's used only by @tomaz82 in the upcoming renderer(s) refactoring (like #626).