### PR TITLE
adds a longer delay (5s) before autoscrolling a game's description

### DIFF
--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -5,7 +5,7 @@
 
 DetailedGameListView::DetailedGameListView(Window* window, FileData* root) :
 	BasicGameListView(window, root),
-	mDescContainer(window), mDescription(window),
+	mDescContainer(window, DESCRIPTION_SCROLL_DELAY), mDescription(window),
 	mThumbnail(window),
 	mMarquee(window),
 	mImage(window),
@@ -306,4 +306,8 @@ std::vector<GuiComponent*> DetailedGameListView::getMDValues()
 	ret.push_back(&mLastPlayed);
 	ret.push_back(&mPlayCount);
 	return ret;
+}
+
+void DetailedGameListView::onFocusLost() {
+	mDescContainer.reset();
 }

--- a/es-app/src/views/gamelist/DetailedGameListView.h
+++ b/es-app/src/views/gamelist/DetailedGameListView.h
@@ -18,6 +18,8 @@ public:
 
 	virtual void launch(FileData* game) override;
 
+	void onFocusLost() override;
+
 private:
 	void updateInfoPanel();
 

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -17,7 +17,7 @@ GridGameListView::GridGameListView(Window* window, FileData* root) :
 	mImage(window),
 	mVideo(nullptr),
 	mVideoPlaying(false),
-	mDescContainer(window), mDescription(window),
+	mDescContainer(window, DESCRIPTION_SCROLL_DELAY), mDescription(window),
 
 	mLblRating(window), mLblReleaseDate(window), mLblDeveloper(window), mLblPublisher(window),
 	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window),
@@ -88,7 +88,7 @@ GridGameListView::GridGameListView(Window* window, FileData* root) :
 	mDescription.setFont(Font::get(FONT_SIZE_SMALL));
 	mDescription.setSize(mDescContainer.getSize().x(), 0);
 	mDescContainer.addChild(&mDescription);
-	
+
 	mMarquee.setOrigin(0.5f, 0.5f);
 	mMarquee.setPosition(mSize.x() * 0.25f, mSize.y() * 0.10f);
 	mMarquee.setMaxSize(mSize.x() * (0.5f - 2*padding), mSize.y() * 0.18f);
@@ -320,7 +320,7 @@ void GridGameListView::updateInfoPanel()
 		mVideo->setImage(file->getThumbnailPath());
 		mMarquee.setImage(file->getMarqueePath());
 		mImage.setImage(file->getImagePath());
- 
+
 		mDescription.setText(file->metadata.get("desc"));
 		mDescContainer.reset();
 
@@ -377,7 +377,7 @@ void GridGameListView::addPlaceholder()
 }
 
 void GridGameListView::launch(FileData* game)
