### PR TITLE
Remove from favorites/collections with double press of Y button

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -4,6 +4,7 @@
 #include "utils/FileSystemUtil.h"
 #include "utils/StringUtil.h"
 #include "views/gamelist/IGameListView.h"
+#include "views/gamelist/ISimpleGameListView.h"
 #include "views/ViewController.h"
 #include "FileData.h"
 #include "FileFilterIndex.h"
@@ -455,7 +456,7 @@ void CollectionSystemManager::exitEditMode()
 }
 
 // adds or removes a game from a specific collection
-bool CollectionSystemManager::toggleGameInCollection(FileData* file)
+bool CollectionSystemManager::toggleGameInCollection(FileData* file, int presscount)
 {
 	if (file->getType() == GAME)
 	{
@@ -481,6 +482,9 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file)
 			SystemData* systemViewToUpdate = getSystemToView(sysData);
 
 			if (found) {
+				if (needDoublePress(presscount)) {
+					return true;
+				}
 				adding = false;
 				// if we found it, we need to remove it
 				FileData* collectionEntry = children.at(key);
@@ -521,6 +525,9 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file)
 			}
 			else
 			{
+				if (needDoublePress(presscount)) {
+					return true;
+				}
 				adding = false;
 				md->set("favorite", "false");
 			}
@@ -543,6 +550,7 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file)
 	}
 	return false;
 }
+
 
 SystemData* CollectionSystemManager::getSystemToView(SystemData* sys)
 {
@@ -1038,6 +1046,17 @@ bool CollectionSystemManager::includeFileInAutoCollections(FileData* file)
 	// if/when there are more in the future, maybe this can be a more complex method, with a proper list
 	// but for now a simple string comparison is more performant
 	return file->getName() != "kodi" && file->getSystem()->isGameSystem();
+}
+
+
+bool CollectionSystemManager::needDoublePress(int presscount) {
+	if (Settings::getInstance()->getBool("DoublePressRemovesFromFavs") && presscount < 2) {
+		GuiInfoPopup* toast = new GuiInfoPopup(mWindow, "Press again to remove from '" + Utils::String::toUpper(mEditingCollection)
+		+ "'", ISimpleGameListView::DOUBLE_PRESS_DETECTION_DURATION, 100, 200);
+		mWindow->setInfoPopup(toast);
+		return true;
+	}
+	return false;
 }
 
 std::string getCustomCollectionConfigPath(std::string collectionName)

--- a/es-app/src/CollectionSystemManager.h
+++ b/es-app/src/CollectionSystemManager.h
@@ -71,7 +71,7 @@ public:
 	void exitEditMode();
 	inline bool isEditing() { return mIsEditingCustom; };
 	inline std::string getEditingCollection() { return mEditingCollection; };
-	bool toggleGameInCollection(FileData* file);
+	bool toggleGameInCollection(FileData* file, int presscount);
 
 	SystemData* getSystemToView(SystemData* sys);
 	void updateCollectionFolderMetadata(SystemData* sys);
@@ -109,6 +109,8 @@ private:
 	bool themeFolderExists(std::string folder);
 
 	bool includeFileInAutoCollections(FileData* file);
+
+	bool needDoublePress(int presscount);
 
 	SystemData* mCustomCollectionsBundle;
 };

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -79,6 +79,11 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	toggleSystemNameInCollections->setState(Settings::getInstance()->getBool("CollectionShowSystemInfo"));
 	mMenu.addWithLabel("SHOW SYSTEM NAME IN COLLECTIONS", toggleSystemNameInCollections);
 
