### PR TITLE
Adds option for background resource indexing during screensaver

### DIFF
--- a/es-app/src/CollectionSystemManager.h
+++ b/es-app/src/CollectionSystemManager.h
@@ -76,6 +76,8 @@ public:
 	SystemData* getSystemToView(SystemData* sys);
 	void updateCollectionFolderMetadata(SystemData* sys);
 
+	SystemData* getAllGamesCollection();
+
 private:
 	static CollectionSystemManager* sInstance;
 	SystemEnvironmentData* mCollectionEnvData;
@@ -89,7 +91,6 @@ private:
 
 	void initAutoCollectionSystems();
 	void initCustomCollectionSystems();
-	SystemData* getAllGamesCollection();
 	SystemData* createNewCollectionEntry(std::string name, CollectionSystemDecl sysDecl, bool index = true);
 	void populateAutoCollection(CollectionSystemData* sysData);
 	void populateCustomCollection(CollectionSystemData* sysData);

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -3,6 +3,7 @@
 #define ES_APP_SYSTEM_SCREEN_SAVER_H
 
 #include "Window.h"
+#include <thread>
 
 class ImageComponent;
 class Sound;
@@ -36,6 +37,8 @@ private:
 	void pickRandomGameListImage(std::string& path);
 	void pickRandomCustomImage(std::string& path);
 
+	void backgroundIndexing();
+
 	void input(InputConfig* config, Input input);
 
 	enum STATE {
@@ -62,6 +65,9 @@ private:
 	int 			mSwapTimeout;
 	std::shared_ptr<Sound>	mBackgroundAudio;
 	bool			mStopBackgroundAudio;
+
+	std::thread*				mThread;
+	bool 						mExit;
 };
 
 #endif // ES_APP_SYSTEM_SCREEN_SAVER_H

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -453,6 +453,12 @@ void GuiMenu::openOtherSettings()
 
 #endif
 
+	// hidden files
+	auto background_indexing = std::make_shared<SwitchComponent>(mWindow);
+	background_indexing->setState(Settings::getInstance()->getBool("BackgroundIndexing"));
+	s->addWithLabel("INDEX FILES DURING SCREENSAVER", background_indexing);
+	s->addSaveFunc([background_indexing] { Settings::getInstance()->setBool("BackgroundIndexing", background_indexing->getState()); });
+
 	// framerate
 	auto framerate = std::make_shared<SwitchComponent>(mWindow);
 	framerate->setState(Settings::getInstance()->getBool("DrawFramerate"));

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -140,6 +140,7 @@ void Settings::setDefaults()
 	mBoolMap["CollectionShowSystemInfo"] = true;
 	mBoolMap["SortAllSystems"] = false;
 	mBoolMap["UseCustomCollectionsSystem"] = true;
+	mBoolMap["BackgroundIndexing"] = false;
 
 	mBoolMap["LocalArt"] = false;
 


### PR DESCRIPTION
Depends on #688 - it includes that commit here, so don't review this beforehand. 

This PR adds an option to run a background job during the screensaver to index files/resources that will be used by ES, to reduce expensive file-system operations during runtime, especially on network media.

It indexes game images, thumbnails, marquees and videos which are, to the best of my understanding, all the external resources that are accessed in runtime when navigating and that can benefit from being cached.