-{	
+{
 	float screenWidth = (float) Renderer::getScreenWidth();
 	float screenHeight = (float) Renderer::getScreenHeight();
 
@@ -394,7 +394,7 @@ void GridGameListView::launch(FileData* game)
 		 mImage.getPosition().y() < screenHeight && mImage.getPosition().y() > 2.0f))
 	{
 		target = Vector3f(mImage.getCenter().x(), mImage.getCenter().y(), 0);
-	}	
+	}
 	else if(mVideo->getPosition().x() < screenWidth && mVideo->getPosition().x() > 0.0f &&
 		 mVideo->getPosition().y() < screenHeight && mVideo->getPosition().y() > 0.0f)
 	{
@@ -493,4 +493,8 @@ void GridGameListView::onShow()
 {
 	GuiComponent::onShow();
 	updateInfoPanel();
+}
+
+void GridGameListView::onFocusLost() {
+	mDescContainer.reset();
 }

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -29,6 +29,8 @@ public:
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 	virtual void launch(FileData* game) override;
 
+	void onFocusLost(void) override;
+
 protected:
 	virtual void update(int deltaTime) override;
 	virtual std::string getQuickSystemSelectRightButton() override;

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -28,6 +28,8 @@ public:
 	virtual void launch(FileData* game) = 0;
 
 protected:
+	static const int DESCRIPTION_SCROLL_DELAY = 5 * 1000; // five secs
+
 	virtual std::string getQuickSystemSelectRightButton() = 0;
 	virtual std::string getQuickSystemSelectLeftButton() = 0;
 	virtual void populateList(const std::vector<FileData*>& files) = 0;

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -13,7 +13,7 @@
 
 VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 	BasicGameListView(window, root),
-	mDescContainer(window), mDescription(window),
+	mDescContainer(window, DESCRIPTION_SCROLL_DELAY), mDescription(window),
 	mThumbnail(window),
 	mMarquee(window),
 	mImage(window),
@@ -395,4 +395,8 @@ void VideoGameListView::onShow()
 {
 	GuiComponent::onShow();
 	updateInfoPanel();
+}
+
+void VideoGameListView::onFocusLost() {
+	mDescContainer.reset();
 }

--- a/es-app/src/views/gamelist/VideoGameListView.h
+++ b/es-app/src/views/gamelist/VideoGameListView.h
@@ -22,6 +22,8 @@ public:
 	virtual const char* getName() const override { return "video"; }
 	virtual void launch(FileData* game) override;
 
+	void onFocusLost(void) override;
+
 protected:
 	virtual void update(int deltaTime) override;
 

--- a/es-core/src/components/ScrollableContainer.cpp
+++ b/es-core/src/components/ScrollableContainer.cpp
@@ -7,8 +7,8 @@
 #define AUTO_SCROLL_DELAY 1000 // ms to wait before we start to scroll
 #define AUTO_SCROLL_SPEED 50 // ms between scrolls
 
-ScrollableContainer::ScrollableContainer(Window* window) : GuiComponent(window),
-	mAutoScrollDelay(0), mAutoScrollSpeed(0), mAutoScrollAccumulator(0), mScrollPos(0, 0), mScrollDir(0, 0), mAutoScrollResetAccumulator(0)
+ScrollableContainer::ScrollableContainer(Window* window, int scrollDelay) : GuiComponent(window),
+	mAutoScrollDelay(scrollDelay), mAutoScrollSpeed(0), mAutoScrollAccumulator(0), mScrollPos(0, 0), mScrollDir(0, 0), mAutoScrollResetAccumulator(0)
 {
 }
 
@@ -39,7 +39,10 @@ void ScrollableContainer::setAutoScroll(bool autoScroll)
 	if(autoScroll)
 	{
 		mScrollDir = Vector2f(0, 1);
-		mAutoScrollDelay = AUTO_SCROLL_DELAY;
+		if (mAutoScrollDelay == 0)
+		{
+			mAutoScrollDelay = AUTO_SCROLL_DELAY;
+		}
 		mAutoScrollSpeed = AUTO_SCROLL_SPEED;
 		reset();
 	}else{

--- a/es-core/src/components/ScrollableContainer.h
+++ b/es-core/src/components/ScrollableContainer.h
@@ -7,7 +7,7 @@
 class ScrollableContainer : public GuiComponent
 {
 public:
-	ScrollableContainer(Window* window);
+	ScrollableContainer(Window* window, int scrollDelay = 0);
 
 	Vector2f getScrollPos() const;
 	void setScrollPos(const Vector2f& pos);


### PR DESCRIPTION
As initially suggested in the [forum](https://retropie.org.uk/forum/topic/28223/more-delayed-scroll-start-of-description-patch-sample)

During testing I noticed that after a "quick system select" forward and backward (left/right joystick combo) the description has not been reset and continued scrolling before the left/right move. The scroll reset is now done in the `onFocusLost()`.

Bare with me about the surplus whitespaces fixes (leftovers by others on empty lines). My editor fixed them automagically.