### PR TITLE
Fix textlist

### DIFF
--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -148,7 +148,7 @@ void TextListComponent<T>::render(const Transform4x4f& parentTrans)
 	int startEntry = 0;
 
 	//number of entries that can fit on the screen simultaniously
-	int screenCount = (int)(mSize.y() / entrySize + 0.5f);
+	int screenCount = (int)(mSize.y() / entrySize);
 
 	if(size() >= screenCount)
 	{


### PR DESCRIPTION
The +0.5 makes the math do a round, thus making the number of rows in the textlist one to many so it grows beyond the height of the component if the original fraction was .5 or bigger.