### PR TITLE
Adds a root <resolution> tag to themes

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -117,6 +117,51 @@ Advanced Features
 
 It is recommended that if you are writing a theme you launch EmulationStation with the `--debug` and `--windowed` switches.  This way you can read error messages without having to check the log file.  You can also reload the current gamelist view and system view with `Ctrl-R` if `--debug` is specified.
 
+### The `<resolution>` tag
+
+You can specifiy the resolution the theme was made for using this. This defaults to 1 1.
+When parsing any elements of type RESOLUTION_RECT, RESOLUTION_PAIR or RESOLUTION_FLOAT, they will have their values divided by the resolution specified so they become percentages.
+The following 2 examples produce the same result
+
+```xml
+<theme>
+	<formatVersion>6</formatVersion>
+	<view name="detailed">
+		<text name="description">
+			<color>00FF00</color>
+		</text>
+		<image name="my_image" extra="true">
+			<pos>0.5 0.5</pos>
+			<origin>0.5 0.5</origin>
+			<size>0.8 0.8</size>
+			<path>./my_art/my_awesome_image.jpg</path>
+		</image>
+	</view>
+</theme>
+```
+
+```xml
+<theme>
+	<formatVersion>6</formatVersion>
+	<resolution>1920 1080</resolution>
+	<view name="detailed">
+		<text name="description">
+			<color>00FF00</color>
+		</text>
+		<image name="my_image" extra="true">
+			<pos>960 540</pos>
+			<origin>0.5 0.5</origin>
+			<size>1536 864</size>
+			<path>./my_art/my_awesome_image.jpg</path>
+		</image>
+	</view>
+</theme>
+```
+
+The difference is how we specify the position and size of the image element.
+This does not limit a theme to be used at a certain resolution, but merely helps the theme makers build their themes using pixel values rather than percentages.
+Parenting of elements can not be used when using a resolution other than 1 1.
+
 ### The `<include>` tag
 
 You can include theme files within theme files, similar to `#include` in C (though the internal mechanism is different, the effect is the same).  Example:
@@ -538,14 +583,15 @@ Reference
 
 ## Types of properties:
 
-* NORMALIZED_PAIR - two decimals, in the range [0..1], delimited by a space.  For example, `0.25 0.5`.  Most commonly used for position (x and y coordinates) and size (width and height).
-* NORMALIZED_RECT - four decimals, in the range [0..1], delimited by a space. For example, `0.25 0.5 0.10 0.30`.  Most commonly used for padding to store top, left, bottom and right coordinates.
+* RESOLUTION_RECT - four decimals, using pixels in the range [0..resolution], delimited by a space. For example, `320 640 80 160`.  Most commonly used for padding to store top, left, bottom and right coordinates.
+* RESOLUTION_PAIR - two decimals, using pixels in the range [0..resolution], delimited by a space.  For example, `320 640`.  Most commonly used for position (x and y coordinates) and size (width and height).
+* RESOLUTION_FLOAT - a decimal, using pixels in the range [0..resolution].  Most commonly used for font size.
+* NORMALIZED_PAIR - two decimals, using percentage in the range [0..1], delimited by a space.  For example, `0.25 0.5`.  Most commonly used for origin (x and y coordinates).
 * PATH - a path.  If the first character is a `~`, it will be expanded into the environment variable for the home path (`$HOME` for Linux or `%HOMEPATH%` for Windows).  If the first character is a `.`, it will be expanded to the theme file's directory, allowing you to specify resources relative to the theme file, like so: `./../general_art/myfont.ttf`.
-* BOOLEAN - `true`/`1` or `false`/`0`.
+* STRING - a string of text.
 * COLOR - a hexidecimal RGB or RGBA color (6 or 8 digits).  If 6 digits, will assume the alpha channel is `FF` (not transparent).
 * FLOAT - a decimal.
-* STRING - a string of text.
-
+* BOOLEAN - `true`/`1` or `false`/`0`.
 
 ## Types of elements and their properties:
 
@@ -559,10 +605,10 @@ Remember, you do *not* need to specify every property!
 
 Can be created as an extra.
 
