### PR TITLE
Add option to ignore common leading articles in Filename sort

### DIFF
--- a/es-app/src/FileSorts.cpp
+++ b/es-app/src/FileSorts.cpp
@@ -1,9 +1,12 @@
 #include "FileSorts.h"
 
 #include "utils/StringUtil.h"
+#include "Settings.h"
+#include "Log.h"
 
 namespace FileSorts
 {
+
 	const FileData::SortType typesArr[] = {
 		FileData::SortType(&compareName, true, "filename, ascending"),
 		FileData::SortType(&compareName, false, "filename, descending"),
@@ -50,6 +53,9 @@ namespace FileSorts
 		if(name2.empty()){
 			name2 = Utils::String::toUpper(file2->metadata.get("name"));
 		}
+
+		ignoreLeadingArticles(name1, name2);
+
 		return name1.compare(name2) < 0;
 	}
 
@@ -115,4 +121,31 @@ namespace FileSorts
 		std::string system2 = Utils::String::toUpper(file2->getSystemName());
 		return system1.compare(system2) < 0;
 	}
+
+	//If option is enabled, ignore leading articles by temporarily modifying the name prior to sorting
+	//(Artciles are defined within the settings config file)
+	void ignoreLeadingArticles(std::string &name1, std::string &name2) {
+
+		if (Settings::getInstance()->getBool("IgnoreLeadingArticles"))
+		{
+
+			std::vector<std::string> articles = Utils::String::delimitedStringToVector(Settings::getInstance()->getString("LeadingArticles"), ",");
+
+			for(Utils::String::stringVector::iterator it = articles.begin(); it != articles.end(); it++)
+			{
+			
+				if (Utils::String::startsWith(Utils::String::toUpper(name1), Utils::String::toUpper(it[0]) + " ")) {
+					name1 = Utils::String::replace(Utils::String::toUpper(name1), Utils::String::toUpper(it[0]) + " ", "");
+				}
+
+				if (Utils::String::startsWith(Utils::String::toUpper(name2), Utils::String::toUpper(it[0]) + " ")) {
+					name2 = Utils::String::replace(Utils::String::toUpper(name2), Utils::String::toUpper(it[0]) + " ", "");
+				}
+
+			}
+
+		}
+
+	}
+
 };

--- a/es-app/src/FileSorts.h
+++ b/es-app/src/FileSorts.h
@@ -18,6 +18,8 @@ namespace FileSorts
 	bool comparePublisher(const FileData* file1, const FileData* file2);
 	bool compareSystem(const FileData* file1, const FileData* file2);
 
+	void ignoreLeadingArticles(std::string &name1, std::string &name2);
+
 	extern const std::vector<FileData::SortType> SortTypes;
 };
 

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -76,6 +76,7 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 
 		mMenu.addWithLabel("SORT GAMES BY", mListSort);
 	}
+	
 	// show filtered menu
 	if(!Settings::getInstance()->getBool("ForceDisableFilters"))
 	{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -19,6 +19,9 @@
 #include <SDL_events.h>
 #include <algorithm>
 #include "platform.h"
+#include "FileSorts.h"
+#include "views/gamelist/IGameListView.h"
+#include "guis/GuiInfoPopup.h"
 
 GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MENU"), mVersion(window)
 {
@@ -330,6 +333,32 @@ void GuiMenu::openUISettings()
 		Settings::getInstance()->setString("GamelistViewStyle", gamelist_style->getSelected());
 		if (needReload)
 			ViewController::get()->reloadAll();
+	});
+
+	// Optionally ignore leading articles when sorting game titles
+	auto ignore_articles = std::make_shared<SwitchComponent>(mWindow);
+	ignore_articles->setState(Settings::getInstance()->getBool("IgnoreLeadingArticles"));
+	s->addWithLabel("IGNORE ARTICLES (NAME SORT ONLY)", ignore_articles);
+	s->addSaveFunc([ignore_articles, window] {
+		bool articles_are_ignored = Settings::getInstance()->getBool("IgnoreLeadingArticles");
+		Settings::getInstance()->setBool("IgnoreLeadingArticles", ignore_articles->getState());
+		if (ignore_articles->getState() != articles_are_ignored)
+		{
+			//For each system...
+			for (auto it = SystemData::sSystemVector.cbegin(); it != SystemData::sSystemVector.cend(); it++)
+			{
+				//Apply sort recursively
+				FileData* root = (*it)->getRootFolder();
+				root->sort(getSortTypeFromString(root->getSortName()));
+
+				//Notify that the root folder was sorted
+				ViewController::get()->getGameListView((*it))->onFileChanged(root, FILE_SORTED);
+			}
+
+			//Display popup to inform user
+			GuiInfoPopup* popup = new GuiInfoPopup(window, "Files sorted", 4000);
+			window->setInfoPopup(popup);
+		}
 	});
 
 	// Optionally start in selected system

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -4,6 +4,8 @@
 
 #include "components/MenuComponent.h"
 #include "GuiComponent.h"
