### PR TITLE
Nested variables in themes

### DIFF
--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -329,7 +329,7 @@ void ThemeData::parseVariables(const pugi::xml_node& root)
 	for(pugi::xml_node_iterator it = variables.begin(); it != variables.end(); ++it)
 	{
 		std::string key = it->name();
-		std::string val = it->text().as_string();
+		std::string val = resolvePlaceholders(it->text().as_string());
 
 		if (!val.empty())
 			mVariables.insert(std::pair<std::string, std::string>(key, val));


### PR DESCRIPTION
Allows nested variables in themes
```
<variables>
	<colorRed>8b0000</colorRed>
	<themeColor>${colorRed}</themeColor>
	<themeArtFolder>./art</themeArtFolder>
	<themeFont>${themeArtFolder}/Cabin-Bold.ttf</themeFont>
</variables>
```