### PR TITLE
InputManager: replace pageUp/Down with left/rightShoulder

### DIFF
--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -269,20 +269,20 @@ bool TextListComponent<T>::input(InputConfig* config, Input input)
 				listInput(-1);
 				return true;
 			}
-			if(config->isMappedTo("pagedown", input))
+			if(config->isMappedLike("rightshoulder", input))
 			{
 				listInput(10);
 				return true;
 			}
 
-			if(config->isMappedTo("pageup", input))
+			if(config->isMappedLike("leftshoulder", input))
 			{
 				listInput(-10);
 				return true;
 			}
 		}else{
 			if(config->isMappedLike("down", input) || config->isMappedLike("up", input) ||
-				config->isMappedTo("pagedown", input) || config->isMappedTo("pageup", input))
+				config->isMappedLike("rightshoulder", input) || config->isMappedTo("leftshoulder", input))
 			{
 				stopScrolling();
 			}

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -94,12 +94,12 @@ void GridGameListView::setCursor(FileData* file)
 
 std::string GridGameListView::getQuickSystemSelectRightButton()
 {
-	return "pagedown"; //rightshoulder
+	return "rightshoulder";
 }
 
 std::string GridGameListView::getQuickSystemSelectLeftButton()
 {
-	return "pageup"; //leftshoulder
+	return "leftshoulder";
 }
 
 bool GridGameListView::input(InputConfig* config, Input input)

--- a/es-core/src/InputConfig.cpp
+++ b/es-core/src/InputConfig.cpp
@@ -122,6 +122,10 @@ bool InputConfig::isMappedLike(const std::string& name, Input input)
 		return isMappedTo("up", input) || isMappedTo("leftanalogup", input) || isMappedTo("rightanalogup", input);
 	}else if(name == "down"){
 		return isMappedTo("down", input) || isMappedTo("leftanalogdown", input) || isMappedTo("rightanalogdown", input);
+	}else if(name == "leftshoulder"){
+		return isMappedTo("leftshoulder", input) || isMappedTo("pageup", input);
+	}else if(name == "rightshoulder"){
+		return isMappedTo("rightshoulder", input) || isMappedTo("pagedown", input);
 	}
 	return isMappedTo(name, input);
 }

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -328,8 +328,8 @@ void InputManager::loadDefaultKBConfig()
 	cfg->mapInput("start", Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_F1, 1, true));
 	cfg->mapInput("select", Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_F2, 1, true));
 
-	cfg->mapInput("pageup", Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_RIGHTBRACKET, 1, true));
-	cfg->mapInput("pagedown", Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_LEFTBRACKET, 1, true));
+	cfg->mapInput("leftshoulder", Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_LEFTBRACKET, 1, true));
+	cfg->mapInput("rightshoulder", Input(DEVICE_KEYBOARD, TYPE_KEY, SDLK_RIGHTBRACKET, 1, true));
 }
 
 void InputManager::writeDeviceConfig(InputConfig* config)

--- a/es-core/src/components/ComponentList.cpp
+++ b/es-core/src/components/ComponentList.cpp
@@ -80,10 +80,10 @@ bool ComponentList::input(InputConfig* config, Input input)
 	{
 		return listInput(input.value != 0 ? 1 : 0);
 
-	}else if(config->isMappedTo("pageup", input))
+	}else if(config->isMappedLike("leftshoulder", input))
 	{
 		return listInput(input.value != 0 ? -6 : 0);
-	}else if(config->isMappedTo("pagedown", input)){
+	}else if(config->isMappedLike("rightshoulder", input)){
 		return listInput(input.value != 0 ? 6 : 0);
 	}
 

--- a/es-core/src/components/DateTimeEditComponent.cpp
+++ b/es-core/src/components/DateTimeEditComponent.cpp
@@ -53,9 +53,9 @@ bool DateTimeEditComponent::input(InputConfig* config, Input input)
 		}
 
 		int incDir = 0;
-		if(config->isMappedLike("up", input) || config->isMappedTo("pageup", input))
+		if(config->isMappedLike("up", input) || config->isMappedLike("leftshoulder", input))
 			incDir = 1;
-		else if(config->isMappedLike("down", input) || config->isMappedTo("pagedown", input))
+		else if(config->isMappedLike("down", input) || config->isMappedLike("rightshoulder", input))
 			incDir = -1;
 
 		if(incDir != 0)


### PR DESCRIPTION
Create an alias (via `isMappedLike`) to accomodate existing configs that use the PageUp/Down buttons (should function as an alternative to https://github.com/RetroPie/EmulationStation/pull/562).

The RetroPie-Setup scripts map left/rightShoulder as `pageup`/`pagedown`, see [the mapping script](https://github.com/RetroPie/RetroPie-Setup/blob/595b09a9b44668727461da748382976dc8dc6b74/scriptmodules/supplementary/emulationstation/configscripts/emulationstation.sh#L50-L54), while EmulationStation maps them (natively) as `left` or `righshoulder`. 
To accomodate both, use `isMappedLike`, so existing RetroPie generated configs will work. In the future, we can replace the mapping produced by [emulationstation.sh](https://github.com/RetroPie/RetroPie-Setup/blob/master/scriptmodules/supplementary/emulationstation/configscripts/emulationstation.sh) to get rid of `pageUp/pageDown` if the input is a gamepad (and not a keyboard).