### PR TITLE
Fix #457: Load delay during gamelist processing

### DIFF
--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -15,7 +15,7 @@ FileData* findOrCreateFile(SystemData* system, const std::string& path, FileType
 	// first, verify that path is within the system's root folder
 	FileData* root = system->getRootFolder();
 	bool contains = false;
-	std::string relative = Utils::FileSystem::removeCommonPath(path, root->getPath(), contains);
+	std::string relative = Utils::FileSystem::removeCommonPath(path, root->getPath(), contains, false);
 
 	if(!contains)
 	{
@@ -117,7 +117,7 @@ void parseGamelist(SystemData* system)
 		FileType type = typeList[i];
 		for(pugi::xml_node fileNode = root.child(tag); fileNode; fileNode = fileNode.next_sibling(tag))
 		{
-			const std::string path = Utils::FileSystem::resolveRelativePath(fileNode.child("path").text().get(), relativeTo, false);
+			const std::string path = Utils::FileSystem::resolveRelativePath(fileNode.child("path").text().get(), relativeTo, false, false);
 
 			if(!trustGamelist && !Utils::FileSystem::exists(path))
 			{
@@ -165,7 +165,7 @@ void addFileDataNode(pugi::xml_node& parent, const FileData* file, const char* t
 		//there's something useful in there so we'll keep the node, add the path
 
 		// try and make the path relative if we can so things still work if we change the rom folder location in the future
-		newNode.prepend_child("path").text().set(Utils::FileSystem::createRelativePath(file->getPath(), system->getStartPath(), false).c_str());
+		newNode.prepend_child("path").text().set(Utils::FileSystem::createRelativePath(file->getPath(), system->getStartPath(), false, false).c_str());
 	}
 }
 
@@ -234,7 +234,7 @@ void updateGamelist(SystemData* system)
 					continue;
 				}
 
-				std::string nodePath = Utils::FileSystem::getCanonicalPath(Utils::FileSystem::resolveRelativePath(pathNode.text().get(), system->getStartPath(), true));
+				std::string nodePath = Utils::FileSystem::getCanonicalPath(Utils::FileSystem::resolveRelativePath(pathNode.text().get(), system->getStartPath(), true, false));
 				std::string gamePath = Utils::FileSystem::getCanonicalPath((*fit)->getPath());
 				if(nodePath == gamePath)
 				{

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -84,7 +84,7 @@ MetaDataList MetaDataList::createFromXML(MetaDataListType type, pugi::xml_node& 
 			std::string value = md.text().get();
 			if (iter->type == MD_PATH)
 			{
-				value = Utils::FileSystem::resolveRelativePath(value, relativeTo, true);
+				value = Utils::FileSystem::resolveRelativePath(value, relativeTo, true, false);
 			}
 			mdl.set(iter->key, value);
 		}else{
@@ -112,7 +112,7 @@ void MetaDataList::appendToXML(pugi::xml_node& parent, bool ignoreDefaults, cons
 			// try and make paths relative if we can
 			std::string value = mapIter->second;
 			if (mddIter->type == MD_PATH)
-				value = Utils::FileSystem::createRelativePath(value, relativeTo, true);
+				value = Utils::FileSystem::createRelativePath(value, relativeTo, true, false);
 
 			parent.append_child(mapIter->first.c_str()).text().set(value.c_str());
 		}

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -271,7 +271,7 @@ void ThemeData::parseIncludes(const pugi::xml_node& root)
 	for(pugi::xml_node node = root.child("include"); node; node = node.next_sibling("include"))
 	{
 		std::string relPath = resolvePlaceholders(node.text().as_string());
-		std::string path = Utils::FileSystem::resolveRelativePath(relPath, mPaths.back(), true);
+		std::string path = Utils::FileSystem::resolveRelativePath(relPath, mPaths.back(), true, true);
 		if(!ResourceManager::getInstance()->fileExists(path))
 			throw error << "Included file \"" << relPath << "\" not found! (resolved to \"" << path << "\")";
 
@@ -457,7 +457,7 @@ void ThemeData::parseElement(const pugi::xml_node& root, const std::map<std::str
 			break;
 		case PATH:
 		{
-			std::string path = Utils::FileSystem::resolveRelativePath(str, mPaths.back(), true);
+			std::string path = Utils::FileSystem::resolveRelativePath(str, mPaths.back(), true, true);
 			if(!ResourceManager::getInstance()->fileExists(path))
 			{
 				std::stringstream ss;

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -481,10 +481,12 @@ namespace Utils
 
 //////////////////////////////////////////////////////////////////////////
 
-		std::string resolveRelativePath(const std::string& _path, const std::string& _relativeTo, const bool _allowHome)
+		std::string resolveRelativePath(const std::string& _path, const std::string& _relativeTo, const bool _allowHome, const bool _searchParents)
 		{
 			const std::string path       = getGenericPath(_path);
-			const std::string relativeTo = isDirectory(_relativeTo) ? getGenericPath(_relativeTo) : getParent(_relativeTo);
+
+			// Do not invoke isDirectory() and touch the filesystem during gamelist processing or there will be significant loading delay
+			const std::string relativeTo = _searchParents ? (isDirectory(_relativeTo) ? getGenericPath(_relativeTo) : getParent(_relativeTo)) : getGenericPath(_relativeTo);
 
 			// nothing to resolve
 			if(!path.length())
@@ -505,10 +507,10 @@ namespace Utils
 
 //////////////////////////////////////////////////////////////////////////
 
-		std::string createRelativePath(const std::string& _path, const std::string& _relativeTo, const bool _allowHome)
+		std::string createRelativePath(const std::string& _path, const std::string& _relativeTo, const bool _allowHome, const bool _searchParents)
 		{
 			bool        contains = false;
-			std::string path     = removeCommonPath(_path, _relativeTo, contains);
+			std::string path     = removeCommonPath(_path, _relativeTo, contains, _searchParents);
 
 			// success
 			if(contains)
@@ -516,7 +518,7 @@ namespace Utils
 
 			if(_allowHome)
 			{
-				path = removeCommonPath(_path, getHomePath(), contains);
+				path = removeCommonPath(_path, getHomePath(), contains, _searchParents);
 
 				// success
 				if(contains)
@@ -530,10 +532,12 @@ namespace Utils
 
 //////////////////////////////////////////////////////////////////////////
 
-		std::string removeCommonPath(const std::string& _path, const std::string& _common, bool& _contains)
+		std::string removeCommonPath(const std::string& _path, const std::string& _common, bool& _contains, const bool _searchParents)
 		{
 			const std::string path   = getGenericPath(_path);
-			const std::string common = isDirectory(_common) ? getGenericPath(_common) : getParent(_common);
+
+			// Do not invoke isDirectory() and touch the filesystem during gamelist processing or there will be significant loading delay
+			const std::string common = _searchParents ? (isDirectory(_common) ? getGenericPath(_common) : getParent(_common)) : getGenericPath(_common);
 
 			// check if path contains common
 			if(path.find(common) == 0)

--- a/es-core/src/utils/FileSystemUtil.h
+++ b/es-core/src/utils/FileSystemUtil.h
@@ -27,9 +27,9 @@ namespace Utils
 		std::string getFileName        (const std::string& _path);
 		std::string getStem            (const std::string& _path);
 		std::string getExtension       (const std::string& _path);
-		std::string resolveRelativePath(const std::string& _path, const std::string& _relativeTo, const bool _allowHome);
-		std::string createRelativePath (const std::string& _path, const std::string& _relativeTo, const bool _allowHome);
-		std::string removeCommonPath   (const std::string& _path, const std::string& _common, bool& _contains);
+		std::string resolveRelativePath(const std::string& _path, const std::string& _relativeTo, const bool _allowHome, const bool _searchParents);
+		std::string createRelativePath (const std::string& _path, const std::string& _relativeTo, const bool _allowHome, const bool _searchParents);
+		std::string removeCommonPath   (const std::string& _path, const std::string& _common, bool& _contains, const bool _searchParents);
 		std::string resolveSymlink     (const std::string& _path);
 		bool        removeFile         (const std::string& _path);
 		bool        createDirectory    (const std::string& _path);


### PR DESCRIPTION
The problem causing slow loading is because of how relative paths are handled. Both the game loader and the theme loader rely on the following functions: `resolveRelativePath`, `createRelativePath`, `removeCommonPath`.

These methods use `isDirectory()` to determine whether a file should search parent directories when referenced by `.` instead of the one it is in. This is relevant for themes which load parent relative content.

This is not relevant for loading games and so every single file of every game list hits the file system multiple times to see if a path is a directory. If you're loading from the network or slow media this can take several minutes while every game is probed.

The fix adds `_searchParents` so that the theme system does (true) and the game loader does not (false).

You also need to set the `ParseGamelistOnly` setting to avoid touching the file system on load.

These changes bring an 8 minute load time down to about 3 seconds.

Added a comment as a warning to hopefully avoid re-introduction of `isDirectory()` in that path in the future.

Please ensure I have not overlooked a game loading use case that actually requires the parent path flow.