### PR TITLE
Feature: Slideshow screensaver video support

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -176,7 +176,8 @@ void SystemScreenSaver::startScreenSaver()
 
 		// Check if file has a known video extension
 		std::string pathExtension = path.substr(path.find_last_of(".") + 1);
-		if (pathExtension == "mp4" || pathExtension == "avi")
+		std::vector<std::string> videoExtensions {"mp4", "avi"};
+		if (std::find(videoExtensions.begin(), videoExtensions.end(), pathExtension) != videoExtensions.end()) 
 		{
 			setVideoScreensaver(path);
 		}

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -63,15 +63,15 @@ bool SystemScreenSaver::isScreenSaverActive()
 
 void SystemScreenSaver::setVideoScreensaver(std::string& path)
 {
-	#ifdef _RPI_
+#ifdef _RPI_
 	// Create the correct type of video component
 	if (Settings::getInstance()->getBool("ScreenSaverOmxPlayer"))
 		mVideoScreensaver = new VideoPlayerComponent(mWindow, getTitlePath());
 	else
 		mVideoScreensaver = new VideoVlcComponent(mWindow, getTitlePath());
-	#else
+#else
 	mVideoScreensaver = new VideoVlcComponent(mWindow, getTitlePath());
-	#endif
+#endif
 
 	mVideoScreensaver->topWindow(true);
 	mVideoScreensaver->setOrigin(0.5f, 0.5f);

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -116,6 +116,13 @@ void SystemScreenSaver::setImageScreensaver(std::string& path)
 		}
 }
 
+bool SystemScreenSaver::isFileVideo(std::string& path)
+{
+	std::vector<std::string> videoExtensions {"mp4", "avi"};
+	std::string pathExtension = path.substr(path.find_last_of(".") + 1);
+	return std::find(videoExtensions.begin(), videoExtensions.end(), pathExtension) != videoExtensions.end();
+}
+
 void SystemScreenSaver::startScreenSaver()
 {
 	// if set to index files in background, start thread
@@ -174,10 +181,7 @@ void SystemScreenSaver::startScreenSaver()
 			pickRandomGameListImage(path);
 		}
 
-		// Check if file has a known video extension
-		std::string pathExtension = path.substr(path.find_last_of(".") + 1);
-		std::vector<std::string> videoExtensions {"mp4", "avi"};
-		if (std::find(videoExtensions.begin(), videoExtensions.end(), pathExtension) != videoExtensions.end()) 
+		if (isFileVideo(path)) 
 		{
 			setVideoScreensaver(path);
 		}

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -34,6 +34,7 @@ private:
 	void pickRandomCustomImage(std::string& path);
 	void setVideoScreensaver(std::string& path);
 	void setImageScreensaver(std::string& path);
+	bool isFileVideo(std::string& path);
 	std::vector<std::string> getCustomImageFiles(const std::string &imageDir);
 	std::vector<FileData*> getAllGamelistNodes();
 	void backgroundIndexing();

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -32,6 +32,8 @@ private:
 	void pickRandomVideo(std::string& path);
 	void pickRandomGameListImage(std::string& path);
 	void pickRandomCustomImage(std::string& path);
+	void setVideoScreensaver(std::string& path);
+	void setImageScreensaver(std::string& path);
 	std::vector<std::string> getCustomImageFiles(const std::string &imageDir);
 	std::vector<FileData*> getAllGamelistNodes();
 	void backgroundIndexing();

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -31,11 +31,11 @@ private:
 	void pickGameListNode(const char *nodeName, std::string& path);
 	void pickRandomVideo(std::string& path);
 	void pickRandomGameListImage(std::string& path);
-	void pickRandomCustomImage(std::string& path);
+	void pickRandomCustomMedia(std::string& path);
 	void setVideoScreensaver(std::string& path);
 	void setImageScreensaver(std::string& path);
 	bool isFileVideo(std::string& path);
-	std::vector<std::string> getCustomImageFiles(const std::string &imageDir);
+	std::vector<std::string> getCustomMediaFiles(const std::string &mediaDir);
 	std::vector<FileData*> getAllGamelistNodes();
 	void backgroundIndexing();
 
@@ -60,7 +60,7 @@ private:
 	std::shared_ptr<Sound>	mBackgroundAudio;
 	bool			mStopBackgroundAudio;
 	std::vector<FileData*> 		mAllFiles;