+#include "components/OptionListComponent.h"
+#include "FileData.h"
 
 class GuiMenu : public GuiComponent
 {
@@ -29,6 +31,9 @@ private:
 
 	MenuComponent mMenu;
 	TextComponent mVersion;
+
+	typedef OptionListComponent<const FileData::SortType*> SortList;
+	std::shared_ptr<SortList> mListSort;
 };
 
 #endif // ES_APP_GUIS_GUI_MENU_H

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -164,6 +164,11 @@ void Settings::setDefaults()
 	mIntMap["ScreenOffsetX"] = 0;
 	mIntMap["ScreenOffsetY"] = 0;
 	mIntMap["ScreenRotate"]  = 0;
+
+	mBoolMap["IgnoreLeadingArticles"] = false;
+	//No spaces!  Order is important!
+	//"The A Squad" given [a,an,the] will sort as "A Squad", but given [the,a,an] will sort as "Squad"
+	mStringMap["LeadingArticles"] = "a,an,the";
 }
 
 template <typename K, typename V>


### PR DESCRIPTION
This enhancement replaces #726 by adding an option called `Ignore Articles (Name Sort Only)` to the START menu.  When enabled, common leading articles are ignored in both ascending and descending order while sorting each system's game titles, similar to popular multimedia-based systems.  The comma-delimited list of articles is stored within the `es_settings.cfg` file as `LeadingArticles`.  By default, common English articles "a", "an", and "the" are ignored, and others may be added to the list manually.  (This also allows more articles to be easily added to the default setting going forward.)  The option itself is persisted as `IgnoreLeadingArticles`.

~~Additionally, all file sorting options are consolidated into one application-wide location by moving the `Sort Games By` selection from the SELECT menu to the START menu (see attached image).  Upon value change, the selection is applied to all systems across the board, and the `SortType` ID is stored within the settings file so it can be restored upon restart/reboot.~~

~~Lastly, a popup message is displayed whenever sorting has been re-performed in response to either of the above selections.~~

Additionally, a popup message is displayed whenever sorting has been re-performed in response to the selection above.

```
Examples:

[SortType = FILENAME ASC, IgnoreLeadingArticles = false]

A Boy and His Blob
Adventures of Lolo
Marble Madness
The Legend of Zelda
Yoshi's Cookie

[SortType = FILENAME ASC, IgnoreLeadingArticles = true]

Adventures of Lolo
A Boy and His Blob   <-- article ignored
The Legend of Zelda   <-- article ignored
Marble Madness
Yoshi's Cookie
```

Changes:
* Adds `Ignore Articles (Name Sort Only)` option to the UI Settings (START) menu
* Adds `IgnoreLeadingArticles` boolean to settings
* Adds `LeadingArticles` string to settings
* Applies `IgnoreLeadingArticles` selection across all systems on value change and ES startup
* ~~Moves `Sort Games By` option from the Options (SELECT) menu to the UI Settings (START) menu~~
* ~~Adds `SortType` enum to `FileSorts` namespace so values can be uniquely referenced by ID~~
* ~~Adds `SortType` int to settings~~
* ~~Applies `SortType` selection across all systems on value change and ES startup~~

Notes:
* `IgnoreLeadingArticles` logic cannot be applied to sort types other than Filename ASC/DESC due to the way the sorting logic compares two files without any outside knowledge of broader intent or scope.  Currently, other sort types group files by their associated comparator (e.g. Rating, Times Played, Developer, etc.).  Ideally, though, the names _within_ each group would be alphabetized ASC/DESC.  For example, sorting by year would display something like `1998 A-Z`, `1995 A-Z`, `1986 A-Z`, etc. (or `1998 Z-A`, `1995 Z-A`, `1986 Z-A` if DESC).  Without that logic in place, `IgnoreLeadingArticles` currently doesn't make sense outside the scope of Filename.

![image](https://user-images.githubusercontent.com/53459459/106521675-944a9380-64ac-11eb-912b-c5603fbd30a6.png)

