### PR TITLE
cmake: add GLES20 renderer build support

### DIFF
--- a/CMake/Packages/FindOpenGLES.cmake
+++ b/CMake/Packages/FindOpenGLES.cmake
@@ -1,101 +1,48 @@
-#snapped from: https://bitbucket.org/sinbad/ogre/src/0bba4f7cdb95/CMake/Packages/FindOpenGLES.cmake?at=default
-#-------------------------------------------------------------------
-# This file is part of the CMake build system for OGRE
-#     (Object-oriented Graphics Rendering Engine)
-# For the latest info, see http://www.ogre3d.org/
-#
-# The contents of this file are placed in the public domain. Feel
-# free to make use of it in any way you like.
-#-------------------------------------------------------------------
-
 # - Try to find OpenGLES
 # Once done this will define
 #  
 #  OPENGLES_FOUND        - system has OpenGLES
-#  OPENGLES_INCLUDE_DIR  - the GL include directory
+#  OPENGLES_INCLUDE_DIRS  - the GL include directory
 #  OPENGLES_LIBRARIES    - Link these to use OpenGLES
 
-IF (WIN32)
-  IF (CYGWIN)
+if(NOT HINT_GLES_LIBNAME)
+ set(HINT_GLES_LIBNAME GLESv1_CM)
+endif()
 
-    FIND_PATH(OPENGLES_INCLUDE_DIR GLES/gl.h )
-
-    FIND_LIBRARY(OPENGLES_gl_LIBRARY libgles_cm )
-
-  ELSE (CYGWIN)
-
-    IF(MSVC)
-      #The user hast to provide this atm. GLES can be emulated via Desktop OpenGL
+if (WIN32)
+    if(CYGWIN)
+        find_path(OPENGLES_INCLUDE_DIR GLES/gl.h )
+        find_library(OPENGLES_gl_LIBRARY libgles_cm )
+  else(CYGWIN)
+    if(MSVC)
+      #The user has to provide this atm. GLES can be emulated via Desktop OpenGL
       #using the ANGLE project found at: http://code.google.com/p/angleproject/
       SET (OPENGLES_gl_LIBRARY import32 CACHE STRING "OpenGL ES 1.x library for win32")
-    ENDIF(MSVC)
-
-  ENDIF (CYGWIN)
-
-ELSE (WIN32)
-
-  IF (APPLE)
-
-        create_search_paths(/Developer/Platforms)
-        findpkg_framework(OpenGLES)
+    endif(MSVC)
+endif(CYGWIN)
+elseif(APPLE)
+    create_search_paths(/Developer/Platforms)
+    findpkg_framework(OpenGLES)
     set(OPENGLES_gl_LIBRARY "-framework OpenGLES")
+else()
+    find_path(OPENGLES_INCLUDE_DIR GLES/gl.h
+              PATHS "${CMAKE_FIND_ROOT_PATH}/usr/include"
+              HINTS "${HINT_GLES_INCDIR}"
+    )
 
-  ELSE(APPLE)
+    find_library(OPENGLES_gl_LIBRARY
+        NAMES ${HINT_GLES_LIBNAME}
+        HINTS "${HINT_GLES_LIBDIR}"
+    )
+endif(WIN32)
 
-    IF (DEFINED BCMHOST)
-      FIND_PATH(OPENGLES_INCLUDE_DIR GLES/gl.h
-        /opt/vc/include
-        NO_DEFAULT_PATH
-      )
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OpenGLES
+    REQUIRED_VARS OPENGLES_gl_LIBRARY OPENGLES_INCLUDE_DIR)
 
-      FIND_LIBRARY(OPENGLES_gl_LIBRARY
-        NAMES brcmGLESv2
-        PATHS /opt/vc/lib
-      )
 
