### PR TITLE
Fix grid hang when scrolling at max scroll speed

### DIFF
--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -86,6 +86,7 @@ private:
 	bool mLastRowPartial;
 	Vector2f mAutoLayout;
 	float mAutoLayoutZoom;
+	int mLastScrollTier;
 
 	Vector4f mPadding;
 	Vector2f mMargin;
@@ -119,6 +120,7 @@ ImageGridComponent<T>::ImageGridComponent(Window* window) : IList<ImageGridData,
 	mAutoLayout = Vector2f::Zero();
 	mAutoLayoutZoom = 1.0;
 
+	mLastScrollTier = 0;
 	mStartPosition = 0;
 
 	mEntriesDirty = true;
@@ -576,19 +578,24 @@ void ImageGridComponent<T>::updateTiles(bool ascending, bool allowAnimation, boo
 	if (!mTiles.size())
 		return;
 
-	// Stop updating the tiles at highest scroll speed
 	if (mScrollTier == 3)
 	{
-		for (int ti = 0; ti < (int)mTiles.size(); ti++)
+		// Stop updating the tiles at highest scroll speed
+		if (mLastScrollTier != 3)
 		{
-			std::shared_ptr<GridTileComponent> tile = mTiles.at(ti);
+			for (int ti = 0; ti < (int) mTiles.size(); ti++)
+			{
+				std::shared_ptr<GridTileComponent> tile = mTiles.at(ti);
 
-			tile->setSelected(false);
-			tile->setImage(mDefaultGameTexture);
-			tile->setVisible(false);
+				tile->setSelected(false);
+				tile->setImage(mDefaultGameTexture);
+				tile->setVisible(false);
+			}
 		}
+		mLastScrollTier = mScrollTier;
 		return;
 	}
+	mLastScrollTier = mScrollTier;
 
 	// Temporary store previous texture so they can't be unloaded
 	std::vector<std::shared_ptr<TextureResource>> previousTextures;


### PR DESCRIPTION
Reset all tiles only when we hit max scroll speed