### PR TITLE
Fix issue with svg scaling

### DIFF
--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -76,7 +76,8 @@ bool TextureData::initSVGFromMemory(const unsigned char* fileData, size_t length
 	unsigned char* dataRGBA = new unsigned char[mWidth * mHeight * 4];
 
 	NSVGrasterizer* rast = nsvgCreateRasterizer();
-	nsvgRasterize(rast, svgImage, 0, 0, mHeight / svgImage->height, dataRGBA, (int)mWidth, (int)mHeight, (int)mWidth * 4);
+	float scale = Math::min(mHeight / svgImage->height, mWidth / svgImage->width);
+	nsvgRasterize(rast, svgImage, 0, 0, scale, dataRGBA, (int)mWidth, (int)mHeight, (int)mWidth * 4);
 	nsvgDeleteRasterizer(rast);
 
 	ImageIO::flipPixelsVert(dataRGBA, mWidth, mHeight);


### PR DESCRIPTION
SVGs were getting cropped at the right side based on certain conditions. This was due to the scaling when rasterizing an image only being based on the height.

Before:
![image](https://user-images.githubusercontent.com/6809037/117602732-3f9b6200-b106-11eb-9ea4-9aeab136656f.png)

After:
![image](https://user-images.githubusercontent.com/6809037/117602624-fd722080-b105-11eb-9c47-4c265b356f03.png)
