### PR TITLE
Fix stuttering when starting to scroll a Game List

### DIFF
--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -215,12 +215,19 @@ void DetailedGameListView::updateInfoPanel()
 	FileData* file = (mList.size() == 0 || mList.isScrolling()) ? NULL : mList.getSelected();
 
 	bool fadingOut;
-	if(file == NULL)
+	if(mFile == file)
+	{
+		// Info is already on the panel, don't waste time reloading
+		return;
+	}
+	else if(file == NULL)
 	{
 		//mImage.setImage("");
 		//mDescription.setText("");
 		fadingOut = true;
-	}else{
+	}
+	else
+	{
 		mThumbnail.setImage(file->getThumbnailPath());
 		mMarquee.setImage(file->getMarqueePath());
 		mImage.setImage(file->getImagePath());
@@ -243,6 +250,8 @@ void DetailedGameListView::updateInfoPanel()
 
 		fadingOut = false;
 	}
+
+	mFile = file;
 
 	std::vector<GuiComponent*> comps = getMDValues();
 	comps.push_back(&mThumbnail);

--- a/es-app/src/views/gamelist/DetailedGameListView.h
+++ b/es-app/src/views/gamelist/DetailedGameListView.h
@@ -26,6 +26,8 @@ private:
 	void initMDLabels();
 	void initMDValues();
 
+	FileData* mFile;
+
 	ImageComponent mThumbnail;
 	ImageComponent mMarquee;
 	ImageComponent mImage;

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -249,7 +249,12 @@ void VideoGameListView::updateInfoPanel()
 	FileData* file = (mList.size() == 0 || mList.isScrolling()) ? NULL : mList.getSelected();
 
 	bool fadingOut;
-	if(file == NULL)
+	if(mFile == file)
+	{
+		// Info is already on the panel, don't waste time reloading
+		return;
+	}
+	else if(file == NULL)
 	{
 		mVideo->setVideo("");
 		mVideo->setImage("");
@@ -257,8 +262,9 @@ void VideoGameListView::updateInfoPanel()
 		//mMarquee.setImage("");
 		//mDescription.setText("");
 		fadingOut = true;
-
-	}else{
+	}
+	else
+	{
 		if (!mVideo->setVideo(file->getVideoPath()))
 		{
 			mVideo->setDefaultVideo();
@@ -289,6 +295,8 @@ void VideoGameListView::updateInfoPanel()
 
 		fadingOut = false;
 	}
+
+	mFile = file;
 
 	std::vector<GuiComponent*> comps = getMDValues();
 	comps.push_back(&mThumbnail);

--- a/es-app/src/views/gamelist/VideoGameListView.h
+++ b/es-app/src/views/gamelist/VideoGameListView.h
@@ -33,6 +33,8 @@ private:
 	void initMDLabels();
 	void initMDValues();
 
+	FileData* mFile;
+
 	ImageComponent mThumbnail;
 	ImageComponent mMarquee;
 	VideoComponent* mVideo;

--- a/es-core/src/components/IList.h
+++ b/es-core/src/components/IList.h
@@ -191,10 +191,6 @@ protected:
 	{
 		PowerSaver::setState(velocity == 0);
 
-		// generate an onCursorChanged event in the stopped state when the user lets go of the key
-		if(velocity == 0 && mScrollVelocity != 0)
-			onCursorChanged(CURSOR_STOPPED);
-
 		mScrollVelocity = velocity;
 		mScrollTier = 0;
 		mScrollTierAccumulator = 0;
@@ -302,7 +298,7 @@ protected:
 			onScroll(absAmt);
 
 		mCursor = cursor;
-		onCursorChanged((mScrollTier > 0) ? CURSOR_SCROLLING : CURSOR_STOPPED);
+		onCursorChanged((amt != 0) ? CURSOR_SCROLLING : CURSOR_STOPPED);
 	}
 
 	virtual void onCursorChanged(const CursorState& /*state*/) {}


### PR DESCRIPTION
Emulations station would stutter a lot when scorlling through game lists that had artwork with. This was due to it performing multiple reads of the screenshots, marquees, video, etc... For example, even if you were scrolling by 1, it would read these data 3 times. Each time it was calling the function `updateInfoPanel` which can kick of some File I/O which can be expensive (especially when you have the data on a NAS)

This gets it down to just 1 read. It also changes the behavior a little (for the better). There are three states in an input for scolling through a list: a rising edge where the button is pressed, a held high state where the button is held, and a falling edge where the button is released.

In the case where it was just press quickly, it was doing a read when the button was first pressed of the next item in the list. Then when it was released it would do another read of the next item in the list TWICE! The behavior now is to blank the info panel when the button is pressed, and then perform ONE read of the screenshot, etc. when the button is released.

Fixes #753 