### PR TITLE
Allow <forceUppercase>0</forceUppercase> in <textlist>

### DIFF
--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -63,9 +63,9 @@ public:
 			it->data.textCache.reset();
 	}
 
-	inline void setUppercase(bool /*uppercase*/)
+	inline void setUppercase(bool uppercase)
 	{
-		mUppercase = true;
+		mUppercase = uppercase;
 		for(auto it = mEntries.begin(); it != mEntries.end(); it++)
 			it->data.textCache.reset();
 	}


### PR DESCRIPTION
In \<textlist\>, setUppercase() always set mUppercase to true.
other elements are work correct.