### PR TITLE
cmake: use the non-glvnd version of GL libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,9 @@ option(USE_MESA_GLES "Set to ON to select the MESA OpenGL ES driver" ${USE_MESA_
 option(USE_GLES1 "Set to ON to force usage of the OpenGLES v1 renderer" ${USE_GLES1})
 
 # OpenGL library preference (https://cmake.org/cmake/help/git-stage/policy/CMP0072.html)
+# Set it to OLD to appease older proprietary drivers without libglvnd support
 if(POLICY CMP0072)
-   cmake_policy(SET CMP0072 NEW)
+   cmake_policy(SET CMP0072 OLD)
 endif()
 
 project(emulationstation-all)


### PR DESCRIPTION
Changed the CMP0072[1] `cmake` policy to use `libGL` for OPENGL_LIBRARIES,
instead of `libOpenGL`, provided by `libglvnd` (default from `cmake` 3.11).

This should fix situations where there the OpenGL implementation doesn't have
`glvnd` support and `emulationstation` gets linked to the `glvnd` library.`libSDL2`
dl-loads a different `libGL` and this results in a non-working GL context.

[1] https://cmake.org/cmake/help/git-stage/policy/CMP0072.html

Should fix #727 and probably other issues reported in the forums with recent Ubuntu (20.x) that have a new `cmake` version.