### PR TITLE
Disable video playback if video component is hidden

### DIFF
--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -295,8 +295,8 @@ void VideoComponent::update(int deltaTime)
 void VideoComponent::manageState()
 {
 	// We will only show if the component is on display and the screensaver
-	// is not active
-	bool show = mShowing && !mScreensaverActive && !mDisable;
+	// is not active and the component is visible
+	bool show = mShowing && !mScreensaverActive && !mDisable && mVisible;
 
 	// See if we're already playing
 	if (mIsPlaying)


### PR DESCRIPTION
The behavior for this was inconsistent.

If the video had 0 delay, it would play even if video component was hidden (grid system didthis, you could hear the audio from the hidden video), but if it had a delay then it would not play at all because it was hidden.

The new behavior is that it won't play at all when hidden, delay or not.
Grid themes using this  broken behavior to get the audio to play can still get that by just setting the video component as visible but off screen (pr https://github.com/RetroPie/EmulationStation/pull/705 defaults it to offscreen), this also gives the ability to set a delay now so the grid system doesn't try to start every video as you scroll through the games.