-* `pos` - type: NORMALIZED_PAIR.
-* `size` - type: NORMALIZED_PAIR.
+* `pos` - type: RESOLUTION_PAIR.
+* `size` - type: RESOLUTION_PAIR.
 	- If only one axis is specified (and the other is zero), the other will be automatically calculated in accordance with the image's aspect ratio.
-* `maxSize` - type: NORMALIZED_PAIR.
+* `maxSize` - type: RESOLUTION_PAIR.
 	- The image will be resized as large as possible so that it fits within this size and maintains its aspect ratio.  Use this instead of `size` when you don't know what kind of image you're using so it doesn't get grossly oversized on one axis (e.g. with a game's image metadata).
 * `origin` - type: NORMALIZED_PAIR.
 	- Where on the image `pos` refers to.  For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the image exactly in the middle of the screen.  If the "POSITION" and "SIZE" attributes are themable, "ORIGIN" is implied.
@@ -585,11 +631,11 @@ Can be created as an extra.
 
 #### imagegrid
 
-* `pos` - type: NORMALIZED_PAIR.
-* `size` - type: NORMALIZED_PAIR.
+* `pos` - type: RESOLUTION_PAIR.
+* `size` - type: RESOLUTION_PAIR.
     - The size of the grid. Take care the selected tile can go out of the grid size, so don't position the grid too close to another element or the screen border.
-* `margin` - type: NORMALIZED_PAIR. Margin between tiles.
-* `padding` - type: NORMALIZED_RECT.
+* `margin` - type: RESOLUTION_PAIR. Margin between tiles.
+* `padding` - type: RESOLUTION_RECT.
     - NEW : Padding for displaying tiles.
 * `autoLayout` - type: NORMALIZED_PAIR.
     - NEW : Number of column and rows in the grid (integer values).
@@ -614,15 +660,15 @@ Can be created as an extra.
 
 #### gridtile
 
-* `size` - type: NORMALIZED_PAIR.
+* `size` - type: RESOLUTION_PAIR.
     - The size of the default gridtile is used to calculate how many tiles can fit in the imagegrid. If not explicitly set, the size of the selected gridtile is equal the size of the default gridtile * 1.2
-* `padding` - type: NORMALIZED_PAIR.
+* `padding` - type: RESOLUTION_PAIR.
     - The padding around the gridtile content. Default `16 16`. If not explicitly set, the selected tile padding will be equal to the default tile padding.
 * `imageColor` - type: COLOR.
     - The default tile image color and selected tile image color have no influence on each others.
 * `backgroundImage` - type: PATH.
     - If not explicitly set, the selected tile background image will be the same as the default tile background image.
-* `backgroundCornerSize` - type: NORMALIZED_PAIR.
+* `backgroundCornerSize` - type: RESOLUTION_PAIR.
     - The corner size of the ninepatch used for the tile background. Default is `16 16`.
 * `backgroundColor` - type: COLOR.
     - A shortcut to define both the center color and edge color at the same time. The default tile background color and selected tile background color have no influence on each others.
@@ -633,10 +679,10 @@ Can be created as an extra.
 
 #### video
 
-* `pos` - type: NORMALIZED_PAIR.
-* `size` - type: NORMALIZED_PAIR.
+* `pos` - type: RESOLUTION_PAIR.
+* `size` - type: RESOLUTION_PAIR.
 	- If only one axis is specified (and the other is zero), the other will be automatically calculated in accordance with the video's aspect ratio.
-* `maxSize` - type: NORMALIZED_PAIR.
+* `maxSize` - type: RESOLUTION_PAIR.
 	- The video will be resized as large as possible so that it fits within this size and maintains its aspect ratio.  Use this instead of `size` when you don't know what kind of video you're using so it doesn't get grossly oversized on one axis (e.g. with a game's video metadata).
 * `origin` - type: NORMALIZED_PAIR.
 	- Where on the image `pos` refers to.  For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the image exactly in the middle of the screen.  If the "POSITION" and "SIZE" attributes are themable, "ORIGIN" is implied.
@@ -661,8 +707,8 @@ Can be created as an extra.
 
 Can be created as an extra.
 
