### PR TITLE
Add grid view scroll sound and adjust sound theming

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -361,7 +361,12 @@ Reference
 	- A header image.  If a non-empty `path` is specified, `text name="logoText"` will be hidden and this image will be, by default, displayed roughly in its place.
 * `textlist name="gamelist"` - ALL
 	- The gamelist.  `primaryColor` is for games, `secondaryColor` is for folders.  Centered by default.
-
+* `sound name="launch"` - ALL
+	- The sound to be played when launching a game or entering a folder
+* `sound name="back"` - ALL
+	- The sound to be played when going back to system menu or exiting a folder
+* `sound name="scroll"` - ALL
+	- The sound to be played when scrolling the game list
 ---
 
 #### detailed
@@ -375,6 +380,12 @@ Reference
 	- A header image.  If a non-empty `path` is specified, `text name="logoText"` will be hidden and this image will be, by default, displayed roughly in its place.
 * `textlist name="gamelist"` - ALL
 	- The gamelist.  `primaryColor` is for games, `secondaryColor` is for folders.  Left aligned by default.
+* `sound name="launch"` - ALL
+	- The sound to be played when launching a game or entering a folder
+* `sound name="back"` - ALL
+	- The sound to be played when going back to system menu or exiting a folder
+* `sound name="scroll"` - ALL
+	- The sound to be played when scrolling the game list
 
 * Metadata
 	* Labels
@@ -424,6 +435,12 @@ Reference
 	- A header image.  If a non-empty `path` is specified, `text name="logoText"` will be hidden and this image will be, by default, displayed roughly in its place.
 * `textlist name="gamelist"` - ALL
 	- The gamelist.  `primaryColor` is for games, `secondaryColor` is for folders.  Left aligned by default.
+* `sound name="launch"` - ALL
+	- The sound to be played when launching a game or entering a folder
+* `sound name="back"` - ALL
+	- The sound to be played when going back to system menu or exiting a folder
+* `sound name="scroll"` - ALL
+	- The sound to be played when scrolling the game list
 
 * Metadata
 	* Labels
@@ -483,6 +500,12 @@ Reference
     - Note that many of the default gridtile parameters change the selected gridtile parameters if they are not explicitly set by the theme. For example, changing the background image of the default gridtile also change the background image of the selected gridtile. Refer to the gridtile documentation for more informations.
 * `gridtile name="selected"` - ALL
     - See default gridtile description right above.
+* `sound name="launch"` - ALL
+	- The sound to be played when launching a game or entering a folder
+* `sound name="back"` - ALL
+	- The sound to be played when going back to system menu or exiting a folder
+* `sound name="scroll"` - ALL
+	- The sound to be played when scrolling the game list
 
 * Metadata
 	* Labels
@@ -532,6 +555,10 @@ Reference
 	- A logo text, to be displayed system name in the system logo carousel when no logo is available.
 * `text name="systemInfo"` - ALL
 	- Displays details of the system currently selected in the carousel.
+* `sound name="launch"` - ALL
+	- The sound to be played when a system is selected
+* `sound name="scroll"` - ALL
+	- The sound to be played when scrolling the system list
 * You can use extra elements (elements with `extra="true"`) to add your own backgrounds, etc.  They will be displayed behind the carousel, and scroll relative to the carousel.
 
 
@@ -713,7 +740,7 @@ Can be created as an extra.
 * `fontPath` - type: PATH.
 * `fontSize` - type: FLOAT.
 * `scrollSound` - type: PATH.
-	- Sound that is played when the list is scrolled.
+	- **Deprecated**: Use global property `sound name="scroll"` instead. Sound that is played when the list is scrolled.
 * `alignment` - type: STRING.
 	- Valid values are "left", "center", or "right".  Controls alignment on the X axis.
 * `horizontalMargin` - type: FLOAT.

