### PR TITLE
Changes necessary to implement Scripting events for "game-select", "system-select" and "screeensaver-game-select"

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -279,12 +279,13 @@ void FileData::launchGame(Window* window)
 	const std::string rom      = Utils::FileSystem::getEscapedPath(getPath());
 	const std::string basename = Utils::FileSystem::getStem(getPath());
 	const std::string rom_raw  = Utils::FileSystem::getPreferredPath(getPath());
+	const std::string name     = getName();
 
 	command = Utils::String::replace(command, "%ROM%", rom);
 	command = Utils::String::replace(command, "%BASENAME%", basename);
 	command = Utils::String::replace(command, "%ROM_RAW%", rom_raw);
 
-	Scripting::fireEvent("game-start", rom, basename);
+	Scripting::fireEvent("game-start", rom, basename, name);
 
 	LOG(LogInfo) << "	" << command;
 	int exitCode = runSystemCommand(command);

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -11,6 +11,7 @@
 #include "FileData.h"
 #include "FileFilterIndex.h"
 #include "Log.h"
+#include "utils/ProfilingUtil.h"
 #include "PowerSaver.h"
 #include "Scripting.h"
 #include "Sound.h"
@@ -107,12 +108,10 @@ void SystemScreenSaver::startScreenSaver()
 #else
 			mVideoScreensaver = new VideoVlcComponent(mWindow, getTitlePath());
 #endif
-			if (mCurrentGame != NULL) {
+			if (mCurrentGame != NULL) 
+			{
 				Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName(), "randomvideo");
-			} else {
-				Scripting::fireEvent("screensaver-game-select", "NULL", "NULL", "NULL", "randomvideo");
 			}
-
 			mVideoScreensaver->topWindow(true);
 			mVideoScreensaver->setOrigin(0.5f, 0.5f);
 			mVideoScreensaver->setPosition(Renderer::getScreenWidth() / 2.0f, Renderer::getScreenHeight() / 2.0f);
@@ -189,19 +188,13 @@ void SystemScreenSaver::startScreenSaver()
 
 		PowerSaver::runningScreenSaver(true);
 		mTimer = 0;
-		if (mCurrentGame != NULL) {
+		if (mCurrentGame != NULL) 
+		{
 			Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName(), "slideshow");
-		} else {
-			Scripting::fireEvent("screensaver-game-select", "NULL", "NULL", "NULL", "slideshow");
 		}
 		return;
 	}
 	// No videos. Just use a standard screensaver
-        if (mCurrentGame != NULL) {
-            Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName(), "novideo");
-        } else {
-            Scripting::fireEvent("screensaver-game-select", "NULL", "NULL", "NULL", "novideo");
-        }
 	mState = STATE_SCREENSAVER_ACTIVE;
 	mCurrentGame = NULL;
 }

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -12,6 +12,7 @@
 #include "FileFilterIndex.h"
 #include "Log.h"
 #include "PowerSaver.h"
+#include "Scripting.h"
 #include "Sound.h"
 #include "SystemData.h"
 #include <unordered_map>
@@ -106,6 +107,9 @@ void SystemScreenSaver::startScreenSaver()
 #else
 			mVideoScreensaver = new VideoVlcComponent(mWindow, getTitlePath());
 #endif
+			if (mCurrentGame != NULL) {
+				Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName());
+			}
 
 			mVideoScreensaver->topWindow(true);
 			mVideoScreensaver->setOrigin(0.5f, 0.5f);
@@ -183,9 +187,17 @@ void SystemScreenSaver::startScreenSaver()
 
 		PowerSaver::runningScreenSaver(true);
 		mTimer = 0;
+		if (mCurrentGame != NULL) {
+			Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName());
+		}
 		return;
 	}
 	// No videos. Just use a standard screensaver
+        if (mCurrentGame != NULL) {
+            Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName());
+        } else {
+            Scripting::fireEvent("screensaver-game-select");
+        }
 	mState = STATE_SCREENSAVER_ACTIVE;
 	mCurrentGame = NULL;
 }

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -11,7 +11,6 @@
 #include "FileData.h"
 #include "FileFilterIndex.h"
 #include "Log.h"
-#include "utils/ProfilingUtil.h"
 #include "PowerSaver.h"
 #include "Scripting.h"
 #include "Sound.h"

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -109,7 +109,7 @@ void SystemScreenSaver::startScreenSaver()
 #endif
 			if (mCurrentGame != NULL) 
 			{
-				Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName(), "randomvideo");
+				Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getPath(), mCurrentGame->getName(), "randomvideo");
 			}
 			mVideoScreensaver->topWindow(true);
 			mVideoScreensaver->setOrigin(0.5f, 0.5f);

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -108,7 +108,9 @@ void SystemScreenSaver::startScreenSaver()
 			mVideoScreensaver = new VideoVlcComponent(mWindow, getTitlePath());
 #endif
 			if (mCurrentGame != NULL) {
-				Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName());
+				Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName(), "randomvideo");
+			} else {
+				Scripting::fireEvent("screensaver-game-select", "NULL", "NULL", "NULL", "randomvideo");
 			}
 
 			mVideoScreensaver->topWindow(true);