-    ELSE (DEFINED BCMHOST)
-
-      FIND_PATH(OPENGLES_INCLUDE_DIR GLES/gl.h
-        /usr/openwin/share/include
-        /opt/graphics/OpenGL/include /usr/X11R6/include
-        /usr/include
-      )
-
-      FIND_LIBRARY(OPENGLES_gl_LIBRARY
-        NAMES GLES_CM GLESv1_CM
-        PATHS /opt/graphics/OpenGL/lib
-              /usr/openwin/lib
-              /usr/shlib /usr/X11R6/lib
-              /usr/lib
-      )
-    ENDIF (DEFINED BCMHOST)
-
-    # On Unix OpenGL most certainly always requires X11.
-    # Feel free to tighten up these conditions if you don't 
-    # think this is always true.
-
-    IF (OPENGLES_gl_LIBRARY)
-      IF(NOT X11_FOUND)
-        INCLUDE(FindX11)
-      ENDIF(NOT X11_FOUND)
-      IF (X11_FOUND)
-        SET (OPENGLES_LIBRARIES ${X11_LIBRARIES})
-      ENDIF (X11_FOUND)
-    ENDIF (OPENGLES_gl_LIBRARY)
-
-  ENDIF(APPLE)
-ENDIF (WIN32)
-
-SET( OPENGLES_FOUND "NO" )
-IF(OPENGLES_gl_LIBRARY)
-
-    SET( OPENGLES_LIBRARIES ${OPENGLES_gl_LIBRARY} ${OPENGLES_LIBRARIES})
-
-    SET( OPENGLES_FOUND "YES" )
-
-ENDIF(OPENGLES_gl_LIBRARY)
-
-MARK_AS_ADVANCED(
-  OPENGLES_INCLUDE_DIR
-  OPENGLES_gl_LIBRARY
-)
+if(OPENGLES_FOUND)
+    set(OPENGLES_LIBRARIES ${OPENGLES_gl_LIBRARY})
+    set(OPENGLES_INCLUDE_DIRS ${OPENGLES_INCLUDE_DIR})
+    mark_as_advanced(OPENGLES_INCLUDE_DIR OPENGLES_gl_LIBRARY)
+endif()

--- a/CMake/Packages/FindOpenGLES2.cmake
+++ b/CMake/Packages/FindOpenGLES2.cmake
@@ -1,0 +1,35 @@
+# FindOpenGLES
+# ------------
+# Finds the OpenGLES2 library
+#
+# This will define the following variables::
+#
+# OPENGLES2_FOUND - system has OpenGLES
+# OPENGLES2_INCLUDE_DIRS - the OpenGLES include directory
+# OPENGLES2_LIBRARIES - the OpenGLES libraries
+
+if(NOT HINT_GLES_LIBNAME)
+ set(HINT_GLES_LIBNAME GLESv2)
+endif()
+
+find_path(OPENGLES2_INCLUDE_DIR GLES2/gl2.h
+    PATHS "${CMAKE_FIND_ROOT_PATH}/usr/include"
+    HINTS ${HINT_GLES_INCDIR}
+)
+
+find_library(OPENGLES2_gl_LIBRARY
+    NAMES ${HINT_GLES_LIBNAME}
+    HINTS ${HINT_GLES_LIBDIR}
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OpenGLES2
+            REQUIRED_VARS OPENGLES2_gl_LIBRARY OPENGLES2_INCLUDE_DIR)
+
+
+if(OPENGLES2_FOUND)
+    set(OPENGLES2_LIBRARIES ${OPENGLES2_gl_LIBRARY})
+    set(OPENGLES2_INCLUDE_DIRS ${OPENGLES2_INCLUDE_DIR})
+    mark_as_advanced(OPENGLES2_INCLUDE_DIR OPENGLES2_gl_LIBRARY)
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,17 @@ cmake_minimum_required(VERSION 2.8)
 
 option(GLES "Set to ON if targeting Embedded OpenGL" ${GLES})
 option(GL "Set to ON if targeting Desktop OpenGL" ${GL})
-option(RPI "Set to ON to enable the Raspberry PI video player (omxplayer)" ${RPI})
+option(RPI "Set to ON to enable the Raspberry PI video player (omxplayer) and audio options" ${RPI})
 option(CEC "Set to ON to enable CEC" ${CEC})
+
+# GLES implementation overrides
+option(USE_MESA_GLES "Set to ON to select the MESA OpenGL ES driver" ${USE_MESA_GLES})
+option(USE_GLES1 "Set to ON to force usage of the OpenGLES v1 renderer" ${USE_GLES1})
+
+# OpenGL library preference (https://cmake.org/cmake/help/git-stage/policy/CMP0072.html)
+if(POLICY CMP0072)
+   cmake_policy(SET CMP0072 NEW)
+endif()
 
 project(emulationstation-all)
 
@@ -14,46 +23,67 @@ LIST(APPEND CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_SOURCE_DIR}/CMake/Packages
 )
 
-#-------------------------------------------------------------------------------
+# default GLES2/GLES library, can be overriden depending on platform
+set(HINT_GLES_LIBNAME GLESv2)
+
 #set up OpenGL system variable
 if(GLES)
     set(GLSystem "Embedded OpenGL" CACHE STRING "The OpenGL system to be used")
 elseif(GL)
     set(GLSystem "Desktop OpenGL" CACHE STRING "The OpenGL system to be used")
