### PR TITLE
scraper: add missing 'daphne' platform index

### DIFF
--- a/es-app/src/PlatformId.cpp
+++ b/es-app/src/PlatformId.cpp
@@ -24,6 +24,7 @@ namespace PlatformIds
 		"bbcmicro",
 		"colecovision",
 		"c64", // commodore 64
+		"daphne",
 		"intellivision",
 		"macintosh",
 		"xbox",


### PR DESCRIPTION
Fixes scraping errors due to erroneous system chosen. Broken in https://github.com/RetroPie/EmulationStation/commit/a5f2739.