-	std::vector<std::string>	mCustomImageFiles;
+	std::vector<std::string>	mCustomMediaFiles;
 	int 				mAllFilesSize;
 	std::thread*				mThread;
 	bool 						mExit;

--- a/es-app/src/guis/GuiSlideshowScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiSlideshowScreensaverOptions.cpp
@@ -11,20 +11,20 @@ GuiSlideshowScreensaverOptions::GuiSlideshowScreensaverOptions(Window* window, c
 {
 	ComponentListRow row;
 
-	// image duration (seconds)
-	auto sss_image_sec = std::make_shared<SliderComponent>(mWindow, 1.f, 60.f, 1.f, "s");
-	sss_image_sec->setValue((float)(Settings::getInstance()->getInt("ScreenSaverSwapImageTimeout") / (1000)));
-	addWithLabel(row, "SWAP IMAGE AFTER (SECS)", sss_image_sec);
-	addSaveFunc([sss_image_sec] {
-		int playNextTimeout = (int)Math::round(sss_image_sec->getValue()) * (1000);
-		Settings::getInstance()->setInt("ScreenSaverSwapImageTimeout", playNextTimeout);
+	// media duration (seconds)
+	auto sss_media_sec = std::make_shared<SliderComponent>(mWindow, 1.f, 60.f, 1.f, "s");
+	sss_media_sec->setValue((float)(Settings::getInstance()->getInt("ScreenSaverSwapMediaTimeout") / (1000)));
+	addWithLabel(row, "SWAP MEDIA AFTER (SECS)", sss_media_sec);
+	addSaveFunc([sss_media_sec] {
+		int playNextTimeout = (int)Math::round(sss_media_sec->getValue()) * (1000);
+		Settings::getInstance()->setInt("ScreenSaverSwapMediaTimeout", playNextTimeout);
 		PowerSaver::updateTimeouts();
 	});
 
 	// stretch
 	auto sss_stretch = std::make_shared<SwitchComponent>(mWindow);
 	sss_stretch->setState(Settings::getInstance()->getBool("SlideshowScreenSaverStretch"));
-	addWithLabel(row, "STRETCH IMAGES", sss_stretch);
+	addWithLabel(row, "STRETCH MEDIA", sss_stretch);
 	addSaveFunc([sss_stretch] {
 		Settings::getInstance()->setBool("SlideshowScreenSaverStretch", sss_stretch->getState());
 	});
@@ -36,23 +36,23 @@ GuiSlideshowScreensaverOptions::GuiSlideshowScreensaverOptions(Window* window, c
 		Settings::getInstance()->setString("SlideshowScreenSaverBackgroundAudioFile", sss_bg_audio_file->getValue());
 	});
 
-	// image source
+	// media source
 	auto sss_custom_source = std::make_shared<SwitchComponent>(mWindow);
-	sss_custom_source->setState(Settings::getInstance()->getBool("SlideshowScreenSaverCustomImageSource"));
-	addWithLabel(row, "USE CUSTOM IMAGES", sss_custom_source);
-	addSaveFunc([sss_custom_source] { Settings::getInstance()->setBool("SlideshowScreenSaverCustomImageSource", sss_custom_source->getState()); });
+	sss_custom_source->setState(Settings::getInstance()->getBool("SlideshowScreenSaverCustomMediaSource"));
+	addWithLabel(row, "USE CUSTOM MEDIA", sss_custom_source);
+	addSaveFunc([sss_custom_source] { Settings::getInstance()->setBool("SlideshowScreenSaverCustomMediaSource", sss_custom_source->getState()); });
 
-	// custom image directory
-	auto sss_image_dir = std::make_shared<TextComponent>(mWindow, "", Font::get(FONT_SIZE_SMALL), 0x777777FF);
-	addEditableTextComponent(row, "CUSTOM IMAGE DIR", sss_image_dir, Settings::getInstance()->getString("SlideshowScreenSaverImageDir"));
-	addSaveFunc([sss_image_dir] {
-		Settings::getInstance()->setString("SlideshowScreenSaverImageDir", sss_image_dir->getValue());
+	// custom media directory
+	auto sss_media_dir = std::make_shared<TextComponent>(mWindow, "", Font::get(FONT_SIZE_SMALL), 0x777777FF);
+	addEditableTextComponent(row, "CUSTOM MEDIA DIR", sss_media_dir, Settings::getInstance()->getString("SlideshowScreenSaverMediaDir"));
+	addSaveFunc([sss_media_dir] {
+		Settings::getInstance()->setString("SlideshowScreenSaverMediaDir", sss_media_dir->getValue());
 	});
 
-	// recurse custom image directory
+	// recurse custom media directory
 	auto sss_recurse = std::make_shared<SwitchComponent>(mWindow);
 	sss_recurse->setState(Settings::getInstance()->getBool("SlideshowScreenSaverRecurse"));
-	addWithLabel(row, "CUSTOM IMAGE DIR RECURSIVE", sss_recurse);
+	addWithLabel(row, "CUSTOM MEDIA DIR RECURSIVE", sss_recurse);
 	addSaveFunc([sss_recurse] {
 		Settings::getInstance()->setBool("SlideshowScreenSaverRecurse", sss_recurse->getState());
 	});
@@ -62,6 +62,13 @@ GuiSlideshowScreensaverOptions::GuiSlideshowScreensaverOptions(Window* window, c
 	addEditableTextComponent(row, "CUSTOM IMAGE FILTER", sss_image_filter, Settings::getInstance()->getString("SlideshowScreenSaverImageFilter"));
 	addSaveFunc([sss_image_filter] {
 		Settings::getInstance()->setString("SlideshowScreenSaverImageFilter", sss_image_filter->getValue());
+	});
+
+	// custom video filter
+	auto sss_video_filter = std::make_shared<TextComponent>(mWindow, "", Font::get(FONT_SIZE_SMALL), 0x777777FF);
+	addEditableTextComponent(row, "CUSTOM VIDEO FILTER", sss_video_filter, Settings::getInstance()->getString("SlideshowScreenSaverVideoFilter"));
+	addSaveFunc([sss_video_filter] {
+		Settings::getInstance()->setString("SlideshowScreenSaverVideoFilter", sss_video_filter->getValue());
 	});
 }
 

--- a/es-core/src/PowerSaver.cpp
+++ b/es-core/src/PowerSaver.cpp
@@ -32,7 +32,7 @@ void PowerSaver::loadWakeupTime()
 	if (behaviour == "random video")
 		mWakeupTimeout = Settings::getInstance()->getInt("ScreenSaverSwapVideoTimeout") - getMode();
 	else if (behaviour == "slideshow")
-		mWakeupTimeout = Settings::getInstance()->getInt("ScreenSaverSwapImageTimeout") - getMode();
+		mWakeupTimeout = Settings::getInstance()->getInt("ScreenSaverSwapMediaTimeout") - getMode();
 	else // Dim and Blank
 		mWakeupTimeout = -1;
 }

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -115,7 +115,7 @@ void Settings::setDefaults()
 	mStringMap["SlideshowScreenSaverBackgroundAudioFile"] = Utils::FileSystem::getHomePath() + "/.emulationstation/slideshow/audio/slideshow_bg.wav";
 	mBoolMap["SlideshowScreenSaverCustomImageSource"] = false;
 	mStringMap["SlideshowScreenSaverImageDir"] = Utils::FileSystem::getHomePath() + "/.emulationstation/slideshow/image";
-	mStringMap["SlideshowScreenSaverImageFilter"] = ".png,.jpg";
+	mStringMap["SlideshowScreenSaverImageFilter"] = ".png,.jpg,.mp4,.avi";
 	mBoolMap["SlideshowScreenSaverRecurse"] = false;
 
 	// This setting only applies to raspberry pi but set it for all platforms so

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -110,12 +110,13 @@ void Settings::setDefaults()
 	mBoolMap["StretchVideoOnScreenSaver"] = false;
 	mStringMap["PowerSaverMode"] = "disabled";
 
-	mIntMap["ScreenSaverSwapImageTimeout"] = 10000;
+	mIntMap["ScreenSaverSwapMediaTimeout"] = 10000;
 	mBoolMap["SlideshowScreenSaverStretch"] = false;
 	mStringMap["SlideshowScreenSaverBackgroundAudioFile"] = Utils::FileSystem::getHomePath() + "/.emulationstation/slideshow/audio/slideshow_bg.wav";
-	mBoolMap["SlideshowScreenSaverCustomImageSource"] = false;
-	mStringMap["SlideshowScreenSaverImageDir"] = Utils::FileSystem::getHomePath() + "/.emulationstation/slideshow/image";
-	mStringMap["SlideshowScreenSaverImageFilter"] = ".png,.jpg,.mp4,.avi";
+	mBoolMap["SlideshowScreenSaverCustomMediaSource"] = false;
+	mStringMap["SlideshowScreenSaverMediaDir"] = Utils::FileSystem::getHomePath() + "/.emulationstation/slideshow/media";
+	mStringMap["SlideshowScreenSaverImageFilter"] = ".png,.jpg";
+	mStringMap["SlideshowScreenSaverVideoFilter"] = ".mp4,.avi";
 	mBoolMap["SlideshowScreenSaverRecurse"] = false;
 
 	// This setting only applies to raspberry pi but set it for all platforms so
@@ -246,6 +247,16 @@ void Settings::loadFile()
 	processBackwardCompatibility();
 }
 
+template<typename Map>
+void Settings::renameSetting(Map& map, std::string&& oldName, std::string&& newName)
+{
+	typename Map::const_iterator it = map.find(oldName);
+	if (it != map.end()) {
+		map[newName] = it->second;
+		map.erase(it);
+	}
+}
+
 void Settings::processBackwardCompatibility()
 {
 	{	// SaveGamelistsOnExit -> SaveGamelistsMode
@@ -255,7 +266,14 @@ void Settings::processBackwardCompatibility()
 			mBoolMap.erase(it);
 		}
 	}
+
+	{ // ScreenSaverSlideShow Image -> Media
+		renameSetting<std::map<std::string, int>>(mIntMap, std::string("ScreenSaverSwapImageTimeout"), std::string("ScreenSaverSwapMediaTimeout"));
+		renameSetting<std::map<std::string, bool>>(mBoolMap, std::string("SlideshowScreenSaverCustomImageSource"), std::string("SlideshowScreenSaverCustomMediaSource"));
+		renameSetting<std::map<std::string, std::string>>(mStringMap, std::string("SlideshowScreenSaverImageDir"), std::string("SlideshowScreenSaverMediaDir"));
+	}
 }
+
 
 //Print a warning message if the setting we're trying to get doesn't already exist in the map, then return the value in the map.
 #define SETTINGS_GETSET(type, mapName, getMethodName, setMethodName) type Settings::getMethodName(const std::string& name) \

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -31,9 +31,10 @@ private:
 
 	Settings();
 
-	//Clear everything and load default values.
-	void setDefaults();
+	void setDefaults();		//Clear everything and load default values.
 	void processBackwardCompatibility();
+	template<typename Map>
+	void renameSetting(Map& map, std::string&& oldName, std::string&& newName);
 
 	std::map<std::string, bool> mBoolMap;
 	std::map<std::string, int> mIntMap;

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -181,7 +181,7 @@ bool Window::inputDuringScreensaver(InputConfig* config, Input input)
 		}
 		else if (is_start_input)
 		{
-			bool slideshow_custom_images = Settings::getInstance()->getBool("SlideshowScreenSaverCustomImageSource");
+			bool slideshow_custom_images = Settings::getInstance()->getBool("SlideshowScreenSaverCustomMediaSource");
 			if (screensaver_type == "random video" || !slideshow_custom_images)
 			{
 				mScreenSaver->launchGame();


### PR DESCRIPTION
Adds support for .mp4 and .avi video files in the custom image directory with the screensaver Slideshow mode. Also adds those extensions to the default settings.

Inspired by [https://retropie.org.uk/forum/topic/12733/animated-screensavers](https://retropie.org.uk/forum/topic/12733/animated-screensavers)

Allows a user to have animated screensavers AND game preview videos at the same time.

Tested on Raspberry Pi 4.

This is my first time working in C++ or attempting to contribute to an open source project, constructive criticism is appreciated. I tried to add this feature while changing as little as possible, my biggest problem was that Slideshow is only associated with images, while Random Video is only associated with game nodes. This makes some things a bit confusing, such as adding videos to the `slideshow/image/` folder and needing to test the file name extension. Also, support for other video file types would need to be added to the videoExtensions vector and is not easily changed by the user. I run this change on my machine and I love being able to use the animated screensavers, and while it's not a perfect implementation I hope it adds functionality without giving anything up.