### PR TITLE
Added option to disable video screensaver audio on VLC and OMXPlayer

### DIFF
--- a/es-app/src/guis/GuiVideoScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiVideoScreensaverOptions.cpp
@@ -63,6 +63,11 @@ GuiVideoScreensaverOptions::GuiVideoScreensaverOptions(Window* window, const cha
 		Settings::getInstance()->setInt("SubtitleSize", subSize);
 	});
 
+	auto ss_video_mute = std::make_shared<SwitchComponent>(mWindow);
+	ss_video_mute->setState(Settings::getInstance()->getBool("ScreenSaverVideoMute"));
+	addWithLabel("MUTE SCREENSAVER AUDIO", ss_video_mute);
+	addSaveFunc([ss_video_mute] { Settings::getInstance()->setBool("ScreenSaverVideoMute", ss_video_mute->getState()); });
+
 	// Define subtitle font
 	auto ss_omx_font_file = std::make_shared<TextComponent>(mWindow, "", Font::get(FONT_SIZE_SMALL), 0x777777FF);
 	addEditableTextComponent(row, "PATH TO FONT FILE", ss_omx_font_file, Settings::getInstance()->getString("SubtitleFont"));

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -128,6 +128,7 @@ void Settings::setDefaults()
 	mIntMap["ScreenSaverSwapVideoTimeout"] = 30000;
 
 	mBoolMap["VideoAudio"] = true;
+	mBoolMap["ScreenSaverVideoMute"] = false;
 	mBoolMap["CaptionsCompatibility"] = true;
 	// Audio out device for Video playback using OMX player.
 	mStringMap["OMXAudioDev"] = "both";

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -162,7 +162,8 @@ void VideoPlayerComponent::startVideo()
 				const char* argv[] = { "", "--layer", "10010", "--loop", "--no-osd", "--aspect-mode", "letterbox", "--vol", "0", "-o", "both","--win", buf1, "--orientation", buf2, "", "", "", "", "", "", "", "", "", "", "", NULL };
 
 				// check if we want to mute the audio
-				if (!Settings::getInstance()->getBool("VideoAudio") || (float)VolumeControl::getInstance()->getVolume() == 0)
+				if ((!Settings::getInstance()->getBool("VideoAudio") || (float)VolumeControl::getInstance()->getVolume() == 0) ||
+					(Settings::getInstance()->getBool("ScreenSaverVideoMute") && mScreensaverMode))
 				{
 					argv[8] = "-1000000";
 				}

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -220,7 +220,8 @@ void VideoVlcComponent::handleLooping()
 		libvlc_state_t state = libvlc_media_player_get_state(mMediaPlayer);
 		if (state == libvlc_Ended)
 		{
-			if (!Settings::getInstance()->getBool("VideoAudio"))
+			if (!Settings::getInstance()->getBool("VideoAudio") ||
+				(Settings::getInstance()->getBool("ScreenSaverVideoMute") && mScreensaverMode))
 			{
 				libvlc_audio_set_mute(mMediaPlayer, 1);
 			}
@@ -295,7 +296,8 @@ void VideoVlcComponent::startVideo()
 					// Setup the media player
 					mMediaPlayer = libvlc_media_player_new_from_media(mMedia);
 
-					if (!Settings::getInstance()->getBool("VideoAudio"))
+					if (!Settings::getInstance()->getBool("VideoAudio") ||
+						(Settings::getInstance()->getBool("ScreenSaverVideoMute") && mScreensaverMode))
 					{
 						libvlc_audio_set_mute(mMediaPlayer, 1);
 					}


### PR DESCRIPTION
- Added option to mute video screensaver audio for both VLC and OMXPlayer.
- Default should be "ON" as it has been so far.
- It should respect general audio settings.