### PR TITLE
Expand sort by filename to ignore common English articles, and persist setting

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -249,6 +249,7 @@ void FileData::removeChild(FileData* file)
 
 void FileData::sort(ComparisonFunction& comparator, bool ascending)
 {
+
 	std::stable_sort(mChildren.begin(), mChildren.end(), comparator);
 
 	for(auto it = mChildren.cbegin(); it != mChildren.cend(); it++)
@@ -259,6 +260,7 @@ void FileData::sort(ComparisonFunction& comparator, bool ascending)
 
 	if(!ascending)
 		std::reverse(mChildren.begin(), mChildren.end());
+
 }
 
 void FileData::sort(const SortType& type)

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -78,12 +78,13 @@ public:
 	typedef bool ComparisonFunction(const FileData* a, const FileData* b);
 	struct SortType
 	{
+		int id;
 		ComparisonFunction* comparisonFunction;
 		bool ascending;
 		std::string description;
 
-		SortType(ComparisonFunction* sortFunction, bool sortAscending, const std::string & sortDescription)
-			: comparisonFunction(sortFunction), ascending(sortAscending), description(sortDescription) {}
+		SortType(int id, ComparisonFunction* sortFunction, bool sortAscending, const std::string & sortDescription)
+			: id(id), comparisonFunction(sortFunction), ascending(sortAscending), description(sortDescription) {}
 	};
 
 	void sort(ComparisonFunction& comparator, bool ascending = true);

