### PR TITLE
Improve text wrapping (rebased #269)

### DIFF
--- a/es-core/src/resources/Font.h
+++ b/es-core/src/resources/Font.h
@@ -42,6 +42,7 @@ public:
 	virtual ~Font();
 
 	Vector2f sizeText(std::string text, float lineSpacing = 1.5f); // Returns the expected size of a string when rendered.  Extra spacing is applied to the Y axis.
+	Vector2f sizeCodePoint(unsigned int, float lineSpacing = 1.5f); // Returns the expected size of a Unicode code point.
 	TextCache* buildTextCache(const std::string& text, float offsetX, float offsetY, unsigned int color);
 	TextCache* buildTextCache(const std::string& text, Vector2f offset, unsigned int color, float xLen, Alignment alignment = ALIGN_LEFT, float lineSpacing = 1.5f);
 	void renderTextCache(TextCache* cache);
@@ -123,6 +124,8 @@ private:
 	std::map<unsigned int, Glyph> mGlyphMap;
 
 	Glyph* getGlyph(unsigned int id);
+
+	bool isWhiteSpace(unsigned int c);
 
 	int mMaxGlyphHeight;
 


### PR DESCRIPTION
This is a re-work of PR#269 and PR#314:

* originally proposed by @eagle0wl and discussed/tested with @zigurana during #269, with the motivation being to accomodate texts in languages that don't use spaces between successive characters and words (e.g. Japanese/Chinese).

* @zigurana created a smaller PR in #314 (now closed), but hasn't been updated after @tomaz82's work that changed the Unicode (UTF8) string handling functions (see #297).

I've taken the changes from @zigurana's PR (#269) and updated the code to use `Utils::String::chars2Unicode`.

I added a smaller change for parsing the text. Since we analyze each Unicode code point now (instead of a string), I replaced the `sizeText` call with a simpler function, which gets the size for just the codepoint being scanned. `lineWidth` is consequently incremended for each Unicode code point or reset on a new line.

The performance of `textWrap` looks similar or better than the previous implementation (based in whitespace tokenization) and the results are similar to what was tested during the initial PR (#269).

**NOTE**: the line breaking for non-whitespace texts is a simple split around Unicode code points. Each language may have additional rules for line breaking in texts (i.e. some characters are not allowed at the end/beginning of a line, etc.). These rules are not implemented in this update, it would require additional text analysis.

Some details on line breaking rules for Japanese/Chinese/Korean languages can be consulted at https://en.wikipedia.org/wiki/Line_breaking_rules_in_East_Asian_languages

Original descriptions for the changes on which this modification is based:

* from @eagl0wl's #269, _refine text wordwrap_:
 > refined single-multibyte text wordwrap.
 > You can now properly wrap Japanese character strings.
 > You can see some screenshot. If necessary, I can present more screenshots.
 >   http://eagle0wl.hatenadiary.jp/entry/2017/10/24/003606

* from @zigurana's #314, _Line-breaking (wrapping) for non ascii strings_
 > New PR (replacing #269).

Closes: #269
Supercedes: #269