### PR TITLE
Update FileSystemUtil.cpp - Allow for multilevel absolute paths in gamelist.xml

### DIFF
--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -505,8 +505,12 @@ namespace Utils
 			if(_allowHome && (path[0] == '~') && (path[1] == '/'))
 				return (getHomePath() + &(path[1]));
 
-			// nothing to resolve
-			return path;
+                        // absolute path
+                        if(path[0] == '/')
+                                return path;
+ 
+                        // concatenate paths
+                        return (relativeTo + '/' + path);
 
 		} // resolveRelativePath
 


### PR DESCRIPTION
Allow for multilevel absolute paths in gamelist.xml.

See discussion here: https://retropie.org.uk/forum/topic/30984/multi-level-absolute-paths-in-gamelist-xml-not-working?_=1631445878380