### PR TITLE
Update TheGamesDB API URL to include "v1"

### DIFF
--- a/es-app/src/scrapers/GamesDBJSONScraper.cpp
+++ b/es-app/src/scrapers/GamesDBJSONScraper.cpp
@@ -103,7 +103,7 @@ void thegamesdb_generate_json_scraper_requests(const ScraperSearchParams& params
 	std::queue<std::unique_ptr<ScraperRequest>>& requests, std::vector<ScraperSearchResult>& results)
 {
 	resources.prepare();
-	std::string path = "https://api.thegamesdb.net";
+	std::string path = "https://api.thegamesdb.net/v1";
 	bool usingGameID = false;
 	const std::string apiKey = std::string("apikey=") + resources.getApiKey();
 	std::string cleanName = params.nameOverride;

--- a/es-app/src/scrapers/GamesDBJSONScraperResources.cpp
+++ b/es-app/src/scrapers/GamesDBJSONScraperResources.cpp
@@ -153,7 +153,7 @@ bool TheGamesDBJSONRequestResources::saveResource(HttpReq* req, std::unordered_m
 
 std::unique_ptr<HttpReq> TheGamesDBJSONRequestResources::fetchResource(const std::string& endpoint)
 {
-	std::string path = "https://api.thegamesdb.net";
+	std::string path = "https://api.thegamesdb.net/v1";
 	path += endpoint;
 	path += "?apikey=" + getApiKey();
 


### PR DESCRIPTION
Updates TheGamesDB API URL hard-coded within two scraper files to include "v1" within the path per note by Zer0xFF at https://forums.thegamesdb.net/viewtopic.php?f=5&t=1223

> for now, we're using a READ ONLY old backup, and the API is also back online,
> but using the prefix /v1/ which is both to get devs to explicitly make sure old data doesn't just crash their apps,
> but this prefix will remain as our main endpoint for this api going forward (aka once latest backup is restored)