### PR TITLE
gridview: ignore placeholders on metadata updates

### DIFF
--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -133,7 +133,7 @@ FileData* GridGameListView::getCursor()
 
 void GridGameListView::setCursor(FileData* file)
 {
-	if(!mGrid.setCursor(file))
+	if(!mGrid.setCursor(file) && (!file->isPlaceHolder()))
 	{
 		populateList(file->getParent()->getChildrenListToDisplay());
 		mGrid.setCursor(file);


### PR DESCRIPTION
Similar to https://github.com/RetroPie/EmulationStation/blob/7c346209dfc56af3685e9a309e2fa2e7b8d27650/es-app/src/views/gamelist/BasicGameListView.cpp#L66.

Prevents ES crashing when trying to update metadata on a placeholder value, like the 1st entry on an empty custom collection.