### PR TITLE
Improve file-system accesses

### DIFF
--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -31,6 +31,7 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 
 	// Create the correct type of video window
 #ifdef _RPI_
+	Utils::FileSystem::removeFile(getTitlePath());
 	if (Settings::getInstance()->getBool("VideoOmxPlayer"))
 		mVideo = new VideoPlayerComponent(window, "");
 	else
@@ -246,8 +247,6 @@ void VideoGameListView::initMDValues()
 void VideoGameListView::updateInfoPanel()
 {
 	FileData* file = (mList.size() == 0 || mList.isScrolling()) ? NULL : mList.getSelected();
-
-	Utils::FileSystem::removeFile(getTitlePath());
 
 	bool fadingOut;
 	if(file == NULL)

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -105,7 +105,7 @@ void VideoComponent::onSizeChanged()
 bool VideoComponent::setVideo(std::string path)
 {
 	// Convert the path into a generic format
-	std::string fullPath = Utils::FileSystem::getCanonicalPath(path);
+	std::string fullPath = Utils::FileSystem::getAbsolutePath(path);
 
 	// Check that it's changed
 	if (fullPath == mVideoPath)


### PR DESCRIPTION
This change improves file-system accesses, especially on remote systems. 
Currently there are multiple instances of unnecessary file-system accesses for checking if files exist, including consecutively when updating the UI and loading the assets for each game during navigation.
This implements a quick and dirty index map for such "exists" operations that are somewhat expensive in remote storage scenarios (NAS), averaging 100ms each, causing navigation to be unnecessarily slow.

Also, changed some of the file-system accesses and calculations on the video player front.

If useful I can implement this as an option, but didn't want to over-engineer it. I suppose the only reason that this would not be desired is if the actual files that ES expects to point to actually change in runtime, outside of ES, but since there's also no "re-scan" feature for file-system changes right now, I imagine that this will not be a meaningful issue. Still, happy to consider.