-#-------------------------------------------------------------------------------
-#check if we're running on Raspberry Pi
+
+# check if the MESA GLES library is requested
+elseif(USE_MESA_GLES)
+    set(GLSystem "Embedded OpenGL" CACHE STRING "The OpenGL system to be used")
+
+#check if we're running on Raspberry Pi (legacy drivers)
 elseif(EXISTS "${CMAKE_FIND_ROOT_PATH}/opt/vc/include/bcm_host.h")
-    MESSAGE("bcm_host.h found")
     set(BCMHOST found)
     set(GLSystem "Embedded OpenGL" CACHE STRING "The OpenGL system to be used")
-#-------------------------------------------------------------------------------
-#check if we're running on OSMC Vero4K
+    set(HINT_GLES_INCDIR "/opt/vc/include")
+    set(HINT_GLES_LIBDIR "/opt/vc/lib")
+    set(HINT_GLES_LIBNAME brcmGLESv2)
+    set(GLES_EXTRA_LIBRARIES bcm_host)
+
+#check if we're running on OSMC Vero4K[+]
 elseif(EXISTS "${CMAKE_FIND_ROOT_PATH}/opt/vero3/lib/libMali.so")
-    MESSAGE("libMali.so found")
     set(VERO4K found)
+    add_definitions(-D_VERO4K_)
     set(GLSystem "Embedded OpenGL" CACHE STRING "The OpenGL system to be used")
-#-------------------------------------------------------------------------------
+    set(HINT_GLES_INCDIR "/opt/vero3/include")
+    set(HINT_GLES_LIBDIR "/opt/vero3/lib")
+    set(HINT_GLES_LIBNAME Mali)
+    set(GLES_EXTRA_LIBRARIES EGL)
+
 #check if we're running on olinuxino / odroid / etc
-elseif(EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/libMali.so" OR
-    EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/arm-linux-gnueabihf/libMali.so" OR
-    EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/aarch64-linux-gnu/libMali.so" OR
-    EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/arm-linux-gnueabihf/mali-egl/libmali.so" OR
-    EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/arm-linux-gnueabihf/libmali.so")
-    MESSAGE("libMali.so found")
+elseif(EXISTS "${CMAKE_FIND_ROOT_PATH}/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}/libMali.so")
     set(GLSystem "Embedded OpenGL" CACHE STRING "The OpenGL system to be used")
+    set(HINT_GLES_LIBNAME Mali)
+
 else()
     set(GLSystem "Desktop OpenGL" CACHE STRING "The OpenGL system to be used")
 endif(GLES)
 
 set_property(CACHE GLSystem PROPERTY STRINGS "Desktop OpenGL" "Embedded OpenGL")
 
-#finding necessary packages
-#-------------------------------------------------------------------------------
 if(${GLSystem} MATCHES "Desktop OpenGL")
     find_package(OpenGL REQUIRED)
+    add_definitions(-DUSE_OPENGL_14)
 else()
-    find_package(OpenGLES REQUIRED)
+    if(NOT USE_GLES1)
+      find_package(OpenGLES2 QUIET REQUIRED)
+      message(STATUS "Found GLESv2: ${OPENGLES2_LIBRARIES}")
+      set(OPENGLES_LIBRARIES ${OPENGLES2_LIBRARIES})
+      set(OPENGLES_INCLUDE_DIRS ${OPENGLES2_INCLUDE_DIRS})
+      add_definitions(-DUSE_OPENGLES_20)
+    else()
+      set(HINT_GLES_LIBNAME GLESv1_CM)
+      find_package(OpenGLES QUIET REQUIRED)
+      message(STATUS "Found GLES: ${OPENGLES_LIBRARIES}")
+      add_definitions(-DUSE_OPENGLES_10)
+    endif()
 endif()
+
 find_package(Freetype REQUIRED)
 find_package(FreeImage REQUIRED)
 find_package(SDL2 REQUIRED)
@@ -77,10 +107,6 @@ if(DEFINED BCMHOST OR RPI)
     add_definitions(-D_RPI_)
 endif()
 
-if(DEFINED VERO4K)
-    add_definitions(-D_VERO4K_)
-endif()
-
 if(DEFINED libCEC_FOUND)
     add_definitions(-DHAVE_LIBCEC)
 endif()
@@ -94,6 +120,9 @@ if(MSVC)
     add_definitions(-DNOMINMAX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP") #multi-processor compilation
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP") #multi-processor compilation
+
+    # Set the start-up project to in VS to 'emulationstation'
+    set(VS_STARTUP_PROJECT "emulationstation")
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX)
@@ -104,24 +133,19 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     endif()
 
     #set up compiler flags for GCC
-if (CMAKE_BUILD_TYPE MATCHES Debug)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-attributes -O0") #support C++11 for std::, optimize
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O0")
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-attributes -O2") #support C++11 for std::, optimize
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O2")  #-s = strip binary
+    if (CMAKE_BUILD_TYPE MATCHES Debug)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-attributes -O0") #support C++11 for std::, optimize
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O0")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-attributes -O2") #support C++11 for std::, optimize
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O2")  #-s = strip binary
 endif()
