### PR TITLE
SystemView: fix random system warp crash

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -542,6 +542,8 @@ SystemData* SystemData::getRandomSystem()
 	if (sSystemVectorShuffled.empty())
 	{
 		std::copy_if(sSystemVector.begin(), sSystemVector.end(), std::back_inserter(sSystemVectorShuffled), [](SystemData *sd){ return sd->isGameSystem(); });
+		if (sSystemVectorShuffled.empty()) return NULL;
+
 		std::shuffle(sSystemVectorShuffled.begin(), sSystemVectorShuffled.end(), sURNG);
 	}
 


### PR DESCRIPTION
When no Game system is visible, choosing a random system in the carousel will lead to a crash.
Added an extra check before the random shuffle is performed.

Reported in the forums in https://retropie.org.uk/forum/topic/32568/.