### PR TITLE
fix pokemon mini default platform name

### DIFF
--- a/es-app/src/PlatformId.cpp
+++ b/es-app/src/PlatformId.cpp
@@ -39,7 +39,7 @@ namespace PlatformIds
 		"nds", // nintendo DS
 		"fds", // Famicom Disk System
 		"nes", // nintendo entertainment system
-		"pokemonmini",
+		"pokemini",
 		"channelf", // Fairchild ChannelF
 		"gb", // game boy
 		"gba", // game boy advance


### PR DESCRIPTION
Scraping does not work with pokemon mini

This is because the default name for the platform when installing `lr-pokemini` is `pokemini` and not `pokemonmini`

```
  <system>
    <name>pokemini</name>
    <fullname>Pokemon Mini</fullname>
    <path>/home/pi/RetroPie/roms/pokemini</path>
    <extension>.min .zip .MIN .ZIP</extension>
    <command>/opt/retropie/supplementary/runcommand/runcommand.sh 0 _SYS_ pokemini %ROM%</command>
    <platform>pokemini</platform>
    <theme>pokemini</theme>
  </system>
```