### PR TITLE
Fix race condition between Video component and Scripting events causing ES to freeze

### DIFF
--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -237,9 +237,18 @@ void VideoPlayerComponent::startVideo()
 
 void catch_child(int sig_num)
 {
-    /* when we get here, we know there's a zombie child waiting */
-    int child_status;
-    wait(&child_status);
+	// When we get here, we know there's at least 1 zombie child waiting.  There
+	// may be others if, for example, a Scripting event was fired at the same time
+	// that the video was stopped.
+	while (1)
+	{
+		int child_status;
+		pid_t pid = waitpid(-1, &child_status, WNOHANG);
+		if (pid <= 0)
+		{
+			break;
+		}
+	}
 }
 
 void VideoPlayerComponent::stopVideo()


### PR DESCRIPTION
https://retropie.org.uk/forum/topic/32586/emulationstation-freezes-after-game-select-event-triggered-and-video-snap-plays

This fixes a race condition between the Video component's `SIGCHLD` signal handler and `system()` calls via Scripting events that causes EmulationStation to become unresponsive.

## Context

I was exploring the use of the new `game-select` event introduced in https://github.com/RetroPie/EmulationStation/pull/751 and found that EmulationStation was becoming unresponsive to new inputs (e.g. up / down) when the OMX player was enabled and a `game-select` script was added.

I was able to confirm:

* The issue goes away when the OMX player is disabled
* The issue goes away when the `game-select` script is removed
* The issue remains with the latest `master` branch of EmulationStation
* The issue remains regardless of theme (both `carbon-2021` and `pixel-metadata`)

## Root cause

The root cause here is a race condition between `system()` calls completing and the `VideoPlayerComponent` being stopped.

When the `VideoPlayerComponent` forks, it adds a `SIGCHLD` signal handler to reap the forked process when it terminates: https://github.com/RetroPie/EmulationStation/blob/e26fa8d48bf304a8ef614df6bdec793982d23953/es-core/src/components/VideoPlayerComponent.cpp#L92

When a `system()` call is made -- https://github.com/RetroPie/EmulationStation/blob/e26fa8d48bf304a8ef614df6bdec793982d23953/es-core/src/platform.cpp#L41 -- a child process is also created and the application is blocked while it waits for a signal from the child process that it has terminated.

The challenge is when these 2 are combined -- the OMX player process and `system()` process end simultaneously.  When this occurs, the OS does 2 things:

* It may combine those signals into a **single** `SIGCHLD` callback (signal compression)
* It has no guarantee around the order in which the signals are made for each child process

The `VideoPlayerComponent` currently only anticipates that it has a single child process to reap: https://github.com/RetroPie/EmulationStation/blob/e26fa8d48bf304a8ef614df6bdec793982d23953/es-core/src/components/VideoPlayerComponent.cpp#L238-L243

Since the `VideoPlayerComponent` ignores a potential second child process in the `catch_child` callback (and also doesn't know which process it's reaping), proper cleanup never happens and the `system()` call never returns.

I was able to confirm this by adding logging before and after the call to `system()`.  When this situation occurs, the log *after* the `system()` call doesn't show up.

References:
* https://stackoverflow.com/a/17555021
* https://pubs.opengroup.org/onlinepubs/009695399/functions/system.html

## Solution

The solution here ends up being fairly straightforward: Change the `SIGCHLD` handler to reap all child processes that have been terminated.  After this fix is made, the freeze no longer happens.

Since this is the only `SIGCHLD` handler in the application (and it remains active throughout the lifetime of the application), I felt that it was appropriate enough to have this handler follow a somewhat cleaner process of ensuring that all child processes are handled in this "compressed" signal from the OS.

References:
* https://stackoverflow.com/a/8398491
* https://man7.org/linux/man-pages/man7/signal.7.html

## Alternatives solutions

There are 2 alternative solutions I considered as part of investigating this issue.  I've described them below for full context.

### Change `system()` calls for Scripting events to `fork()` / `execve()`

