### PR TITLE
Update platform.cpp add video at poweroff and restart system

### DIFF
--- a/es-core/src/platform.cpp
+++ b/es-core/src/platform.cpp
@@ -15,7 +15,9 @@ int runShutdownCommand()
 #ifdef WIN32 // windows
 	return system("shutdown -s -t 0");
 #else // osx / linux
-	return system("sudo shutdown -h now");
+	int pid = system("sudo omxplayer -b /opt/retropie/configs/all/emulationstation/video/poweroff.mp4");
+	pid = system("sudo shutdown -h now");
+	return pid;
 #endif
 }
 
@@ -24,7 +26,9 @@ int runRestartCommand()
 #ifdef WIN32 // windows
 	return system("shutdown -r -t 0");
 #else // osx / linux
-	return system("sudo shutdown -r now");
+	int pid = system("sudo omxplayer -b /opt/retropie/configs/all/emulationstation/video/restart.mp4");
+	pid = system("sudo shutdown -r now");
+	return pid;
 #endif
 }
 


### PR DESCRIPTION
Thanks to julenvitoria and bitstuffing
Add code to play video when select poweroff system or restart system with omxplayer, /opt/retropie/configs/all/emulationstation/video/restart.mp4
/opt/retropie/configs/all/emulationstation/video/restart.mp4
It is necessary to create the folder and corresponding video