--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -390,7 +390,8 @@ void TextListComponent<T>::applyTheme(const std::shared_ptr<ThemeData>& theme, c
 	const float selectorHeight = Math::max(mFont->getHeight(1.0), (float)mFont->getSize()) * mLineSpacing;
 	setSelectorHeight(selectorHeight);
 
-	if(properties & SOUND && elem->has("scrollSound"))
+	mScrollSound = Sound::getPath(theme, view, "scroll");
+	if(mScrollSound.empty() && properties & SOUND && elem->has("scrollSound"))
 		mScrollSound = elem->get<std::string>("scrollSound");
 
 	if(properties & ALIGNMENT)

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -8,6 +8,7 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include "Window.h"
+#include "Sound.h"
 
 // buffer values for scrolling velocity (left, stopped, right)
 const int logoBuffersLeft[] = { -5, -2, -1 };
@@ -151,12 +152,14 @@ bool SystemView::input(InputConfig* config, Input input)
 		case VERTICAL_WHEEL:
 			if (config->isMappedLike("up", input))
 			{
-				listInput(-1);
+				if (listInput(-1))
+					Sound::get(mScrollSound)->play();
 				return true;
 			}
 			if (config->isMappedLike("down", input))
 			{
-				listInput(1);
+				if (listInput(1))
+					Sound::get(mScrollSound)->play();
 				return true;
 			}
 			break;
@@ -165,12 +168,14 @@ bool SystemView::input(InputConfig* config, Input input)
 		default:
 			if (config->isMappedLike("left", input))
 			{
-				listInput(-1);
+				if (listInput(-1))
+					Sound::get(mScrollSound)->play();
 				return true;
 			}
 			if (config->isMappedLike("right", input))
 			{
-				listInput(1);
+				if (listInput(1))
+					Sound::get(mScrollSound)->play();
 				return true;
 			}
 			break;
@@ -178,6 +183,7 @@ bool SystemView::input(InputConfig* config, Input input)
 
 		if(config->isMappedTo("a", input))
 		{
+			Sound::get(mLaunchSound)->play();
 			stopScrolling();
 			ViewController::get()->goToGameList(getSelected());
 			return true;
@@ -186,15 +192,18 @@ bool SystemView::input(InputConfig* config, Input input)
 		{
 			// get random system
 			// go to system
-			setCursor(SystemData::getRandomSystem());
+			if (setCursor(SystemData::getRandomSystem()))
+				Sound::get(mScrollSound)->play();
 			return true;
 		}
 	}else{
 		if(config->isMappedLike("left", input) ||
 			config->isMappedLike("right", input) ||
 			config->isMappedLike("up", input) ||
-			config->isMappedLike("down", input))
-			listInput(0);
+			config->isMappedLike("down", input)) {
+			if (listInput(0))
+				Sound::get(mScrollSound)->play();
+		}
 		if(!UIModeController::getInstance()->isUIModeKid() && config->isMappedTo("select", input) && Settings::getInstance()->getBool("ScreenSaverControls"))
 		{
 			mWindow->startScreenSaver();
@@ -418,6 +427,9 @@ void  SystemView::getViewElements(const std::shared_ptr<ThemeData>& theme)
 	const ThemeData::ThemeElement* sysInfoElem = theme->getElement("system", "systemInfo", "text");
 	if (sysInfoElem)
 		mSystemInfo.applyTheme(theme, "system", "systemInfo", ThemeFlags::ALL);
+
+	mScrollSound = Sound::getPath(theme, "system", "scroll");
+	mLaunchSound = Sound::getPath(theme, "system", "launch");
 
 	mViewNeedsReload = false;
 }

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -87,6 +87,8 @@ private:
 
 	bool mViewNeedsReload;
 	bool mShowing;
+	std::string mScrollSound;
+	std::string mLaunchSound;
 };
 
 #endif // ES_APP_VIEWS_SYSTEM_VIEW_H

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -91,6 +91,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 				// it's a folder
 				if(cursor->getChildren().size() > 0)
 				{
+					Sound::getFromTheme(getTheme(), getName(), "launch")->play();
 					mCursorStack.push(cursor);
 					populateList(cursor->getChildrenListToDisplay());
 					FileData* cursor = getCursor();
@@ -101,12 +102,12 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 			return true;
 		}else if(config->isMappedTo("b", input))
 		{
+			Sound::getFromTheme(getTheme(), getName(), "back")->play();
 			if(mCursorStack.size())
 			{
 				populateList(mCursorStack.top()->getParent()->getChildren());
 				setCursor(mCursorStack.top());
 				mCursorStack.pop();
-				Sound::getFromTheme(getTheme(), getName(), "back")->play();
 			}else{
 				onFocusLost();
 				SystemData* systemToView = getCursor()->getSystem();

--- a/es-core/src/Sound.cpp
+++ b/es-core/src/Sound.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<Sound> Sound::get(const std::string& path)
 	return sound;
 }
 
-std::shared_ptr<Sound> Sound::getFromTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element)
+const std::string Sound::getPath(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element)
 {
 	LOG(LogInfo) << " req sound [" << view << "." << element << "]";
 
@@ -27,10 +27,15 @@ std::shared_ptr<Sound> Sound::getFromTheme(const std::shared_ptr<ThemeData>& the
 	if(!elem || !elem->has("path"))
 	{
 		LOG(LogInfo) << "   (missing)";
-		return get("");
+		return "";
 	}
 
-	return get(elem->get<std::string>("path"));
+	return elem->get<std::string>("path");
+}
+
+std::shared_ptr<Sound> Sound::getFromTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element)
+{
+	return get(getPath(theme, view, element));
 }
 
 Sound::Sound(const std::string & path) : mSampleData(NULL), mSamplePos(0), mSampleLength(0), playing(false)