-endif()
-
-if(${GLSystem} MATCHES "Desktop OpenGL")
-    add_definitions(-DUSE_OPENGL_14)
-else()
-    add_definitions(-DUSE_OPENGLES_10)
 endif()
 
 # Enable additional defines for the Debug build configuration
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -D_DEBUG")
+
 
 #-------------------------------------------------------------------------------
 #add include directories
@@ -135,6 +159,16 @@ set(COMMON_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/external
     ${CMAKE_CURRENT_SOURCE_DIR}/es-core/src
 )
+
+if(${GLSystem} MATCHES "Desktop OpenGL")
+        LIST(APPEND COMMON_INCLUDE_DIRS
+            ${OPENGL_INCLUDE_DIRS}
+        )
+else()
+        LIST(APPEND COMMON_INCLUDE_DIRS
+            ${OPENGLES_INCLUDE_DIRS}
+        )
+endif()
 
 #add libCEC_INCLUDE_DIR
 if(DEFINED libCEC_FOUND)
@@ -150,41 +184,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     )
 endif()
 
-if(DEFINED BCMHOST)
-    LIST(APPEND COMMON_INCLUDE_DIRS
-        "${CMAKE_FIND_ROOT_PATH}/opt/vc/include"
-        "${CMAKE_FIND_ROOT_PATH}/opt/vc/include/interface/vcos"
-        "${CMAKE_FIND_ROOT_PATH}/opt/vc/include/interface/vmcs_host/linux"
-        "${CMAKE_FIND_ROOT_PATH}/opt/vc/include/interface/vcos/pthreads"
-    )
-#add include directory for Vero4K
-elseif(DEFINED VERO4K)
-    LIST(APPEND COMMON_INCLUDE_DIRS
-        "${CMAKE_FIND_ROOT_PATH}/opt/vero3/include"
-    )
-else()
-    if(${GLSystem} MATCHES "Desktop OpenGL")
-        LIST(APPEND COMMON_INCLUDE_DIRS
-            ${OPENGL_INCLUDE_DIR}
-        )
-    else()
-        LIST(APPEND COMMON_INCLUDE_DIRS
-            ${OPENGLES_INCLUDE_DIR}
-        )
-    endif()
-endif()
-
 #-------------------------------------------------------------------------------
 #define libraries and directories
-if(DEFINED BCMHOST)
-    link_directories(
-        "${CMAKE_FIND_ROOT_PATH}/opt/vc/lib"
-    )
-elseif(DEFINED VERO4K)
-    link_directories(
-        "${CMAKE_FIND_ROOT_PATH}/opt/vero3/lib"
-    )
-endif()
 
 set(COMMON_LIBRARIES
     ${FREETYPE_LIBRARIES}
@@ -216,34 +217,26 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     )
 endif()
 
-if(DEFINED BCMHOST)
+if(MSVC)
     LIST(APPEND COMMON_LIBRARIES
-        bcm_host
-        brcmEGL
-        ${OPENGLES_LIBRARIES}
+        winmm
     )
-elseif(DEFINED VERO4K)
+endif()
+
+if(DEFINED HINT_GLES_LIBDIR)
+    link_directories("${HINT_GLES_LIBDIR}")
+endif()
+
+if(${GLSystem} MATCHES "Desktop OpenGL")
     LIST(APPEND COMMON_LIBRARIES
-        EGL
-        ${OPENGLES_LIBRARIES}
+        ${OPENGL_LIBRARIES}
     )
 else()
-    if(MSVC)
-        LIST(APPEND COMMON_LIBRARIES
-            winmm
-        )
-    endif()
-    if(${GLSystem} MATCHES "Desktop OpenGL")
-        LIST(APPEND COMMON_LIBRARIES
-            ${OPENGL_LIBRARIES}
-        )
-    else()
-        LIST(APPEND COMMON_LIBRARIES
-            EGL
-            ${OPENGLES_LIBRARIES}
-        )
-    endif()
+    LIST(APPEND COMMON_LIBRARIES
+        ${OPENGLES_LIBRARIES} ${GLES_EXTRA_LIBRARIES}
+    )
 endif()
