### PR TITLE
Fix broken grid themes

### DIFF
--- a/es-core/src/components/GridTileComponent.cpp
+++ b/es-core/src/components/GridTileComponent.cpp
@@ -68,7 +68,13 @@ void applyThemeToProperties(const ThemeData::ThemeElement* elem, GridTilePropert
 		properties->mSize = elem->get<Vector2f>("size") * screen;
 
 	if (elem->has("padding"))
+	{
 		properties->mPadding = elem->get<Vector2f>("padding") * screen;
+
+		// hack to fix broken themes now that this uses percentage rather than pixels
+		if(properties->mPadding.x() > screen.x())
+			properties->mPadding /= screen;
+	}
 
 	if (elem->has("imageColor"))
 		properties->mImageColor = elem->get<unsigned int>("imageColor");
@@ -77,7 +83,13 @@ void applyThemeToProperties(const ThemeData::ThemeElement* elem, GridTilePropert
 		properties->mBackgroundImage = elem->get<std::string>("backgroundImage");
 
 	if (elem->has("backgroundCornerSize"))
+	{
 		properties->mBackgroundCornerSize = elem->get<Vector2f>("backgroundCornerSize") * screen;
+
+		// hack to fix broken themes now that this uses percentage rather than pixels
+		if(properties->mBackgroundCornerSize.x() > screen.x())
+			properties->mBackgroundCornerSize /= screen;
+	}
 
 	if (elem->has("backgroundColor"))
 	{


### PR DESCRIPTION
This hack fixes existing grid themes that will break from the fixes in https://github.com/RetroPie/EmulationStation/pull/710