### PR TITLE
Full screen paging in gamelist view with lb/rb

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -354,6 +354,14 @@ void GuiMenu::openUISettings()
 		}
 	});
 
+	// lb/rb uses full screen size paging instead of -10/+10 steps
+	auto use_fullscreen_paging = std::make_shared<SwitchComponent>(mWindow);
+	use_fullscreen_paging->setState(Settings::getInstance()->getBool("UseFullscreenPaging"));
+	s->addWithLabel("USE FULL SCREEN PAGING FOR LB/RB", use_fullscreen_paging);
+	s->addSaveFunc([use_fullscreen_paging] {
+		Settings::getInstance()->setBool("UseFullscreenPaging", use_fullscreen_paging->getState());
+	});
+
 	// Optionally start in selected system
 	auto systemfocus_list = std::make_shared< OptionListComponent<std::string> >(mWindow, "START ON SYSTEM", false);
 	systemfocus_list->add("NONE", "", Settings::getInstance()->getString("StartupSystem") == "");

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -168,6 +168,8 @@ void Settings::setDefaults()
 	mIntMap["ScreenOffsetY"] = 0;
 	mIntMap["ScreenRotate"]  = 0;
 
+	mBoolMap["UseFullscreenPaging"] = false;
+
 	mBoolMap["IgnoreLeadingArticles"] = false;
 	//No spaces!  Order is important!
 	//"The A Squad" given [a,an,the] will sort as "A Squad", but given [the,a,an] will sort as "Squad"


### PR DESCRIPTION
Configurable option to allow full page up down with lb/rb.

Default is off ("use full screen paging for lb/rb" in UI Settings), which is the current implementation: -10/+10 per lb/rb press.

Refers to: 
https://retropie.org.uk/forum/topic/29459/page-up-down-function-on-es-textlists-via-lb-rb-not-accurate