+
 
 #-------------------------------------------------------------------------------
 # set up build directories

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ EmulationStation is a cross-platform graphical front-end for emulators with cont
 Building
 ========
 
+**Building on Linux**
+
 EmulationStation uses some C++11 code, which means you'll need to use at least g++-4.7 on Linux, or VS2010 on Windows, to compile.
 
 EmulationStation has a few dependencies. For building, you'll need CMake, SDL2, FreeImage, FreeType, cURL and RapidJSON.  You also should probably install the `fonts-droid` package which contains fallback fonts for Chinese/Japanese/Korean characters, but ES will still work fine without it (this package is only used at run-time).
@@ -15,7 +17,7 @@ EmulationStation has a few dependencies. For building, you'll need CMake, SDL2, 
 All of this be easily installed with `apt-get`:
 ```bash
 sudo apt-get install libsdl2-dev libfreeimage-dev libfreetype6-dev libcurl4-openssl-dev rapidjson-dev \
-  libasound2-dev libgl1-mesa-dev build-essential cmake fonts-droid-fallback libvlc-dev \
+  libasound2-dev libgles2-mesa-dev build-essential cmake fonts-droid-fallback libvlc-dev \
   libvlccore-dev vlc-bin
 ```
 **On Fedora:**
@@ -26,7 +28,7 @@ sudo dnf install SDL2-devel freeimage-devel freetype-devel curl-devel \
   vlc-devel rapidjson-devel 
 ```
 
-Note this Repository uses a git submodule - to checkout the source and all submodules, use
+**Note**: this repository uses a git submodule - to checkout the source and all submodules, use
 
 ```bash
 git clone --recursive https://github.com/RetroPie/EmulationStation.git
@@ -52,11 +54,20 @@ NOTE: to generate a `Debug` build on Unix/Linux, run the Makefile generation ste
 cmake -DCMAKE_BUILD_TYPE=Debug .
 ```
 
-**On the Raspberry Pi:**
+**On the Raspberry Pi**  
 
-Complete Raspberry Pi build instructions at [emulationstation.org](http://emulationstation.org/gettingstarted.html#install_rpi_standalone).
+* Choosing a GLES implementation.
 
-**On Windows:**
+   * if the Pi system uses the legacy/Broadcom driver, install the `libraspberry-dev` package before running `cmake` to configure the build
+   * if the Pi system uses the Mesa VC3/V3D GL driver, build using `-DUSE_MESA_GLES=On` to choose the MESA GLES implementation. This option is _mandatory_ when compiling for a Pi4 system, since the legacy GL drivers are not supported anymore on this system.
+
+* Support for using `omxplayer` to play video previews in the gamelist is enabled by adding `-DRPI=On` to the build options
+
+**GLES build notes**
+
+ If your system doesn't have a working GLESv2 implementation, the GLESv1 legacy renderer can be compiled in by adding `-DUSE_GLES1=On` to the build options.
+
+**Building on Windows**
 
 [FreeImage](http://downloads.sourceforge.net/freeimage/FreeImage3154Win32.zip)
 


### PR DESCRIPTION
Added support for the GLESv2 renderer to the CMake build (added in https://github.com/RetroPie/EmulationStation/pull/642 by @tomaz82).

* Refactored the OpenGLES detection for both versions. Platform detection is done only in the main project file, settings hints (includes/libaries) for the GLES detection in the corresponding 'Find' cmake modules from `CMake/Packages`.
* Simplified the `FindGLES.cmake`, based on platform detection.
* Added building notes for the Raspberry Pi to _README.md_, the information from Aloshi's page is incomplete.

**Notes**:
* GLESv2 has been set as default for GLES-enabled systems.
* For the Raspberry Pi systems, both the legacy (BRCM) and the new (MESA) GLES libraries can be present (defaults to the legacy drivers). 
Selecting between them can be done via the `USE_MESA_GLES` CMake option (default: _Off_)

  For the Pi4, the GL renderer/system can be chosen from:
   - the OpenGL 2 renderer with `-DGL=On` (like it's currently set in the RetroPie scripst)
   -  the GLESv2 renderer with `-DUSE_MESA_GLES=On`

* the GLESv1 renderer can still be forcibly enabled using the `FORCE_GLESv1` build option, for platforms where GLESv1 is the only option (or GLESv2 is buggy).

Minor - set the start-up project in MS Visual Studio to _emulationstation_ so you don't have to switch to start debugging.

**NB**: testing will require including https://github.com/RetroPie/EmulationStation/pull/642 to the source, otherwise linking will fail.

Would probably supercede https://github.com/RetroPie/EmulationStation/pull/642.