-* `pos` - type: NORMALIZED_PAIR.
-* `size` - type: NORMALIZED_PAIR.
+* `pos` - type: RESOLUTION_PAIR.
+* `size` - type: RESOLUTION_PAIR.
 	- Possible combinations:
 	- `0 0` - automatically size so text fits on one line (expanding horizontally).
 	- `w 0` - automatically wrap text so it doesn't go beyond `w` (expanding vertically).
@@ -678,7 +724,7 @@ Can be created as an extra.
 * `backgroundColor` - type: COLOR;
 * `fontPath` - type: PATH.
 	- Path to a truetype font (.ttf).
-* `fontSize` - type: FLOAT.
+* `fontSize` - type: RESOLUTION_FLOAT.
 	- Size of the font as a percentage of screen height (e.g. for a value of `0.1`, the text's height would be 10% of the screen height).
 * `alignment` - type: STRING.
 	- Valid values are "left", "center", or "right".  Controls alignment on the X axis.  "center" will also align vertically.
@@ -691,8 +737,8 @@ Can be created as an extra.
 
 #### textlist
 
-* `pos` - type: NORMALIZED_PAIR.
-* `size` - type: NORMALIZED_PAIR.
+* `pos` - type: RESOLUTION_PAIR.
+* `size` - type: RESOLUTION_PAIR.
 * `origin` - type: NORMALIZED_PAIR.
 	- Where on the component `pos` refers to.  For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the component exactly in the middle of the screen.  If the "POSITION" and "SIZE" attributes are themable, "ORIGIN" is implied.
 * `selectorColor` - type: COLOR.
@@ -701,9 +747,9 @@ Can be created as an extra.
 	- Path to image to render in place of "selector bar."
 * `selectorImageTile` - type: BOOLEAN.
 	- If true, the selector image will be tiled instead of stretched to fit its size.
-* `selectorHeight` - type: FLOAT.
+* `selectorHeight` - type: RESOLUTION_FLOAT.
 	- Height of the "selector bar".
-* `selectorOffsetY` - type: FLOAT.
+* `selectorOffsetY` - type: RESOLUTION_FLOAT.
 	- Allows moving of the "selector bar" up or down from its computed position.  Useful for fine tuning the position of the "selector bar" relative to the text.
 * `selectedColor` - type: COLOR.
 	- Color of the highlighted entry text.
@@ -712,12 +758,12 @@ Can be created as an extra.
 * `secondaryColor` - type: COLOR.
 	- Secondary color; what this means depends on the text list.  For example, for game lists, it is the color of a folder.
 * `fontPath` - type: PATH.
-* `fontSize` - type: FLOAT.
+* `fontSize` - type: RESOLUTION_FLOAT.
 * `scrollSound` - type: PATH.
 	- Sound that is played when the list is scrolled.
 * `alignment` - type: STRING.
 	- Valid values are "left", "center", or "right".  Controls alignment on the X axis.
-* `horizontalMargin` - type: FLOAT.
+* `horizontalMargin` - type: RESOLUTION_FLOAT.
 	- Horizontal offset for text from the alignment point.  If `alignment` is "left", offsets the text to the right.  If `alignment` is "right", offsets text to the left.  No effect if `alignment` is "center".  Given as a percentage of the element's parent's width (same unit as `size`'s X value).
 * `forceUppercase` - type: BOOLEAN.  Draw text in uppercase.
 * `lineSpacing` - type: FLOAT.  Controls the space between lines (as a multiple of font height).  Default is 1.5.
@@ -726,8 +772,8 @@ Can be created as an extra.
 
 #### ninepatch
 
-* `pos` - type: NORMALIZED_PAIR.
-* `size` - type: NORMALIZED_PAIR.
+* `pos` - type: RESOLUTION_PAIR.
+* `size` - type: RESOLUTION_PAIR.
 * `path` - type: PATH.
 * `visible` - type: BOOLEAN.
     - If true, component will be rendered, otherwise rendering will be skipped.  Can be used to hide elements from a particular view.
@@ -738,8 +784,8 @@ EmulationStation borrows the concept of "nine patches" from Android (or "9-Slice
 
 #### rating
 
-* `pos` - type: NORMALIZED_PAIR.
-* `size` - type: NORMALIZED_PAIR.
+* `pos` - type: RESOLUTION_PAIR.
+* `size` - type: RESOLUTION_PAIR.
 	- Only one value is actually used. The other value should be zero.  (e.g. specify width OR height, but not both.  This is done to maintain the aspect ratio.)
 * `origin` - type: NORMALIZED_PAIR.
 	- Where on the component `pos` refers to.  For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the component exactly in the middle of the screen.  If the "POSITION" and "SIZE" attributes are themable, "ORIGIN" is implied.
@@ -759,8 +805,8 @@ EmulationStation borrows the concept of "nine patches" from Android (or "9-Slice
 	- z-index value for component.  Components will be rendered in order of z-index value from low to high.	
 
 #### datetime
-* `pos` - type: NORMALIZED_PAIR.
-* `size` - type: NORMALIZED_PAIR.
+* `pos` - type: RESOLUTION_PAIR.
+* `size` - type: RESOLUTION_PAIR.
 	- Possible combinations:
 	- `0 0` - automatically size so text fits on one line (expanding horizontally).
 	- `w 0` - automatically wrap text so it doesn't go beyond `w` (expanding vertically).
@@ -775,7 +821,7 @@ EmulationStation borrows the concept of "nine patches" from Android (or "9-Slice
 * `backgroundColor` - type: COLOR;
 * `fontPath` - type: PATH.
 	- Path to a truetype font (.ttf).
-* `fontSize` - type: FLOAT.
+* `fontSize` - type: RESOLUTION_FLOAT.
 	- Size of the font as a percentage of screen height (e.g. for a value of `0.1`, the text's height would be 10% of the screen height).
 * `alignment` - type: STRING.
 	- Valid values are "left", "center", or "right".  Controls alignment on the X axis.  "center" will also align vertically.
@@ -801,13 +847,13 @@ EmulationStation borrows the concept of "nine patches" from Android (or "9-Slice
 
 #### helpsystem
 
-* `pos` - type: NORMALIZED_PAIR.  Default is "0.012 0.9515"
+* `pos` - type: RESOLUTION_PAIR.  Default is "0.012 0.9515"
 * `origin` - type: NORMALIZED_PAIR.
 	- Where on the component `pos` refers to. For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the component exactly in the middle of the screen.
 * `textColor` - type: COLOR.  Default is 777777FF.
 * `iconColor` - type: COLOR.  Default is 777777FF.
 * `fontPath` - type: PATH.
-* `fontSize` - type: FLOAT.
+* `fontSize` - type: RESOLUTION_FLOAT.
 
 #### carousel
 
@@ -815,8 +861,8 @@ EmulationStation borrows the concept of "nine patches" from Android (or "9-Slice
 	- Sets the scoll direction of the carousel.
 	- Accepted values are "horizontal", "vertical", "horizontal_wheel" or "vertical_wheel".
 	- Default is "horizontal".
-* `size` - type: NORMALIZED_PAIR. Default is "1 0.2325"
-* `pos` - type: NORMALIZED_PAIR.  Default is "0 0.38375".
+* `size` - type: RESOLUTION_PAIR. Default is "1 0.2325"
+* `pos` - type: RESOLUTION_PAIR.  Default is "0 0.38375".
 * `origin` - type: NORMALIZED_PAIR.
 	- Where on the carousel `pos` refers to.  For example, an origin of `0.5 0.5` and a `pos` of `0.5 0.5` would place the carousel exactly in the middle of the screen.  If the "POSITION" and "SIZE" attributes are themable, "ORIGIN" is implied.
 * `color` - type: COLOR.

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -15,9 +15,9 @@ std::vector<std::string> ThemeData::sSupportedFeatures { { "video" }, { "carouse
 
 std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> ThemeData::sElementMap {
 	{ "image", {
-		{ "pos", NORMALIZED_PAIR },
-		{ "size", NORMALIZED_PAIR },
-		{ "maxSize", NORMALIZED_PAIR },
+		{ "pos", RESOLUTION_PAIR },
+		{ "size", RESOLUTION_PAIR },
+		{ "maxSize", RESOLUTION_PAIR },
 		{ "origin", NORMALIZED_PAIR },
 		{ "rotation", FLOAT },
 		{ "rotationOrigin", NORMALIZED_PAIR },
@@ -30,10 +30,10 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "visible", BOOLEAN },
 		{ "zIndex", FLOAT } } },
 	{ "imagegrid", {
-		{ "pos", NORMALIZED_PAIR },
-		{ "size", NORMALIZED_PAIR },
-		{ "margin", NORMALIZED_PAIR },
-		{ "padding", NORMALIZED_RECT },
+		{ "pos", RESOLUTION_PAIR },
+		{ "size", RESOLUTION_PAIR },
+		{ "margin", RESOLUTION_PAIR },
+		{ "padding", RESOLUTION_RECT },
 		{ "autoLayout", NORMALIZED_PAIR },
 		{ "autoLayoutSelectedZoom", FLOAT },
 		{ "gameImage", PATH },
@@ -45,24 +45,24 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "animate", BOOLEAN },
 		{ "zIndex", FLOAT } } },
 	{ "gridtile", {
-		{ "size", NORMALIZED_PAIR },
-		{ "padding", NORMALIZED_PAIR },
+		{ "size", RESOLUTION_PAIR },
+		{ "padding", RESOLUTION_PAIR },
 		{ "imageColor", COLOR },
 		{ "backgroundImage", PATH },
-		{ "backgroundCornerSize", NORMALIZED_PAIR },
+		{ "backgroundCornerSize", RESOLUTION_PAIR },
 		{ "backgroundColor", COLOR },
 		{ "backgroundCenterColor", COLOR },
 		{ "backgroundEdgeColor", COLOR } } },
 	{ "text", {
-		{ "pos", NORMALIZED_PAIR },
-		{ "size", NORMALIZED_PAIR },
+		{ "pos", RESOLUTION_PAIR },
+		{ "size", RESOLUTION_PAIR },
 		{ "origin", NORMALIZED_PAIR },
 		{ "rotation", FLOAT },
 		{ "rotationOrigin", NORMALIZED_PAIR },
 		{ "text", STRING },
 		{ "backgroundColor", COLOR },
 		{ "fontPath", PATH },
-		{ "fontSize", FLOAT },
+		{ "fontSize", RESOLUTION_FLOAT },
 		{ "color", COLOR },
 		{ "alignment", STRING },
 		{ "forceUppercase", BOOLEAN },
@@ -71,11 +71,11 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "visible", BOOLEAN },
 		{ "zIndex", FLOAT } } },
 	{ "textlist", {
-		{ "pos", NORMALIZED_PAIR },
-		{ "size", NORMALIZED_PAIR },
+		{ "pos", RESOLUTION_PAIR },
+		{ "size", RESOLUTION_PAIR },
 		{ "origin", NORMALIZED_PAIR },
-		{ "selectorHeight", FLOAT },
-		{ "selectorOffsetY", FLOAT },
+		{ "selectorHeight", RESOLUTION_FLOAT },
+		{ "selectorOffsetY", RESOLUTION_FLOAT },
 		{ "selectorColor", COLOR },
 		{ "selectorColorEnd", COLOR },
 		{ "selectorGradientType", STRING },
@@ -85,34 +85,34 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "primaryColor", COLOR },
 		{ "secondaryColor", COLOR },
 		{ "fontPath", PATH },
-		{ "fontSize", FLOAT },
+		{ "fontSize", RESOLUTION_FLOAT },
 		{ "scrollSound", PATH },
 		{ "alignment", STRING },
-		{ "horizontalMargin", FLOAT },
+		{ "horizontalMargin", RESOLUTION_FLOAT },
 		{ "forceUppercase", BOOLEAN },
 		{ "lineSpacing", FLOAT },
 		{ "zIndex", FLOAT } } },
 	{ "container", {
-		{ "pos", NORMALIZED_PAIR },
-		{ "size", NORMALIZED_PAIR },
+		{ "pos", RESOLUTION_PAIR },
+		{ "size", RESOLUTION_PAIR },
 	 	{ "origin", NORMALIZED_PAIR },
 	 	{ "visible", BOOLEAN },
 	 	{ "zIndex", FLOAT } } },
 	{ "ninepatch", {
-		{ "pos", NORMALIZED_PAIR },
-		{ "size", NORMALIZED_PAIR },
+		{ "pos", RESOLUTION_PAIR },
+		{ "size", RESOLUTION_PAIR },
 		{ "path", PATH },
 	 	{ "visible", BOOLEAN },
 		{ "zIndex", FLOAT } } },
 	{ "datetime", {
-		{ "pos", NORMALIZED_PAIR },
-		{ "size", NORMALIZED_PAIR },
+		{ "pos", RESOLUTION_PAIR },
+		{ "size", RESOLUTION_PAIR },
 		{ "origin", NORMALIZED_PAIR },
 		{ "rotation", FLOAT },
 		{ "rotationOrigin", NORMALIZED_PAIR },
 		{ "backgroundColor", COLOR },
 		{ "fontPath", PATH },
-		{ "fontSize", FLOAT },
+		{ "fontSize", RESOLUTION_FLOAT },
 		{ "color", COLOR },
 		{ "alignment", STRING },
 		{ "forceUppercase", BOOLEAN },
@@ -123,8 +123,8 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 	 	{ "visible", BOOLEAN },
 	 	{ "zIndex", FLOAT } } },
 	{ "rating", {
-		{ "pos", NORMALIZED_PAIR },
-		{ "size", NORMALIZED_PAIR },
+		{ "pos", RESOLUTION_PAIR },
+		{ "size", RESOLUTION_PAIR },
 		{ "origin", NORMALIZED_PAIR },
 		{ "rotation", FLOAT },
 		{ "rotationOrigin", NORMALIZED_PAIR },
@@ -136,16 +136,16 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 	{ "sound", {
 		{ "path", PATH } } },
 	{ "helpsystem", {
-		{ "pos", NORMALIZED_PAIR },
+		{ "pos", RESOLUTION_PAIR },
 		{ "origin", NORMALIZED_PAIR },
 		{ "textColor", COLOR },
 		{ "iconColor", COLOR },
 		{ "fontPath", PATH },
-		{ "fontSize", FLOAT } } },
+		{ "fontSize", RESOLUTION_FLOAT } } },
 	{ "video", {
-		{ "pos", NORMALIZED_PAIR },
-		{ "size", NORMALIZED_PAIR },
-		{ "maxSize", NORMALIZED_PAIR },
+		{ "pos", RESOLUTION_PAIR },
+		{ "size", RESOLUTION_PAIR },
+		{ "maxSize", RESOLUTION_PAIR },
 		{ "origin", NORMALIZED_PAIR },
 		{ "rotation", FLOAT },
 		{ "rotationOrigin", NORMALIZED_PAIR },
@@ -157,8 +157,8 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "showSnapshotDelay", BOOLEAN } } },
 	{ "carousel", {
 		{ "type", STRING },
-		{ "size", NORMALIZED_PAIR },
-		{ "pos", NORMALIZED_PAIR },
+		{ "size", RESOLUTION_PAIR },
+		{ "pos", RESOLUTION_PAIR },
 		{ "origin", NORMALIZED_PAIR },
 		{ "color", COLOR },
 		{ "colorEnd", COLOR },
@@ -222,6 +222,7 @@ std::string resolvePlaceholders(const char* in)
 ThemeData::ThemeData()
 {
 	mVersion = 0;
+	mResolution = { 1, 1 };
 }
 
 void ThemeData::loadFile(std::map<std::string, std::string> sysDataMap, const std::string& path)
@@ -235,6 +236,7 @@ void ThemeData::loadFile(std::map<std::string, std::string> sysDataMap, const st
 		throw error << "File does not exist!";
 
 	mVersion = 0;
+	mResolution = { 1, 1 };
 	mViews.clear();
 	mVariables.clear();
 
@@ -256,6 +258,23 @@ void ThemeData::loadFile(std::map<std::string, std::string> sysDataMap, const st
 
 	if(mVersion < MINIMUM_THEME_FORMAT_VERSION)
 		throw error << "Theme uses format version " << mVersion << ". Minimum supported version is " << MINIMUM_THEME_FORMAT_VERSION << ".";
+
+	// parse resolution
+	std::string resolution = root.child("resolution").text().as_string("");
+
+	if(resolution.size())
+	{
+		size_t divider = resolution.find(' ');
+
+		if(divider != std::string::npos)
+		{
+			std::string w = resolution.substr(0, divider);
+			std::string h = resolution.substr(divider, std::string::npos);
+
+			mResolution.x() = (float)atof(w.c_str());
+			mResolution.y() = (float)atof(h.c_str());
+		}
+	}
 
 	parseVariables(root);
 	parseIncludes(root);
@@ -419,6 +438,45 @@ void ThemeData::parseElement(const pugi::xml_node& root, const std::map<std::str
 
 		switch(typeIt->second)
 		{
+		case RESOLUTION_RECT:
+		{
+			Vector4f val;
+
+			auto splits = Utils::String::delimitedStringToVector(str, " ");
+			if (splits.size() == 2)
+			{
+				val = Vector4f((float)atof(splits.at(0).c_str()), (float)atof(splits.at(1).c_str()),
+					(float)atof(splits.at(0).c_str()), (float)atof(splits.at(1).c_str()));
+			}
+			else if (splits.size() == 4)
+			{
+				val = Vector4f((float)atof(splits.at(0).c_str()), (float)atof(splits.at(1).c_str()),
+					(float)atof(splits.at(2).c_str()), (float)atof(splits.at(3).c_str()));
+			}
+
+			element.properties[node.name()] = val / Vector4f(mResolution.x(), mResolution.y(), mResolution.x(), mResolution.y());
+			break;
+		}
+		case RESOLUTION_PAIR:
+		{
+			size_t divider = str.find(' ');
+			if(divider == std::string::npos)
+				throw error << "invalid normalized pair (property \"" << node.name() << "\", value \"" << str.c_str() << "\")";
+
+			std::string first = str.substr(0, divider);
+			std::string second = str.substr(divider, std::string::npos);
+
+			Vector2f val((float)atof(first.c_str()), (float)atof(second.c_str()));
+
+			element.properties[node.name()] = val / mResolution;
+			break;
+		}
+		case RESOLUTION_FLOAT:
+		{
+			float val = static_cast<float>(strtod(str.c_str(), 0));
+			element.properties[node.name()] = val / mResolution.y();
+			break;
+		}
 		case NORMALIZED_RECT:
 		{
 			Vector4f val;

--- a/es-core/src/ThemeData.h
+++ b/es-core/src/ThemeData.h
@@ -144,6 +144,9 @@ public:
 
 	enum ElementPropertyType
 	{
+		RESOLUTION_RECT,
+		RESOLUTION_PAIR,
+		RESOLUTION_FLOAT,
 		NORMALIZED_RECT,
 		NORMALIZED_PAIR,
 		PATH,
@@ -172,6 +175,7 @@ private:
 
 	std::deque<std::string> mPaths;
 	float mVersion;
+	Vector2f mResolution;
 
 	void parseFeatures(const pugi::xml_node& themeRoot);
 	void parseIncludes(const pugi::xml_node& themeRoot);


### PR DESCRIPTION
```
<theme>
	<formatVersion>6</formatVersion>
	<resolution>1920 1080</resolution>
```

This allows theme makers to use pixel values for most items in the theme instead of using percentages.
What ES will do then is take the pixel values and divide by the set resolution on load, so they end up being the percentages again in the end.

```
		<image name="centerfade" extra="true">
			<path>${themeArtFolder}/centerfade.png</path>
			<size>1920 540</size>
			<pos>960 540</pos>
			<origin>0.5 0.5</origin>
			<color>${themeColor}50</color>
		</image>
```

versus

```
		<image name="centerfade" extra="true">
			<path>${themeArtFolder}/centerfade.png</path>
			<size>1 0.5</size>
			<pos>0.5 0.5</pos>
			<origin>0.5 0.5</origin>
			<color>${themeColor}50</color>
		</image>
```

resolution defaults to 1 1 so this wont break existing themes.

This is a complete rewrite of Carbon to take advantage of variables, this resolution pr and adds gridview.
https://github.com/tomaz82/es-theme-carbon