+	// double press to remove from favorites
+	doublePressToRemoveFavs = std::make_shared<SwitchComponent>(mWindow);
+	doublePressToRemoveFavs->setState(Settings::getInstance()->getBool("DoublePressRemovesFromFavs"));
+	mMenu.addWithLabel("PRESS (Y) TWICE TO REMOVE FROM FAVS./COLL.", doublePressToRemoveFavs);
+
 	if(CollectionSystemManager::get()->isEditing())
 	{
 		row.elements.clear();
@@ -176,7 +181,10 @@ void GuiCollectionSystemsOptions::applySettings()
 	bool prevBundle = Settings::getInstance()->getBool("UseCustomCollectionsSystem");
 	bool prevShow = Settings::getInstance()->getBool("CollectionShowSystemInfo");
 	bool outShow = toggleSystemNameInCollections->getState();
-	bool needUpdateSettings = prevAuto != outAuto || prevCustom != outCustom || outSort != prevSort || outBundle != prevBundle || prevShow != outShow ;
+	bool prevDblPressRmFavs = Settings::getInstance()->getBool("DoublePressRemovesFromFavs");
+	bool outDblPressRmFavs = doublePressToRemoveFavs->getState();
+	bool needUpdateSettings = prevAuto != outAuto || prevCustom != outCustom || outSort != prevSort || outBundle != prevBundle
+		|| prevShow != outShow || prevDblPressRmFavs != outDblPressRmFavs;
 	if (needUpdateSettings)
 	{
 		updateSettings(outAuto, outCustom);
@@ -192,6 +200,7 @@ void GuiCollectionSystemsOptions::updateSettings(std::string newAutoSettings, st
 	Settings::getInstance()->setBool("SortAllSystems", sortAllSystemsSwitch->getState());
 	Settings::getInstance()->setBool("UseCustomCollectionsSystem", bundleCustomCollections->getState());
 	Settings::getInstance()->setBool("CollectionShowSystemInfo", toggleSystemNameInCollections->getState());
+	Settings::getInstance()->setBool("DoublePressRemovesFromFavs", doublePressToRemoveFavs->getState());
 	Settings::getInstance()->saveFile();
 	CollectionSystemManager::get()->loadEnabledListFromSettings();
 	CollectionSystemManager::get()->updateSystemsList();

--- a/es-app/src/guis/GuiCollectionSystemsOptions.h
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.h
@@ -31,6 +31,7 @@ private:
 	std::shared_ptr<SwitchComponent> sortAllSystemsSwitch;
 	std::shared_ptr<SwitchComponent> bundleCustomCollections;
 	std::shared_ptr<SwitchComponent> toggleSystemNameInCollections;
+	std::shared_ptr<SwitchComponent> doublePressToRemoveFavs;
 	MenuComponent mMenu;
 	SystemData* mSystem;
 };

--- a/es-app/src/guis/GuiInfoPopup.cpp
+++ b/es-app/src/guis/GuiInfoPopup.cpp
@@ -5,8 +5,8 @@
 #include "components/TextComponent.h"
 #include <SDL_timer.h>
 
-GuiInfoPopup::GuiInfoPopup(Window* window, std::string message, int duration) :
-	GuiComponent(window), mMessage(message), mDuration(duration), running(true)
+GuiInfoPopup::GuiInfoPopup(Window* window, std::string message, int duration, int fadein, int fadeout) :
+	GuiComponent(window), mMessage(message), mDuration(duration), mFadein(fadein), mFadeout(fadeout), running(true)
 {
 	mFrame = new NinePatchComponent(window);
 	float maxWidth = Renderer::getScreenWidth() * 0.9f;
@@ -96,16 +96,16 @@ bool GuiInfoPopup::updateState()
 		running = false;
 		return false;
 	}
-	else if (curTime - mStartTime <= 500) {
-		alpha = ((curTime - mStartTime)*255/500);
+	else if (curTime - mStartTime <= mFadein) {
+		alpha = (curTime - mStartTime) * 255 / mFadein;
 	}
-	else if (curTime - mStartTime < mDuration - 500)
+	else if (curTime - mStartTime < mDuration - mFadeout)
 	{
 		alpha = 255;
 	}
 	else
 	{
-		alpha = ((-(curTime - mStartTime - mDuration)*255)/500);
+		alpha = -(curTime - mStartTime - mDuration) * 255 / mFadeout;
 	}
 	mGrid->setOpacity((unsigned char)alpha);
 

--- a/es-app/src/guis/GuiInfoPopup.h
+++ b/es-app/src/guis/GuiInfoPopup.h
@@ -11,13 +11,15 @@ class NinePatchComponent;
 class GuiInfoPopup : public GuiComponent, public Window::InfoPopup
 {
 public:
-	GuiInfoPopup(Window* window, std::string message, int duration);
+	GuiInfoPopup(Window* window, std::string message, int duration, int fadein = 500, int fadeout = 500);
 	~GuiInfoPopup();
 	void render(const Transform4x4f& parentTrans) override;
 	inline void stop() { running = false; };
 private:
 	std::string mMessage;
 	int mDuration;
+	int mFadein;
+	int mFadeout;
 	int alpha;
 	bool updateState();
 	int mStartTime;

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -6,6 +6,7 @@
 #include "Settings.h"
 #include "Sound.h"
 #include "SystemData.h"
+#include <SDL_timer.h>
 
 ISimpleGameListView::ISimpleGameListView(Window* window, FileData* root) : IGameListView(window, root),
 	mHeaderText(window), mHeaderImage(window), mBackground(window)
@@ -150,7 +151,8 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 		{
 			if(mRoot->getSystem()->isGameSystem())
 			{
-				if(CollectionSystemManager::get()->toggleGameInCollection(getCursor()))
+				int presscount = getPressCountInDuration();
+				if (CollectionSystemManager::get()->toggleGameInCollection(getCursor(), presscount))
 				{
 					return true;
 				}
@@ -162,11 +164,12 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 }
 
 
-
-
-
-
-
-
-
-
+int ISimpleGameListView::getPressCountInDuration() {
+	Uint32 now = SDL_GetTicks();
+	if (now - firstPressMs < DOUBLE_PRESS_DETECTION_DURATION) {
+		return 2;
+	} else {
+		firstPressMs = now;
+		return 1;
+	}
+}

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -1,3 +1,4 @@
+
 #pragma once
 #ifndef ES_APP_VIEWS_GAME_LIST_ISIMPLE_GAME_LIST_VIEW_H
 #define ES_APP_VIEWS_GAME_LIST_ISIMPLE_GAME_LIST_VIEW_H
@@ -27,6 +28,8 @@ public:
 	virtual bool input(InputConfig* config, Input input) override;
 	virtual void launch(FileData* game) = 0;
 
+	static const int DOUBLE_PRESS_DETECTION_DURATION = 1500; // millis
+
 protected:
 	static const int DESCRIPTION_SCROLL_DELAY = 5 * 1000; // five secs
 
@@ -41,6 +44,10 @@ protected:
 	std::vector<GuiComponent*> mThemeExtras;
 
 	std::stack<FileData*> mCursorStack;
+
+private:
+	int getPressCountInDuration();
+	Uint32 firstPressMs = 0;
 };
 
 #endif // ES_APP_VIEWS_GAME_LIST_ISIMPLE_GAME_LIST_VIEW_H

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -71,6 +71,7 @@ void Settings::setDefaults()
 
 	mBoolMap["EnableSounds"] = true;
 	mBoolMap["ShowHelpPrompts"] = true;
+	mBoolMap["DoublePressRemovesFromFavs"] = false;
 	mBoolMap["ScrapeRatings"] = true;
 	mBoolMap["IgnoreGamelist"] = false;
 	mBoolMap["HideConsole"] = true;


### PR DESCRIPTION
Adds a option which hinders accidentally removal of a game from Favorites or the Collection currently edited.

When enabled a toast / popup is shown to press again to confirm remove (within 1.5sec).
Default is disabled (Option in UI Settings: 'Press (y) twice to remove from favs./coll.'): Removes a favorite when Y is pressed once on a game marked as favorite (as-is implementation).

Refers to:  #326