--- a/es-core/src/Sound.h
+++ b/es-core/src/Sound.h
@@ -20,7 +20,8 @@ class Sound
 
 public:
 	static std::shared_ptr<Sound> get(const std::string& path);
-	static std::shared_ptr<Sound> getFromTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& elem);
+	static const std::string getPath(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element);
+	static std::shared_ptr<Sound> getFromTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element);
 
 	~Sound();
 

--- a/es-core/src/components/ImageGridComponent.h
+++ b/es-core/src/components/ImageGridComponent.h
@@ -7,6 +7,7 @@
 #include "components/IList.h"
 #include "resources/TextureResource.h"
 #include "GridTileComponent.h"
+#include "Sound.h"
 
 #define EXTRAITEMS 2
 
@@ -63,6 +64,7 @@ public:
 	ImageSource	getImageSource() { return mImageSource; };
 
 protected:
+	virtual void onScroll(int /*amt*/) { if(!mScrollSound.empty()) Sound::get(mScrollSound)->play(); }
 	virtual void onCursorChanged(const CursorState& state) override;
 
 private:
@@ -91,6 +93,7 @@ private:
 	Vector2f mMargin;
 	Vector2f mTileSize;
 	Vector2i mGridDimension;
+	std::string mScrollSound;
 	std::shared_ptr<ThemeData> mTheme;
 	std::vector< std::shared_ptr<GridTileComponent> > mTiles;
 
@@ -299,6 +302,8 @@ void ImageGridComponent<T>::applyTheme(const std::shared_ptr<ThemeData>& theme, 
 			mAnimate = (elem->get<bool>("animate"));
 		else
 			mAnimate = true;
+
+		mScrollSound = Sound::getPath(theme, view, "scroll");
 
 		if (elem->has("gameImage"))
 		{


### PR DESCRIPTION
- Add scroll sound to the grid view using new syntax
- textlist property "scrollSound" is kept for backward compatibility but overrode by new syntax
- Play sounds "back" and "launch" in a more consistent way

You can test by using a modified version of @lilbud 's material theme that you can find [here](https://github.com/benjdero/es-theme-material)

The [syntax](https://github.com/benjdero/es-theme-material/commit/5293dae2e9ab2b5adf899986d09f34f1af7b6f91#diff-30690359c688abea44fc1e9f70fff9eaR274) is an extension to the existing one.

Should fix #485 and #155 and the numerous requests people did on the forum to add scroll sounds to the grid view.

Feedback would be highly appreciated