--- a/es-app/src/FileSorts.cpp
+++ b/es-app/src/FileSorts.cpp
@@ -4,36 +4,40 @@
 
 namespace FileSorts
 {
+
 	const FileData::SortType typesArr[] = {
-		FileData::SortType(&compareName, true, "filename, ascending"),
-		FileData::SortType(&compareName, false, "filename, descending"),
+		FileData::SortType(NAME_ASC, &compareName, true, "filename, ascending"),
+		FileData::SortType(NAME_DESC, &compareName, false, "filename, descending"),
 
-		FileData::SortType(&compareRating, true, "rating, ascending"),
-		FileData::SortType(&compareRating, false, "rating, descending"),
+		FileData::SortType(NAME_IGNORE_ARTICLES_ASC, &compareNameIgnoreArticles, true, "filename (ignore articles), ascending"),
+		FileData::SortType(NAME_IGNORE_ARTICLES_DESC, &compareNameIgnoreArticles, false, "filename (ignore articles), descending"),
 
-		FileData::SortType(&compareTimesPlayed, true, "times played, ascending"),
-		FileData::SortType(&compareTimesPlayed, false, "times played, descending"),
+		FileData::SortType(RATING_ASC, &compareRating, true, "rating, ascending"),
+		FileData::SortType(RATING_DESC, &compareRating, false, "rating, descending"),
 
-		FileData::SortType(&compareLastPlayed, true, "last played, ascending"),
-		FileData::SortType(&compareLastPlayed, false, "last played, descending"),
+		FileData::SortType(TIMES_PLAYED_ASC, &compareTimesPlayed, true, "times played, ascending"),
+		FileData::SortType(TIMES_PLAYED_DESC, &compareTimesPlayed, false, "times played, descending"),
 
-		FileData::SortType(&compareNumPlayers, true, "number players, ascending"),
-		FileData::SortType(&compareNumPlayers, false, "number players, descending"),
+		FileData::SortType(LAST_PLAYED_ASC, &compareLastPlayed, true, "last played, ascending"),
+		FileData::SortType(LAST_PLAYED_DESC, &compareLastPlayed, false, "last played, descending"),
 
-		FileData::SortType(&compareReleaseDate, true, "release date, ascending"),
-		FileData::SortType(&compareReleaseDate, false, "release date, descending"),
+		FileData::SortType(NUM_PLAYERS_ASC, &compareNumPlayers, true, "number players, ascending"),
+		FileData::SortType(NUM_PLAYERS_DESC, &compareNumPlayers, false, "number players, descending"),
 
-		FileData::SortType(&compareGenre, true, "genre, ascending"),
-		FileData::SortType(&compareGenre, false, "genre, descending"),
+		FileData::SortType(RELEASE_DATE_ASC, &compareReleaseDate, true, "release date, ascending"),
+		FileData::SortType(RELEASE_DATE_DESC, &compareReleaseDate, false, "release date, descending"),
 
-		FileData::SortType(&compareDeveloper, true, "developer, ascending"),
-		FileData::SortType(&compareDeveloper, false, "developer, descending"),
+		FileData::SortType(GENRE_ASC, &compareGenre, true, "genre, ascending"),
+		FileData::SortType(GENRE_DESC, &compareGenre, false, "genre, descending"),
 
-		FileData::SortType(&comparePublisher, true, "publisher, ascending"),
-		FileData::SortType(&comparePublisher, false, "publisher, descending"),
+		FileData::SortType(DEVELOPER_ASC, &compareDeveloper, true, "developer, ascending"),
+		FileData::SortType(DEVELOPER_DESC, &compareDeveloper, false, "developer, descending"),
 
-		FileData::SortType(&compareSystem, true, "system, ascending"),
-		FileData::SortType(&compareSystem, false, "system, descending")
+		FileData::SortType(PUBLISHER_ASC, &comparePublisher, true, "publisher, ascending"),
+		FileData::SortType(PUBLISHER_DESC, &comparePublisher, false, "publisher, descending"),
+
+		FileData::SortType(SYSTEM_ASC, &compareSystem, true, "system, ascending"),
+		FileData::SortType(SYSTEM_DESC, &compareSystem, false, "system, descending")
 	};
 
 	const std::vector<FileData::SortType> SortTypes(typesArr, typesArr + sizeof(typesArr)/sizeof(typesArr[0]));
@@ -50,6 +54,44 @@ namespace FileSorts
 		if(name2.empty()){
 			name2 = Utils::String::toUpper(file2->metadata.get("name"));
 		}
+		return name1.compare(name2) < 0;
+	}
+
+	//returns if file1 should come before file2, ignores articles ("the", "a") while sorting
+	bool compareNameIgnoreArticles(const FileData* file1, const FileData* file2)
+	{
+		// we compare the actual metadata name, as collection files have the system appended which messes up the order
+		std::string name1 = Utils::String::toUpper(file1->metadata.get("sortname"));
+		std::string name2 = Utils::String::toUpper(file2->metadata.get("sortname"));
+		if(name1.empty()){
+			name1 = Utils::String::toUpper(file1->metadata.get("name"));
+		}
+		if(name2.empty()){
+			name2 = Utils::String::toUpper(file2->metadata.get("name"));
+		}
+
+		//Filter out any common leading English articles
+		//(This can probably be optimized via a loop and external lookup of some kind)
+		if (Utils::String::startsWith(name1, "A ")) {
+			name1 = Utils::String::replace(name1, "A ", "");
+		}
+		else if (Utils::String::startsWith(name1, "AN ")) {
+			name1 = Utils::String::replace(name1, "AN ", "");
+		}
+		else if (Utils::String::startsWith(name1, "THE ")) {
+			name1 = Utils::String::replace(name1, "THE ", "");
+		}
+
+		if (Utils::String::startsWith(name2, "A ")) {
+			name2 = Utils::String::replace(name2, "A ", "");
+		}
+		else if (Utils::String::startsWith(name2, "AN ")) {
+			name2 = Utils::String::replace(name2, "AN ", "");
+		}
+		else if (Utils::String::startsWith(name2, "THE ")) {
+			name2 = Utils::String::replace(name2, "THE ", "");
+		}
+
 		return name1.compare(name2) < 0;
 	}
 

