### PR TITLE
Fix navigating to parent when list is filtered

### DIFF
--- a/es-app/src/guis/GuiFastSelect.cpp
+++ b/es-app/src/guis/GuiFastSelect.cpp
@@ -142,7 +142,7 @@ void GuiFastSelect::updateGameListSort()
 
 void GuiFastSelect::updateGameListCursor()
 {
-	const std::vector<FileData*>& list = mGameList->getCursor()->getParent()->getChildren();
+	const std::vector<FileData*>& list = mGameList->getCursor()->getParent()->getChildrenListToDisplay();
 
 	// only skip by letter when the sort mode is alphabetical
 	const FileData::SortType& sort = FileSorts::SortTypes.at(mSortId);

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -104,7 +104,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 		{
 			if(mCursorStack.size())
 			{
-				populateList(mCursorStack.top()->getParent()->getChildren());
+				populateList(mCursorStack.top()->getParent()->getChildrenListToDisplay());
 				setCursor(mCursorStack.top());
 				mCursorStack.pop();
 				Sound::getFromTheme(getTheme(), getName(), "back")->play();


### PR DESCRIPTION
Fixes #775 . 
Tested here: https://retropie.org.uk/forum/topic/32086/es-dev-bug-report-hidden-filter-fails-at-system-level-after-entering-a-subfolder-and-returning