### PR TITLE
fix wrong Sharp X68000 platform id

### DIFF
--- a/es-app/src/PlatformId.cpp
+++ b/es-app/src/PlatformId.cpp
@@ -66,7 +66,7 @@ namespace PlatformIds
 		"snes", // super nintendo entertainment system
 		"scummvm",
 		"x1",
-		"x6800",
+		"x68000",
 		"solarus",
 		"moto", // Thomson MO/TO
 		"pc88", // NEC PC-8801


### PR DESCRIPTION
`x68000` is the name of the ROMs folder and the platform name in RetroPie's `platforms.cfg`.