### PR TITLE
changed RPI default AudioDevice to HDMI

### DIFF
--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -145,7 +145,7 @@ void Settings::setDefaults()
 
 	// Audio out device for volume control
 	#ifdef _RPI_
-		mStringMap["AudioDevice"] = "PCM";
+		mStringMap["AudioDevice"] = "HDMI";
 	#else
 		mStringMap["AudioDevice"] = "Master";
 	#endif


### PR DESCRIPTION
New kernels now use HDMI / Headphone - see https://retropie.org.uk/forum/topic/26628/audio-issues-after-latest-raspbian-updates