### PR TITLE
Audio menu: adjust mixer and OMX sound output options

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -103,12 +103,6 @@ void GuiMenu::openSoundSettings()
 		// audio card
 		auto audio_card = std::make_shared< OptionListComponent<std::string> >(mWindow, "AUDIO CARD", false);
 		std::vector<std::string> audio_cards;
-	#ifdef _RPI_
-		// RPi Specific  Audio Cards
-		audio_cards.push_back("local");
-		audio_cards.push_back("hdmi");
-		audio_cards.push_back("both");
-	#endif
 		audio_cards.push_back("default");
 		audio_cards.push_back("sysdefault");
 		audio_cards.push_back("dmix");
@@ -133,6 +127,8 @@ void GuiMenu::openSoundSettings()
 		auto vol_dev = std::make_shared< OptionListComponent<std::string> >(mWindow, "AUDIO DEVICE", false);
 		std::vector<std::string> transitions;
 		transitions.push_back("PCM");
+		transitions.push_back("HDMI");
+		transitions.push_back("Headphone");
 		transitions.push_back("Speaker");
 		transitions.push_back("Master");
 		transitions.push_back("Digital");
@@ -180,6 +176,7 @@ void GuiMenu::openSoundSettings()
 		omx_cards.push_back("local");
 		omx_cards.push_back("hdmi");
 		omx_cards.push_back("both");
+		omx_cards.push_back("alsa");
 		omx_cards.push_back("alsa:hw:0,0");
 		omx_cards.push_back("alsa:hw:1,0");
 		if (Settings::getInstance()->getString("OMXAudioDev") != "") {


### PR DESCRIPTION
* Added 2 new mixer options - HDMI/Headphone - which should be used when the Pi's _snd_bcm2835_ module is configured with separate ALSA devices (see https://github.com/RetroPie/RetroPie-Setup/pull/3151). Seems to be the new default configuration in Buster now.
* Added the 'alsa' output option for 'omxplayer', which enables usage of the default ALSA output device.
* Removed the _HDMI_,_local_, _both_ sound cards options, they only make sense for OMXPlayer, the default ALSA card names for the Pi are not named like that.