### PR TITLE
TimeUtil: use `strftime` for date/time formatting.

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -832,13 +832,18 @@ EmulationStation borrows the concept of "nine patches" from Android (or "9-Slice
 * `zIndex` - type: FLOAT.
 	- z-index value for component.  Components will be rendered in order of z-index value from low to high.
 * `displayRelative` - type: BOOLEAN.  Renders the datetime as a a relative string (ex: 'x days ago')
-* `format` - type: STRING. Specifies format for rendering datetime.
+* `format` - type: STRING. Specifies format for rendering datetime, according to the `strftime` conversion format (see https://man7.org/linux/man-pages/man3/strftime.3.html).
+	 Common formating placeholders(see the link above for all available sequences):
 	- %Y: The year, including the century (1900)
+	- %y: The year as a decimal number without a century
 	- %m: The month number [01,12]
 	- %d: The day of the month [01,31]
 	- %H: The hour (24-hour clock) [00,23]
 	- %M: The minute [00,59]
 	- %S: The second [00,59]
+	- %R: The time in 24-hour notation
+	- %B: The full month name
+	- %b: Abbreviated month name
 
 #### sound
 

--- a/es-core/src/utils/TimeUtil.cpp
+++ b/es-core/src/utils/TimeUtil.cpp
@@ -219,73 +219,16 @@ namespace Utils
 			const char* f          = _format.c_str();
 			const tm    timeStruct = *localtime(&_time);
 			char        buf[256]   = { '\0' };
-			char*       s          = buf;
+			const int   MAX_LENGTH = 256;
 
-			while(*f)
-			{
-				if(*f == '%')
-				{
-					++f;
-
-					switch(*f++)
-					{
-						case 'Y': // The year, including the century (1900)
-						{
-							const int year = timeStruct.tm_year + 1900;
-							*s++ = (char)((year - (year % 1000)) / 1000) + '0';
-							*s++ = (char)(((year % 1000) - (year % 100)) / 100) + '0';
-							*s++ = (char)(((year % 100) - (year % 10)) / 10) + '0';
-							*s++ = (char)(year % 10) + '0';
-						}
-						break;
-
-						case 'm': // The month number [00,11]
-						{
-							const int mon = timeStruct.tm_mon + 1;
-							*s++ = (char)(mon / 10) + '0';
-							*s++ = (char)(mon % 10) + '0';
-						}
-						break;
-
-						case 'd': // The day of the month [01,31]
-						{
-							*s++ = (char)(timeStruct.tm_mday / 10) + '0';
-							*s++ = (char)(timeStruct.tm_mday % 10) + '0';
-						}
-						break;
-
-						case 'H': // The hour (24-hour clock) [00,23]
-						{
-							*s++ = (char)(timeStruct.tm_hour / 10) + '0';
-							*s++ = (char)(timeStruct.tm_hour % 10) + '0';
-						}
-						break;
-
-						case 'M': // The minute [00,59]
-						{
-							*s++ = (char)(timeStruct.tm_min / 10) + '0';
-							*s++ = (char)(timeStruct.tm_min % 10) + '0';
-						}
-						break;
-
-						case 'S': // The second [00,59]
-						{
-							*s++ = (char)(timeStruct.tm_sec / 10) + '0';
-							*s++ = (char)(timeStruct.tm_sec % 10) + '0';
-						}
-						break;
-					}
-				}
-				else
-				{
-					*s++ = *f++;
-				}
-
-				*s = '\0';
+			// Use strftime to format the string
+			if (!strftime(buf, MAX_LENGTH, _format.c_str(), &timeStruct)) {
+				return "";
 			}
-
-			return std::string(buf);
-
+			else 
+			{
+				return std::string(buf);
+			}
 		} // timeToString
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The change extends the DateTime formatting options and simplifies a bit the code.
The `strftime` format is compatible with the format specifiers that are used right now, so it shouldn't cause any incompatibilities with themes.