### PR TITLE
Misc

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -340,7 +340,7 @@ std::vector<FileData*> SystemScreenSaver::getAllGamelistNodes()
 
 void SystemScreenSaver::pickGameListNode(const char *nodeName, std::string& path)
 {
-	FileData *itf;
+	FileData *itf = nullptr;
 	bool found =  false;
 	int missCtr = 0;
 	while (!found) {

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -57,8 +57,10 @@ void InputManager::init()
 		Settings::getInstance()->getBool("BackgroundJoystickInput") ? "1" : "0");
 	// Don't enable the HIDAPI drivers by default, it will break the existing configurations
 	// for a few controller types, since the names and the input mappings are different.
-#if SDL_VERSION_ATLEAST(2,0,9) and not(_WIN32)
+#if !defined(_WIN32)
+#if	SDL_VERSION_ATLEAST(2,0,9)
 	SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI, "0");
+#endif
 #endif
 	SDL_InitSubSystem(SDL_INIT_JOYSTICK);
 	SDL_JoystickEventState(SDL_ENABLE);

--- a/es-core/src/resources/ResourceManager.h
+++ b/es-core/src/resources/ResourceManager.h
@@ -4,6 +4,7 @@
 
 #include <list>
 #include <memory>
+#include <string>
 
 //The ResourceManager exists to...
 //Allow loading resources embedded into the executable like an actual file.

--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -46,7 +46,7 @@ bool TextureData::initSVGFromMemory(const unsigned char* fileData, size_t length
 
 	NSVGimage* svgImage = nsvgParse(copy, "px", DPI);
 	free(copy);
-	if (!svgImage)
+	if (!svgImage || (svgImage->width == 0) || (svgImage->height == 0))
 	{
 		LOG(LogError) << "Error parsing SVG image.";
 		return false;
@@ -54,24 +54,13 @@ bool TextureData::initSVGFromMemory(const unsigned char* fileData, size_t length
 
 	// We want to rasterise this texture at a specific resolution. If the source size
 	// variables are set then use them otherwise set them from the parsed file
-	if ((mSourceWidth == 0.0f) && (mSourceHeight == 0.0f))
-	{
-		mSourceWidth = svgImage->width;
+	if (mSourceHeight == 0.0f)
 		mSourceHeight = svgImage->height;
-	}
+
+	mSourceWidth = (mSourceHeight * svgImage->width) / svgImage->height;
+
 	mWidth = (size_t)Math::round(mSourceWidth);
 	mHeight = (size_t)Math::round(mSourceHeight);
-
-	if (mWidth == 0)
-	{
-		// auto scale width to keep aspect
-		mWidth = (size_t)Math::round(((float)mHeight / svgImage->height) * svgImage->width);
-	}
-	else if (mHeight == 0)
-	{
-		// auto scale height to keep aspect
-		mHeight = (size_t)Math::round(((float)mWidth / svgImage->width) * svgImage->height);
-	}
 
 	unsigned char* dataRGBA = new unsigned char[mWidth * mHeight * 4];
 

--- a/es-core/src/utils/TimeUtil.cpp
+++ b/es-core/src/utils/TimeUtil.cpp
@@ -216,19 +216,20 @@ namespace Utils
 
 		std::string timeToString(const time_t& _time, const std::string& _format)
 		{
-			const char* f          = _format.c_str();
-			const tm    timeStruct = *localtime(&_time);
-			char        buf[256]   = { '\0' };
-			const int   MAX_LENGTH = 256;
+			const tm  timeStruct = *localtime(&_time);
+			char      buf[256]   = { '\0' };
+			const int MAX_LENGTH = 256;
 
 			// Use strftime to format the string
-			if (!strftime(buf, MAX_LENGTH, _format.c_str(), &timeStruct)) {
+			if(!strftime(buf, MAX_LENGTH, _format.c_str(), &timeStruct))
+			{
 				return "";
 			}
 			else 
 			{
 				return std::string(buf);
 			}
+
 		} // timeToString
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is a collection of fixes

* Silence warnings in MSVC 2017
* Make Utils::FileSystem more threadsafe, this should fix crashes related to the mutlithreaded loader
* Fix MSVC 2019 compilation (from https://github.com/RetroPie/EmulationStation/pull/676)
* Base svg loading size on height (from https://github.com/RetroPie/EmulationStation/pull/589)