### PR TITLE
Scraping platforms update

### DIFF
--- a/es-app/src/PlatformId.cpp
+++ b/es-app/src/PlatformId.cpp
@@ -49,6 +49,7 @@ namespace PlatformIds
 		"wiiu",
 		"virtualboy",
 		"gameandwatch",
+		"switch", // Nintendo Switch
 		"openbor",
 		"pc",
 		"sega32x",
@@ -60,6 +61,7 @@ namespace PlatformIds
 		"megadrive", // sega megadrive
 		"saturn", // sega saturn
 		"sg-1000",
+		"samcoupe",
 		"psx",
 		"ps2",
 		"ps3",
@@ -71,11 +73,14 @@ namespace PlatformIds
 		"x1",
 		"x68000",
 		"solarus",
+		"pico8",
+		"tic80",
 		"moto", // Thomson MO/TO
 		"pc88", // NEC PC-8801
 		"pc98", // NEC PC-9801
 		"pcengine", // (aka turbografx-16) HuCards only
 		"pcenginecd", // (aka turbografx-16) CD-ROMs only
+		"pcfx",
 		"wonderswan",
 		"wonderswancolor",
 		"zxspectrum",
@@ -84,6 +89,7 @@ namespace PlatformIds
 		"vectrex",
 		"trs-80",
 		"coco",
+		"zmachine",
 
 		"ignore", // do not allow scraping for this system
 		"invalid"

--- a/es-app/src/PlatformId.h
+++ b/es-app/src/PlatformId.h
@@ -50,6 +50,7 @@ namespace PlatformIds
 		NINTENDO_WII_U,
 		NINTENDO_VIRTUAL_BOY,
 		NINTENDO_GAME_AND_WATCH,
+		NINTENDO_SWITCH,
 		OPENBOR,
 		PC,
 		SEGA_32X,
@@ -61,6 +62,7 @@ namespace PlatformIds
 		SEGA_MEGA_DRIVE,
 		SEGA_SATURN,
 		SEGA_SG1000,
+		SAM_COUPE,
 		PLAYSTATION,
 		PLAYSTATION_2,
 		PLAYSTATION_3,
@@ -72,11 +74,14 @@ namespace PlatformIds
 		SHARP_X1,
 		SHARP_X6800,
 		SOLARUS,
+		PICO_8,
+		TIC_80,
 		THOMSON_MOTO,
 		NEC_PC_8801,
 		NEC_PC_9801,
 		TURBOGRAFX_16, // (aka PC Engine) HuCards only
 		TURBOGRAFX_CD, // (aka PC Engine) CD-ROMs only
+		NEC_PCFX,
 		WONDERSWAN,
 		WONDERSWAN_COLOR,
 		ZX_SPECTRUM,
@@ -85,6 +90,7 @@ namespace PlatformIds
 		VECTREX,
 		TRS80_COLOR_COMPUTER,
 		TANDY,
+		ZMACHINE,
 
 		PLATFORM_IGNORE, // do not allow scraping for this system
 		PLATFORM_COUNT

--- a/es-app/src/scrapers/GamesDBJSONScraper.cpp
+++ b/es-app/src/scrapers/GamesDBJSONScraper.cpp
@@ -74,6 +74,7 @@ const std::map<PlatformId, std::string> gamesdb_new_platformid_map{
 	{ NINTENDO_WII_U, "38" },
 	{ NINTENDO_VIRTUAL_BOY, "4918" },
 	{ NINTENDO_GAME_AND_WATCH, "4950" },
+	{ NINTENDO_SWITCH, "4971" },
 	{ PC, "1" },
 	{ SEGA_32X, "33" },
 	{ SEGA_CD, "21" },
@@ -84,6 +85,7 @@ const std::map<PlatformId, std::string> gamesdb_new_platformid_map{
 	{ SEGA_MEGA_DRIVE, "36" },
 	{ SEGA_SATURN, "17" },
 	{ SEGA_SG1000, "4949" },
+	{ SAM_COUPE, "4979" },
 	{ PLAYSTATION, "10" },
 	{ PLAYSTATION_2, "11" },
 	{ PLAYSTATION_3, "12" },
@@ -97,9 +99,11 @@ const std::map<PlatformId, std::string> gamesdb_new_platformid_map{
 	{ NEC_PC_9801, "4934"},
 	{ TURBOGRAFX_16, "34" },   // HuCards only
 	{ TURBOGRAFX_CD, "4955" }, // CD-ROMs only
+	{ NEC_PCFX, "4930" },
 	{ WONDERSWAN, "4925" },
 	{ WONDERSWAN_COLOR, "4926" },
 	{ ZX_SPECTRUM, "4913" },
+	{ ZX81_SINCLAR, "5010" },
 	{ VIDEOPAC_ODYSSEY2, "4927" },
 	{ VECTREX, "4939" },
 	{ TRS80_COLOR_COMPUTER, "4941" },

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -58,6 +58,7 @@ const std::map<PlatformId, unsigned short> screenscraper_platformid_map{
 	{ NINTENDO_WII_U, 18 },
 	{ NINTENDO_VIRTUAL_BOY, 11 },
 	{ NINTENDO_GAME_AND_WATCH, 52 },
+	{ NINTENDO_SWITCH, 225 },
 	{ PC, 135 },
 	{ OPENBOR, 214 },
 	{ SCUMMVM, 123},
@@ -70,9 +71,12 @@ const std::map<PlatformId, unsigned short> screenscraper_platformid_map{
 	{ SEGA_MEGA_DRIVE, 1 },
 	{ SEGA_SATURN, 22 },
 	{ SEGA_SG1000, 109 },
+	{ SAM_COUPE, 213 },
 	{ SHARP_X1, 220},
 	{ SHARP_X6800, 79},
 	{ SOLARUS, 223 },
+	{ PICO_8, 234 },
+	{ TIC_80, 222 },
 	{ THOMSON_MOTO, 141},
 	{ NEC_PC_8801, 221},
 	{ NEC_PC_9801, 208},
@@ -85,6 +89,7 @@ const std::map<PlatformId, unsigned short> screenscraper_platformid_map{
 	{ SUPER_NINTENDO, 4 },
 	{ TURBOGRAFX_16, 31 },
 	{ TURBOGRAFX_CD, 114 },
+	{ NEC_PCFX, 72 },
 	{ WONDERSWAN, 45 },
 	{ WONDERSWAN_COLOR, 46 },
 	{ ZX_SPECTRUM, 76 },
@@ -92,7 +97,8 @@ const std::map<PlatformId, unsigned short> screenscraper_platformid_map{
 	{ VIDEOPAC_ODYSSEY2, 104 },
 	{ VECTREX, 102 },
 	{ TRS80_COLOR_COMPUTER, 144 },
-	{ TANDY, 144 }
+	{ TANDY, 144 },
+	{ ZMACHINE, 21 }
 };
 
 


### PR DESCRIPTION
Added:
 * Nintendo Switch (TGDB, ScreenScraper)
 * TIC 80 (ScreenScraper)
 * PICO-8 (ScreenScraper)
 * Sam Coupe (TGDB, ScreenScraper)
 * PC-FX (TGDB, ScreenScraper)
 * ZMachine (ScreenScraper)

Updated:
 * ZX81 Sinclair (added scraping for TGDB)