### PR TITLE
Ignore filenames when loading systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ All systems must be contained within the <systemList> tag.-->
 		You MUST include the period at the start of the extension! It's also case sensitive. -->
 		<extension>.smc .sfc .SMC .SFC</extension>
 
+		<!-- A list of filenames to ignore, delimited by any of the whitespace characters (", \r\n\t").
+		You MUST wrap each filename in double quotes (since some filenames contain spaces). Not case sensitive. -->
+		<ignore>"filename1.bin" "filename2.iso" "filename3.zip"</ignore>
+
 		<!-- The shell command executed when a game is selected. A few special tags are replaced if found in a command, like %ROM% (see below). -->
 		<command>snesemulator %ROM%</command>
 		<!-- This example would run the bash command "snesemulator /home/user/roms/snes/Super\ Mario\ World.sfc". -->

--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -46,6 +46,8 @@ CollectionSystemManager::CollectionSystemManager(Window* window) : mWindow(windo
 	mCollectionEnvData->mStartPath = "";
 	std::vector<std::string> exts;
 	mCollectionEnvData->mSearchExtensions = exts;
+	std::vector<std::string> ignores;
+	mCollectionEnvData->mFilesToIgnore = ignores;
 	mCollectionEnvData->mLaunchCommand = "";
 	std::vector<PlatformIds::PlatformId> allPlatformIds;
 	allPlatformIds.push_back(PlatformIds::PLATFORM_IGNORE);

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -20,6 +20,7 @@ struct SystemEnvironmentData
 {
 	std::string mStartPath;
 	std::vector<std::string> mSearchExtensions;
+	std::vector<std::string> mFilesToIgnore;
 	std::string mLaunchCommand;
 	std::vector<PlatformIds::PlatformId> mPlatformIds;
 };
@@ -35,6 +36,7 @@ public:
 	inline const std::string& getFullName() const { return mFullName; }
 	inline const std::string& getStartPath() const { return mEnvData->mStartPath; }
 	inline const std::vector<std::string>& getExtensions() const { return mEnvData->mSearchExtensions; }
+	inline const std::vector<std::string>& getFilesToIgnore() const { return mEnvData->mFilesToIgnore; }
 	inline const std::string& getThemeFolder() const { return mThemeFolder; }
 	inline SystemEnvironmentData* getSystemEnvData() const { return mEnvData; }
 	inline const std::vector<PlatformIds::PlatformId>& getPlatformIds() const { return mEnvData->mPlatformIds; }


### PR DESCRIPTION
This enhancement allows users to specify one or more files that should be ignored during the system loading process.

(Inspired by posts such as: https://www.reddit.com/r/RetroPie/comments/5rnips/neogeo_and_mame_how_to_hide_bios_files_in_game)

Any files explicitly added to an `<ignore>` node within the `es_systems.cfg` file will be excluded from the game list that is displayed to the user.  Each filename MUST be wrapped in double quotes (since some filenames contain spaces).  Filenames are not case sensitive.

Example:

```
  <system>
    <name>arcade</name>
    <fullname>Arcade</fullname>
    <path>/home/pi/RetroPie/roms/arcade</path>
    <extension>.7z .cue .fba .iso .zip .7Z .CUE .FBA .ISO .ZIP</extension>
    <ignore>"filename1.bin" "filename2.iso" "filename3.zip"</ignore>
    <command>/opt/retropie/supplementary/runcommand/runcommand.sh 0 _SYS_ arcade %ROM%</command>
    <platform>arcade</platform>
    <theme>arcade</theme>
    <directlaunch/>
  </system>
```