@@ -188,15 +190,17 @@ void SystemScreenSaver::startScreenSaver()
 		PowerSaver::runningScreenSaver(true);
 		mTimer = 0;
 		if (mCurrentGame != NULL) {
-			Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName());
+			Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName(), "slideshow");
+		} else {
+			Scripting::fireEvent("screensaver-game-select", "NULL", "NULL", "NULL", "slideshow");
 		}
 		return;
 	}
 	// No videos. Just use a standard screensaver
         if (mCurrentGame != NULL) {
-            Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName());
+            Scripting::fireEvent("screensaver-game-select", mCurrentGame->getSystem()->getName(), mCurrentGame->getFileName(), mCurrentGame->getName(), "novideo");
         } else {
-            Scripting::fireEvent("screensaver-game-select");
+            Scripting::fireEvent("screensaver-game-select", "NULL", "NULL", "NULL", "novideo");
         }
 	mState = STATE_SCREENSAVER_ACTIVE;
 	mCurrentGame = NULL;

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -5,6 +5,7 @@
 #include "views/UIModeController.h"
 #include "views/ViewController.h"
 #include "Log.h"
+#include "Scripting.h"
 #include "Settings.h"
 #include "SystemData.h"
 #include "Window.h"
@@ -195,6 +196,7 @@ bool SystemView::input(InputConfig* config, Input input)
 			config->isMappedLike("up", input) ||
 			config->isMappedLike("down", input))
 			listInput(0);
+		Scripting::fireEvent("system-select", this->IList::getSelected()->getName(), "input");
 		if(!UIModeController::getInstance()->isUIModeKid() && config->isMappedTo("select", input) && Settings::getInstance()->getBool("ScreenSaverControls"))
 		{
 			mWindow->startScreenSaver();

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -58,7 +58,7 @@ void ViewController::goToStart()
 				FileData* cursor = getGameListView(*it)->getCursor();
 				if (cursor != NULL)
 				{
-					Scripting::fireEvent("game-select", requestedSystem, cursor->getFileName(), cursor->getName(), "requestedgame");
+					Scripting::fireEvent("game-select", requestedSystem, cursor->getPath(), cursor->getName(), "requestedgame");
 				}
 				else
 				{

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -13,6 +13,7 @@
 #include "views/UIModeController.h"
 #include "FileFilterIndex.h"
 #include "Log.h"
+#include "Scripting.h"
 #include "Settings.h"
 #include "SystemData.h"
 #include "Window.h"
@@ -53,6 +54,7 @@ void ViewController::goToStart()
 			if ((*it)->getName() == requestedSystem)
 			{
 				goToGameList(*it);
+				Scripting::fireEvent("system-select", requestedSystem, "requestedsystem");
 				return;
 			}
 		}
@@ -61,6 +63,7 @@ void ViewController::goToStart()
 		Settings::getInstance()->setString("StartupSystem", "");
 	}
 	goToSystemView(SystemData::sSystemVector.at(0));
+	Scripting::fireEvent("system-select", SystemData::sSystemVector.at(0)->getName(), "gotostart");
 }
 
 void ViewController::ReloadAndGoToStart()

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -60,6 +60,10 @@ void ViewController::goToStart()
 				{
 					Scripting::fireEvent("game-select", requestedSystem, cursor->getFileName(), cursor->getName(), "requestedgame");
 				}
+				else
+				{
+					Scripting::fireEvent("game-select", "NULL", "NULL", "NULL", "requestedgame");
+				}
 				return;
 			}
 		}

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -54,7 +54,12 @@ void ViewController::goToStart()
 			if ((*it)->getName() == requestedSystem)
 			{
 				goToGameList(*it);
-				Scripting::fireEvent("system-select", requestedSystem, "requestedsystem");
+                                Scripting::fireEvent("system-select", requestedSystem, "requestedsystem");
+				FileData* cursor = getGameListView(*it)->getCursor();
+				if (cursor != NULL)
+				{
+					Scripting::fireEvent("game-select", requestedSystem, cursor->getFileName(), cursor->getName(), "requestedgame");
+				}
 				return;
 			}
 		}

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -164,7 +164,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 	FileData* cursor = getCursor();
 	SystemData* system = this->mRoot->getSystem();
     	if (system != NULL) {
-            Scripting::fireEvent("game-select", system->getName(), cursor->getFileName(), cursor->getName(), "input");
+            Scripting::fireEvent("game-select", system->getName(), cursor->getPath(), cursor->getName(), "input");
         }
 	else
 	{

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -164,9 +164,12 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 	FileData* cursor = getCursor();
 	SystemData* system = this->mRoot->getSystem();
     	if (system != NULL) {
-            Scripting::fireEvent("game-select", system->getName(), cursor->getFileName(), cursor->getName());
+            Scripting::fireEvent("game-select", system->getName(), cursor->getFileName(), cursor->getName(), "input");
         }
-
+	else
+	{
+	    Scripting::fireEvent("game-select", "NULL", "NULL", "NULL", "input");
+	}
 	return IGameListView::input(config, input);
 }
 

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -3,6 +3,7 @@
 #include "views/UIModeController.h"
 #include "views/ViewController.h"
 #include "CollectionSystemManager.h"
