### PR TITLE
More sane defaults for several components

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -285,6 +285,7 @@ You can now change the order in which elements are rendered by setting `zIndex` 
 * Media
 	* `image name="md_image"` - 30
 	* `video name="md_video"` - 30
+	* `image name="md_thumbnail"` - 35
 	* `image name="md_marquee"` - 35
 * Metadata - 40
 	* Labels

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -26,29 +26,30 @@ DetailedGameListView::DetailedGameListView(Window* window, FileData* root) :
 	mList.setAlignment(TextListComponent<FileData*>::ALIGN_LEFT);
 	mList.setCursorChangedCallback([&](const CursorState& /*state*/) { updateInfoPanel(); });
 
-	// Thumbnail
-	mThumbnail.setOrigin(0.5f, 0.5f);
-	mThumbnail.setPosition(2.0f, 2.0f);
-	mThumbnail.setVisible(false);
-	mThumbnail.setMaxSize(mSize.x() * (0.25f - 2*padding), mSize.y() * 0.10f);
-	mThumbnail.setDefaultZIndex(25);
-	addChild(&mThumbnail);
-
-	// Marquee
-	mMarquee.setOrigin(0.5f, 0.5f);
-	// Default to off the screen
-	mMarquee.setPosition(2.0f, 2.0f);
-	mMarquee.setVisible(false);
-	mMarquee.setMaxSize(mSize.x() * (0.5f - 2*padding), mSize.y() * 0.18f);
-	mMarquee.setDefaultZIndex(35);
-	addChild(&mMarquee);
-
-	// image
+	// Image
 	mImage.setOrigin(0.5f, 0.5f);
 	mImage.setPosition(mSize.x() * 0.25f, mList.getPosition().y() + mSize.y() * 0.2125f);
 	mImage.setMaxSize(mSize.x() * (0.50f - 2*padding), mSize.y() * 0.4f);
 	mImage.setDefaultZIndex(30);
 	addChild(&mImage);
+
+	// Thumbnail
+	// Default to off the screen
+	mThumbnail.setOrigin(0.5f, 0.5f);
+	mThumbnail.setPosition(2.0f, 2.0f);
+	mThumbnail.setMaxSize(mSize.x(), mSize.y());
+	mThumbnail.setDefaultZIndex(35);
+	mThumbnail.setVisible(false);
+	addChild(&mThumbnail);
+
+	// Marquee
+	// Default to off the screen
+	mMarquee.setOrigin(0.5f, 0.5f);
+	mMarquee.setPosition(2.0f, 2.0f);
+	mMarquee.setMaxSize(mSize.x(), mSize.y());
+	mMarquee.setDefaultZIndex(35);
+	mMarquee.setVisible(false);
+	addChild(&mMarquee);
 
 	// metadata labels + values
 	mLblRating.setText("Rating: ");

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -89,26 +89,32 @@ GridGameListView::GridGameListView(Window* window, FileData* root) :
 	mDescription.setSize(mDescContainer.getSize().x(), 0);
 	mDescContainer.addChild(&mDescription);
 	
-	mMarquee.setOrigin(0.5f, 0.5f);
-	mMarquee.setPosition(mSize.x() * 0.25f, mSize.y() * 0.10f);
-	mMarquee.setMaxSize(mSize.x() * (0.5f - 2*padding), mSize.y() * 0.18f);
-	mMarquee.setDefaultZIndex(35);
-	mMarquee.setVisible(false);
-	addChild(&mMarquee);
-
+	// Image
+	// Default to off the screen
 	mImage.setOrigin(0.5f, 0.5f);
 	mImage.setPosition(2.0f, 2.0f);
-	mImage.setMaxSize(1.0f, 1.0f);
-	mImage.setDefaultZIndex(10);
+	mImage.setMaxSize(mSize.x(), mSize.y());
+	mImage.setDefaultZIndex(30);
 	mImage.setVisible(false);
 	addChild(&mImage);
 
+	// Video
+	// Default to off the screen
 	mVideo->setOrigin(0.5f, 0.5f);
