### PR TITLE
input: disable the SDL2 HIDAPI drivers by default

### DIFF
--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -55,6 +55,11 @@ void InputManager::init()
 
 	SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS,
 		Settings::getInstance()->getBool("BackgroundJoystickInput") ? "1" : "0");
+	// Don't enable the HIDAPI drivers by default, it will break the existing configurations
+	// for a few controller types, since the names and the input mappings are different.
+#if SDL_VERSION_ATLEAST(2,0,9) and not(_WIN32)
+	SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI, "0");
+#endif
 	SDL_InitSubSystem(SDL_INIT_JOYSTICK);
 	SDL_JoystickEventState(SDL_ENABLE);
 


### PR DESCRIPTION
This ensures that configurations created before HIDAPI drivers were enabled by default (2.0.12)
will work when EmulationStation uses a newer SDL2 version.

Using the HIDAPI drivers may produce a different name for joysticks and pottentially changes the mapping.
Example using a PS4 (Dualshock 4) controller:
 - without HIDAPI, the controller is named "Wireless Controller", with HIDAPI enabled is named "PS4 Controller"
 - without HIDAPI, the D-Pad is detected as a HAT, but with the drivers enabled it's detected as a series of buttons
 - the device GUID is different between the 2 configurations
The different name would probably break also the input configuration script for RetroArch, which doesn't use SDL2 as default input driver and would receive a wrong name and wrong mappings.

Note that the HIDAPI drivers are available just for a few controller models (PS4/PS4/Amazon Luna/Stadia/Xbox360(w)/Xbox One/Steam),
but these controllers are widely used and breaking their configuration would cause much confusion.