+#include "Scripting.h"
 #include "Settings.h"
 #include "Sound.h"
 #include "SystemData.h"
@@ -159,6 +160,12 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 			}
 		}
 	}
+
+	FileData* cursor = getCursor();
+	SystemData* system = this->mRoot->getSystem();
+    	if (system != NULL) {
+            Scripting::fireEvent("game-select", system->getName(), cursor->getFileName(), cursor->getName());
+        }
 
 	return IGameListView::input(config, input);
 }

--- a/es-core/src/Scripting.cpp
+++ b/es-core/src/Scripting.cpp
@@ -5,7 +5,7 @@
 
 namespace Scripting
 {
-    int fireEvent(const std::string& eventName, const std::string& arg1, const std::string& arg2)
+    int fireEvent(const std::string& eventName, const std::string& arg1, const std::string& arg2, const std::string& arg3)
     {
         LOG(LogDebug) << "fireEvent: " << eventName << " " << arg1 << " " << arg2;
 
@@ -37,6 +37,9 @@ namespace Scripting
                     script += " \"" + arg1 + "\"";
                     if (arg2.length() > 0) {
                         script += " \"" + arg2 + "\"";
+			if (arg3.length() > 0) {
+			    script += " \"" + arg3 + "\"";
+			}
                     }
                 }
                 LOG(LogDebug) << "executing: " << script;

--- a/es-core/src/Scripting.cpp
+++ b/es-core/src/Scripting.cpp
@@ -5,7 +5,7 @@
 
 namespace Scripting
 {
-    int fireEvent(const std::string& eventName, const std::string& arg1, const std::string& arg2, const std::string& arg3)
+    int fireEvent(const std::string& eventName, const std::string& arg1, const std::string& arg2, const std::string& arg3, const std::string& arg4)
     {
         LOG(LogDebug) << "fireEvent: " << eventName << " " << arg1 << " " << arg2;
 
@@ -39,7 +39,10 @@ namespace Scripting
                         script += " \"" + arg2 + "\"";
 			if (arg3.length() > 0) {
 			    script += " \"" + arg3 + "\"";
-			}
+                            if (arg4.length() > 0) {
+                                script += " \"" + arg4 + "\"";
+			    }
+                        }
                     }
                 }
                 LOG(LogDebug) << "executing: " << script;

--- a/es-core/src/Scripting.h
+++ b/es-core/src/Scripting.h
@@ -6,7 +6,7 @@
 
 namespace Scripting
 {
-	int fireEvent(const std::string& eventName, const std::string& arg1="", const std::string& arg2="", const std::string& arg3="");
+	int fireEvent(const std::string& eventName, const std::string& arg1="", const std::string& arg2="", const std::string& arg3="", const std::string& arg4="");
 } // Scripting::
 
 #endif //ES_CORE_SCRIPTING_H

--- a/es-core/src/Scripting.h
+++ b/es-core/src/Scripting.h
@@ -6,7 +6,7 @@
 
 namespace Scripting
 {
-	int fireEvent(const std::string& eventName, const std::string& arg1="", const std::string& arg2="");
+	int fireEvent(const std::string& eventName, const std::string& arg1="", const std::string& arg2="", const std::string& arg3="");
 } // Scripting::
 
 #endif //ES_CORE_SCRIPTING_H

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -457,13 +457,13 @@ void Window::startScreenSaver()
 {
 	if (mScreenSaver && !mRenderScreenSaver)
 	{
+		Scripting::fireEvent("screensaver-start");
 		// Tell the GUI components the screensaver is starting
 		for(auto i = mGuiStack.cbegin(); i != mGuiStack.cend(); i++)
 			(*i)->onScreenSaverActivate();
 
 		mScreenSaver->startScreenSaver();
 		mRenderScreenSaver = true;
-		Scripting::fireEvent("screensaver-start");
 	}
 }
 


### PR DESCRIPTION
Hi modified the core Scripting.h and Scripting.cpp at add an additional optional parameter to support triggering events and running script files that take "system name", "rom file name", "rom file game name" as parameters to their command-line.  I also modified the necessary files to trigger events for when the game selected via the UI changes, the system selected via the UI changes, or the screen saver switches videos or shows no video at all.  The changes allow easier interception of those events that I originally did to integrate the PixelCade LED Marquee with ES without having to use a custom build of ES to support it.  The logic that was modified I have moved and enhanced into the bash scripts that now get executed so developers can customize the behavior to their own liking.

For example, the default behavior of the Pixelcade is if you call it's RESTFUL API with the system, the rom name, and the game name of the rom it will try to display the marquee of the rom if it exists, else scroll the text name of the game.  I have modified this behavior in my script to see if the marquee file exists and if it doesn't exist display the marquee of the system.  There are probably other use cases or intercepting these events.