--- a/es-app/src/FileSorts.h
+++ b/es-app/src/FileSorts.h
@@ -7,7 +7,34 @@
 
 namespace FileSorts
 {
+	
+	enum SortType {
+		NAME_ASC,
+		NAME_DESC,
+		NAME_IGNORE_ARTICLES_ASC,
+		NAME_IGNORE_ARTICLES_DESC,
+		RATING_ASC,
+		RATING_DESC,
+		TIMES_PLAYED_ASC,
+		TIMES_PLAYED_DESC,
+		LAST_PLAYED_ASC,
+		LAST_PLAYED_DESC,
+		NUM_PLAYERS_ASC,
+		NUM_PLAYERS_DESC,
+		RELEASE_DATE_ASC,
+		RELEASE_DATE_DESC,
+		GENRE_ASC,
+		GENRE_DESC,
+		DEVELOPER_ASC,
+		DEVELOPER_DESC,
+		PUBLISHER_ASC,
+		PUBLISHER_DESC,
+		SYSTEM_ASC,
+		SYSTEM_DESC
+	};
+
 	bool compareName(const FileData* file1, const FileData* file2);
+	bool compareNameIgnoreArticles(const FileData* file1, const FileData* file2);
 	bool compareRating(const FileData* file1, const FileData* file2);
 	bool compareTimesPlayed(const FileData* file1, const FileData* file2);
 	bool compareLastPlayed(const FileData* file1, const FileData* file2);

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -35,7 +35,9 @@ SystemData::SystemData(const std::string& name, const std::string& fullName, Sys
 		if(!Settings::getInstance()->getBool("IgnoreGamelist"))
 			parseGamelist(this);
 
-		mRootFolder->sort(FileSorts::SortTypes.at(0));
+		//Apply previously saved SortType to all game lists on startup
+		const FileData::SortType& sort = FileSorts::SortTypes.at(Settings::getInstance()->getInt("SortType"));
+		mRootFolder->sort(sort);
 
 		indexAllGameFilters(mRootFolder);
 	}

--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -15,10 +15,11 @@ class GuiGamelistOptions : public GuiComponent
 public:
 	GuiGamelistOptions(Window* window, SystemData* system);
 	virtual ~GuiGamelistOptions();
-
+	void save();
 	virtual bool input(InputConfig* config, Input input) override;
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 	virtual HelpStyle getHelpStyle() override;
+	inline void addSaveFunc(const std::function<void()>& func) { mSaveFuncs.push_back(func); };
 
 private:
 	void openGamelistFilter();
@@ -39,6 +40,8 @@ private:
 	IGameListView* getGamelist();
 	bool fromPlaceholder;
 	bool mFiltersChanged;
+
+	std::vector< std::function<void()> > mSaveFuncs;
 };
 
 #endif // ES_APP_GUIS_GUI_GAME_LIST_OPTIONS_H

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -436,6 +436,7 @@ void ViewController::render(const Transform4x4f& parentTrans)
 
 void ViewController::preload()
 {
+	
 	uint32_t i = 0;
 	for(auto it = SystemData::sSystemVector.cbegin(); it != SystemData::sSystemVector.cend(); it++)
 	{
@@ -451,7 +452,9 @@ void ViewController::preload()
 
 		(*it)->getIndex()->resetFilters();
 		getGameListView(*it);
+
 	}
+
 }
 
 void ViewController::reloadGameListView(IGameListView* view, bool reloadTheme)

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -6,6 +6,8 @@
 #include "CollectionSystemManager.h"
 #include "Settings.h"
 #include "SystemData.h"
+#include "FileSorts.h"
+#include "FileData.h"
 
 BasicGameListView::BasicGameListView(Window* window, FileData* root)
 	: ISimpleGameListView(window, root), mList(window)
@@ -14,6 +16,10 @@ BasicGameListView::BasicGameListView(Window* window, FileData* root)
 	mList.setPosition(0, mSize.y() * 0.2f);
 	mList.setDefaultZIndex(20);
 	addChild(&mList);
+
+	//Apply previously saved SortType to all game lists on startup
+	const FileData::SortType& sort = FileSorts::SortTypes.at(Settings::getInstance()->getInt("SortType"));
+	root->sort(sort);
 
 	populateList(root->getChildrenListToDisplay());
 }
@@ -54,6 +60,7 @@ void BasicGameListView::populateList(const std::vector<FileData*>& files)
 	{
 		addPlaceholder();
 	}
+
 }
 
 FileData* BasicGameListView::getCursor()

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -164,6 +164,8 @@ void Settings::setDefaults()
 	mIntMap["ScreenOffsetX"] = 0;
 	mIntMap["ScreenOffsetY"] = 0;
 	mIntMap["ScreenRotate"]  = 0;
+
+	mIntMap["SortType"]  = 0;
 }
 
 template <typename K, typename V>


### PR DESCRIPTION
This enhancement adds sorting of file names ignoring common leading English articles (a, an, the) in both ascending and descending order, similar to other media-based systems.  It also applies the change to all systems across the board, and it persists the change so it can be restored upon restart/reboot.
 
For example:

[FILENAME, ASCENDING]
A Boy and His Blob
Adventures of Lolo
Marble Madness
The Legend of Zelda
Yoshi's Cookie

[FILENAME (IGNORE ARTICLES), ASCENDING]
Adventures of Lolo
A Boy and His Blob
The Legend of Zelda
Marble Madness
Yoshi's Cookie

Changes:
* Adds SortType enum to FileSorts namespace so values can be uniquely referenced by ID
* Adds sort by filename with common leading articles ignored (hard-coded with room for optimization)
* Applies SortType selection across all systems on value change
* Saves and persists SortType selection for future sessions (es_settings.cfg)
* Applies SortType selection across all systems on ES startup