-	mVideo->setPosition(mSize.x() * 0.25f, mSize.y() * 0.4f);
-	mVideo->setSize(mSize.x() * (0.5f - 2*padding), mSize.y() * 0.4f);
-	mVideo->setDefaultZIndex(15);
+	mVideo->setPosition(2.0f, 2.0f);
+	mVideo->setSize(mSize.x(), mSize.y());
+	mVideo->setDefaultZIndex(30);
 	mVideo->setVisible(false);
 	addChild(mVideo);
+
+	// Marquee
+	// Default to off the screen
+	mMarquee.setOrigin(0.5f, 0.5f);
+	mMarquee.setPosition(2.0f, 2.0f);
+	mMarquee.setMaxSize(mSize.x(), mSize.y());
+	mMarquee.setDefaultZIndex(35);
+	mMarquee.setVisible(false);
+	addChild(&mMarquee);
 
 	initMDLabels();
 	initMDValues();

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -44,36 +44,39 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 	mList.setAlignment(TextListComponent<FileData*>::ALIGN_LEFT);
 	mList.setCursorChangedCallback([&](const CursorState& /*state*/) { updateInfoPanel(); });
 
-	// Thumbnail
-	mThumbnail.setOrigin(0.5f, 0.5f);
-	mThumbnail.setPosition(2.0f, 2.0f);
-	mThumbnail.setVisible(false);
-	mThumbnail.setMaxSize(mSize.x() * (0.25f - 2*padding), mSize.y() * 0.10f);
-	mThumbnail.setDefaultZIndex(35);
-	addChild(&mThumbnail);
-
-	// Marquee
-	mMarquee.setOrigin(0.5f, 0.5f);
-	mMarquee.setPosition(mSize.x() * 0.25f, mSize.y() * 0.10f);
-	mMarquee.setMaxSize(mSize.x() * (0.5f - 2*padding), mSize.y() * 0.18f);
-	mMarquee.setDefaultZIndex(35);
-	addChild(&mMarquee);
-
 	// Image
-	mImage.setOrigin(0.5f, 0.5f);
 	// Default to off the screen
+	mImage.setOrigin(0.5f, 0.5f);
 	mImage.setPosition(2.0f, 2.0f);
-	mImage.setVisible(false);
-	mImage.setMaxSize(1.0f, 1.0f);
+	mImage.setMaxSize(mSize.x(), mSize.y());
 	mImage.setDefaultZIndex(30);
+	mImage.setVisible(false);
 	addChild(&mImage);
 
-	// video
+	// Video
 	mVideo->setOrigin(0.5f, 0.5f);
 	mVideo->setPosition(mSize.x() * 0.25f, mSize.y() * 0.4f);
 	mVideo->setSize(mSize.x() * (0.5f - 2*padding), mSize.y() * 0.4f);
 	mVideo->setDefaultZIndex(30);
 	addChild(mVideo);
+
+	// Thumbnail
+	// Default to off the screen
+	mThumbnail.setOrigin(0.5f, 0.5f);
+	mThumbnail.setPosition(2.0f, 2.0f);
+	mThumbnail.setMaxSize(mSize.x(), mSize.y());
+	mThumbnail.setDefaultZIndex(35);
+	mThumbnail.setVisible(false);
+	addChild(&mThumbnail);
+
+	// Marquee
+	// Default to off the screen
+	mMarquee.setOrigin(0.5f, 0.5f);
+	mMarquee.setPosition(2.0f, 2.0f);
+	mMarquee.setMaxSize(mSize.x(), mSize.y());
+	mMarquee.setDefaultZIndex(35);
+	mImage.setVisible(false);
+	addChild(&mMarquee);
 
 	// metadata labels + values
 	mLblRating.setText("Rating: ");


### PR DESCRIPTION
More sane defaults for several components (md_image, md_video, md_marquee and md_thumbnail) and move the hidden ones offscreen and set their maxSize to entire screen

This fixes bugs in grid and video view where the image would get the wrong aspect ratio because the default maxSize was set to 1

Should fix issue https://github.com/RetroPie/EmulationStation/issues/667