### PR TITLE
Add macros to <command> field in es_systems.cfg

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -279,10 +279,14 @@ void FileData::launchGame(Window* window)
 	const std::string rom      = Utils::FileSystem::getEscapedPath(getPath());
 	const std::string basename = Utils::FileSystem::getStem(getPath());
 	const std::string rom_raw  = Utils::FileSystem::getPreferredPath(getPath());
+	const std::string es_home  = Utils::FileSystem::getHomePath();
+	const std::string rom_dir  = Utils::FileSystem::getParent(getPath());
 
 	command = Utils::String::replace(command, "%ROM%", rom);
 	command = Utils::String::replace(command, "%BASENAME%", basename);
 	command = Utils::String::replace(command, "%ROM_RAW%", rom_raw);
+	command = Utils::String::replace(command, "%ES_HOME%", es_home);
+	command = Utils::String::replace(command, "%ROM_DIR%", rom_dir);
 
 	Scripting::fireEvent("game-start", rom, basename);
 


### PR DESCRIPTION
Adds `%ES_HOME%` and `%ROM_DIR%` macros to `<command>` fields in `es_systems.cfg`.

Fixes #680.