I originally played around with changing the `system()` calls to follow the same `fork()` process used by the video player component.  However, this ultimately had the same issue with the same fix as above.  Even when installing its own `SIGCHLD` handler, the handler needed to anticipate that the OS may compress multiple child process signals into a single callback (or may trigger the signals out of order).

Additional, this was going to be a significantly more complex change.  Since this change alone would not have fixed the issue, I decided to forego further development on it.

### Change `VideoPlayerComponent` to only reap its own process

This was the first solution that resolved the issue.  The idea here was to change the `VideoPlayerComponent`'s `catch_child` signal handler to only ever attempt to reap its own process.  You can see an implementation of this here: https://github.com/RetroPie/EmulationStation/compare/master...obrie:game-select-omx-freeze

However, the nature of the the signal handler needing to be a global function meant we didn't have the context of which pid to reap.  I worked around this by effectively introducing a global variable to track the OMX player's PID.  Ultimately, I felt this type of global state was undesirable and anything different would be a more complicated solution.

## System information

Here are the system details I used when testing:

Pi Model or other hardware: 4B
Power Supply used: CanaKit 3.5A
RetroPie Version Used: 4.8
Built From: Pre made SD Image on RetroPie website
USB Devices connected: SSD USB adapter, wireless keyboard adapter
Controller used: Keyboard
Error messages received: N/A
Verbose log (if relevant):
Guide used: N/A
File: N/A
Emulator: N/A
Attachment of config files: https://pastebin.com/E0uH84ig
EmulationStation build: Version 2.10.2rp, built Mar 7 2022

## Steps to reproduce

These steps are effectively copied from the forum post.  Note that not everyone has been able to successfully reproduce the issue, but an isolated c program that simulates the issue can more easily demonstrate the issue.

* Create sd card from v4.8 rpi4_400 image
* Add roms, scraped media, and gamelist to the system
* Boot up the system and configure a keyboard controller
* Exit EmulationStation
* Update emulationstation:
  ```sh
  sudo $HOME/RetroPie-Setup/retropie_packages.sh emulationstation _binary_
  ```
* Create `$HOME/.emulationstation/es_settings.cfg`:
  ```sh
  <?xml version="1.0"?>
  <bool name="VideoOmxPlayer" value="true" />
  ```
* Create `$HOME/.emulationstation/scripts/game-select/test.sh`:
  ```sh
  #!/bin/sh
  
  exit 0
  ```
* Restart EmulationStation
* Open any system's gamelist view
* Wait for video to start playing
* Attempt to do anything (scroll down / up) -- ES is now unresponsive

You may need to repeat the last 2 steps several times in order for the issue to appear.

When ES becomes unresponsive, you can actually make it responsive again by following these steps:

* Find the omx player process:
  ```
  $ ps aux | grep letterbox
  pi        1888  3.2  0.7 196248 27988 tty1     SLl+ 04:02   0:03  --layer 10010 --loop --no-osd --aspect-mode letterbox --vol -210 -o both --win 326,81,632,258 --orientation 0 /home/pi/.emulationstation/downloaded_media/arcade/videos/88games.mp4
* Kill the process:
  ```sh
  kill 1888
  ```
* Notice the that the selected game in the gamelist view has actually changed -- the prior inputs have since been processed by ES.

When the OMX Player process is killed, you'll see the following log message in `es_log.txt`:

```
Apr 24 04:17:39 lvl1: 	/home/pi/.emulationstation/scripts/game-select/test.sh "arcade" "/home/pi/RetroPie/roms/arcade/10yard.zip" "10-yard Fight" "input" failed with exit code != 0. Terminating processing for this event.
```

This demonstrates that the `system()` command was blocked.  Only after I killed the second process (the OMX process) did the command finally unblock.

## Testing

I tested this using the same system setup steps described above.  I was also able to confirm the theory of the signal handler being the source of the problem by commenting out this line: https://github.com/RetroPie/EmulationStation/blob/e26fa8d48bf304a8ef614df6bdec793982d23953/es-core/src/components/VideoPlayerComponent.cpp#L92

Of course, we end up with zombie processes being left behind.  However, commenting out this line avoided interference with the `system()` calls and addressed the freezing issue.