### PR TITLE
Fixes scroll detection for themes with forceuppercase gamelist display

### DIFF
--- a/es-app/src/components/TextListComponent.h
+++ b/es-app/src/components/TextListComponent.h
@@ -304,7 +304,8 @@ void TextListComponent<T>::update(int deltaTime)
 		mMarqueeOffset2 = 0;
 
 		// if we're not scrolling and this object's text goes outside our size, marquee it!
-		const float textLength = mFont->sizeText(mEntries.at((unsigned int)mCursor).name).x();
+		auto name = mEntries.at((unsigned int)mCursor).name;
+		const float textLength = mFont->sizeText(mUppercase ? Utils::String::toUpper(name) : name).x();
 		const float limit      = mSize.x() - mHorizontalMargin * 2;
 
 		if(textLength > limit)


### PR DESCRIPTION
Fixes the textlength calculation  which is used to detect the scrolling (x-axis) of a long game name in the gamelist view.
This fix honors the uppercase flag if used by a theme to display game names in the gamelist view (e.g. in Carbon theme).

Refers to: https://retropie.org.uk/forum/topic/30133/scroll-of-title-of-game-better-understand-how-it-works