### PR TITLE
Fixed missing string includes needed by GCC 10

### DIFF
--- a/es-app/src/FileFilterIndex.h
+++ b/es-app/src/FileFilterIndex.h
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <vector>
+#include <string>
 
 class FileData;
 

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <vector>
+#include <string>
 
 namespace pugi { class xml_node; }
 

--- a/es-core/src/InputManager.h
+++ b/es-core/src/InputManager.h
@@ -4,6 +4,7 @@
 
 #include <SDL_joystick.h>
 #include <map>
+#include <string>
 
 class InputConfig;
 class Window;

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -3,6 +3,7 @@
 #define ES_CORE_SETTINGS_H
 
 #include <map>
+#include <string>
 
 //This is a singleton for storing settings.
 class Settings

--- a/es-core/src/Sound.h
+++ b/es-core/src/Sound.h
@@ -5,6 +5,7 @@
 #include "SDL_audio.h"
 #include <map>
 #include <memory>
+#include <string>
 
 class ThemeData;
 


### PR DESCRIPTION
Some files require to include the `<string>` header. The missing header prevents the compilation on GCC 10.1.0 . Probably with other compilers the header is implicitly included via other ones (maybe `<map>`). The proposed patch add the missing includes needed to compile without errors using GCC 10.