### PR TITLE
Fix infinite loop in wrapText when maxWidth is less than 0

### DIFF
--- a/es-core/src/resources/Font.cpp
+++ b/es-core/src/resources/Font.cpp
@@ -501,6 +501,10 @@ bool Font::isWhiteSpace(unsigned int c)
 std::string Font::wrapText(std::string text, float maxWidth)
 {
 	std::string out = "";
+
+	if(maxWidth <= 0)
+		return out;
+
 	while(text.length() > 0)  // find next cut-point
 	{
 		size_t cursor = 0;


### PR DESCRIPTION
Don't wrap at all if maxWidth is 0 or negative