### PR TITLE
Fix rotation for OMX Player

### DIFF
--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -118,7 +118,7 @@ void VideoPlayerComponent::startVideo()
 
 					case 1:
 					{
-						const int x1 = (int)(Renderer::getScreenWidth() - Renderer::getScreenOffsetY() - y - mSize.y());
+						const int x1 = (int)(Renderer::getWindowWidth() - Renderer::getScreenOffsetY() - y - mSize.y());
 						const int y1 = (int)(Renderer::getScreenOffsetX() + x);
 						const int x2 = (int)(x1 + mSize.y());
 						const int y2 = (int)(y1 + mSize.x());
@@ -128,8 +128,8 @@ void VideoPlayerComponent::startVideo()
 
 					case 2:
 					{
-						const int x1 = (int)(Renderer::getScreenWidth()  - Renderer::getScreenOffsetX() - x - mSize.x());
-						const int y1 = (int)(Renderer::getScreenHeight() - Renderer::getScreenOffsetY() - y - mSize.y());
+						const int x1 = (int)(Renderer::getWindowWidth()  - Renderer::getScreenOffsetX() - x - mSize.x());
+						const int y1 = (int)(Renderer::getWindowHeight() - Renderer::getScreenOffsetY() - y - mSize.y());
 						const int x2 = (int)(x1 + mSize.x());
 						const int y2 = (int)(y1 + mSize.y());
 						sprintf(buf1, "%d,%d,%d,%d", x1, y1, x2, y2);
@@ -139,7 +139,7 @@ void VideoPlayerComponent::startVideo()
 					case 3:
 					{
 						const int x1 = (int)(Renderer::getScreenOffsetY() + y);
-						const int y1 = (int)(Renderer::getScreenHeight() - Renderer::getScreenOffsetX() - x - mSize.x());
+						const int y1 = (int)(Renderer::getWindowHeight() - Renderer::getScreenOffsetX() - x - mSize.x());
 						const int x2 = (int)(x1 + mSize.y());
 						const int y2 = (int)(y1 + mSize.x());
 						sprintf(buf1, "%d,%d,%d,%d", x1, y1, x2, y2);


### PR DESCRIPTION
Should address #649 .

@tomaz82 - This seems to work correctly now on the Pi4, at least. I do recall us testing things out back in the day, so I'm not sure if it's something that changed between OS updates or just something that I missed back then.

Since it's OMXPlayer related, this would only apply on the Pi. If anyone can test this on a Pi3 prior to the latest Buster images, I'd appreciate it as I don't have one anymore. Otherwise, should be good to go.