### PR TITLE
RPI support: split omxplayer build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 2.8)
 
 option(GLES "Set to ON if targeting Embedded OpenGL" ${GLES})
 option(GL "Set to ON if targeting Desktop OpenGL" ${GL})
-option(RPI "Set to ON to enable the Raspberry PI video player (omxplayer) and audio options" ${RPI})
+option(RPI "Set to ON to enable the Raspberry PI memory and audio options" ${RPI})
+option(OMX "Set to On to enable OMXPlayer for video snapshots" ${OMX})
 option(CEC "Set to ON to enable CEC" ${CEC})
 option(PROFILING "Set to ON to enable profiling" ${PROFILING})
 
@@ -108,6 +109,10 @@ endif()
 #set up compiler flags and excutable names
 if(DEFINED BCMHOST OR RPI)
     add_definitions(-D_RPI_)
+endif()
+
+if(OMX)
+    add_definitions(-D_OMX_)
 endif()
 
 if(DEFINED libCEC_FOUND)

--- a/README.md
+++ b/README.md
@@ -54,14 +54,18 @@ NOTE: to generate a `Debug` build on Unix/Linux, run the Makefile generation ste
 cmake -DCMAKE_BUILD_TYPE=Debug .
 ```
 
-**On the Raspberry Pi**  
+**On the Raspberry Pi**
 
 * Choosing a GLES implementation.
 
    * if the Pi system uses the legacy/Broadcom driver, install the `libraspberry-dev` package before running `cmake` to configure the build
-   * if the Pi system uses the Mesa VC3/V3D GL driver, build using `-DUSE_MESA_GLES=On` to choose the MESA GLES implementation. This option is _mandatory_ when compiling for a Pi4 system, since the legacy GL drivers are not supported anymore on this system.
+   * if the Pi system uses the Mesa VC4/V3D GL driver, build using `-DUSE_MESA_GLES=On` to choose the MESA GLES implementation. This option is _mandatory_ when compiling for a Pi4 system, since the legacy GL drivers are not supported anymore on this system.
 
-* Support for using `omxplayer` to play video previews in the gamelist is enabled by adding `-DRPI=On` to the build options
+  NOTE: Starting with RasPI OS 'Bullseye', the legacy/Broadcom drivers are not supported anymore, so `-DUSE_MESA_GLES=On` should be used.
+
+* Enable the audio/memory defaults by adding `-DRPI=On` to the build options
+* Support for using `omxplayer` to play video previews in the gamelist is enabled by adding `-DOMX=On` to the build options.
+  NOTE: `omxplayer` support is not available on 64bit RasPI OS or in the default RasPI OS 'Bullseye' configuration.
 
 **GLES build notes**
 

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -1,6 +1,6 @@
 #include "SystemScreenSaver.h"
 
-#ifdef _RPI_
+#ifdef _OMX_
 #include "components/VideoPlayerComponent.h"
 #endif
 #include "components/VideoVlcComponent.h"
@@ -64,7 +64,7 @@ bool SystemScreenSaver::isScreenSaverActive()
 
 void SystemScreenSaver::setVideoScreensaver(std::string& path)
 {
-#ifdef _RPI_
+#ifdef _OMX_
 	// Create the correct type of video component
 	if (Settings::getInstance()->getBool("ScreenSaverOmxPlayer"))
 		mVideoScreensaver = new VideoPlayerComponent(mWindow, getTitlePath());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -164,7 +164,7 @@ void GuiMenu::openSoundSettings()
 		s->addWithLabel("ENABLE VIDEO AUDIO", video_audio);
 		s->addSaveFunc([video_audio] { Settings::getInstance()->setBool("VideoAudio", video_audio->getState()); });
 
-#ifdef _RPI_
+#ifdef _OMX_
 		// OMX player Audio Device
 		auto omx_audio_dev = std::make_shared< OptionListComponent<std::string> >(mWindow, "OMX PLAYER AUDIO DEVICE", false);
 		std::vector<std::string> omx_cards;
@@ -463,7 +463,7 @@ void GuiMenu::openOtherSettings()
 	s->addWithLabel("SHOW HIDDEN FILES", hidden_files);
 	s->addSaveFunc([hidden_files] { Settings::getInstance()->setBool("ShowHiddenFiles", hidden_files->getState()); });
 
-#ifdef _RPI_
+#ifdef _OMX_
 	// Video Player - VideoOmxPlayer
 	auto omx_player = std::make_shared<SwitchComponent>(mWindow);
 	omx_player->setState(Settings::getInstance()->getBool("VideoOmxPlayer"));

--- a/es-app/src/guis/GuiVideoScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiVideoScreensaverOptions.cpp
@@ -23,7 +23,7 @@ GuiVideoScreensaverOptions::GuiVideoScreensaverOptions(Window* window, const cha
 	addWithLabel("STRETCH VIDEO ON SCREENSAVER", stretch_screensaver);
 	addSaveFunc([stretch_screensaver] { Settings::getInstance()->setBool("StretchVideoOnScreenSaver", stretch_screensaver->getState()); });
 
-#ifdef _RPI_
+#ifdef _OMX_
 	auto ss_omx = std::make_shared<SwitchComponent>(mWindow);
 	ss_omx->setState(Settings::getInstance()->getBool("ScreenSaverOmxPlayer"));
 	addWithLabel("USE OMX PLAYER FOR SCREENSAVER", ss_omx);
@@ -59,7 +59,7 @@ GuiVideoScreensaverOptions::GuiVideoScreensaverOptions(Window* window, const cha
 	addWithLabel("VLC: SCREENSAVER VIDEO RESOLUTION", ss_vlc_resolution);
 	addSaveFunc([ss_vlc_resolution, this] { Settings::getInstance()->setString("VlcScreenSaverResolution", ss_vlc_resolution->getSelected()); });
 
-#ifdef _RPI_
+#ifdef _OMX_
 	ComponentListRow row;
 
 	// Set subtitle position
@@ -103,12 +103,12 @@ GuiVideoScreensaverOptions::~GuiVideoScreensaverOptions()
 
 void GuiVideoScreensaverOptions::save()
 {
-#ifdef _RPI_
+#ifdef _OMX_
 	bool startingStatusNotRisky = (Settings::getInstance()->getString("ScreenSaverGameInfo") == "never" || !Settings::getInstance()->getBool("ScreenSaverOmxPlayer"));
 #endif
 	GuiScreensaverOptions::save();
 
-#ifdef _RPI_
+#ifdef _OMX_
 	bool endStatusRisky = (Settings::getInstance()->getString("ScreenSaverGameInfo") != "never" && Settings::getInstance()->getBool("ScreenSaverOmxPlayer"));
 	if (startingStatusNotRisky && endStatusRisky) {
 		// if before it wasn't risky but now there's a risk of problems, show warning

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -6,7 +6,7 @@
 #include "CollectionSystemManager.h"
 #include "Settings.h"
 #include "SystemData.h"
-#ifdef _RPI_
+#ifdef _OMX_
 #include "components/VideoPlayerComponent.h"
 #endif
 #include "components/VideoVlcComponent.h"
@@ -29,7 +29,7 @@ GridGameListView::GridGameListView(Window* window, FileData* root) :
 	const float padding = 0.01f;
 
 // Create the correct type of video window
-#ifdef _RPI_
+#ifdef _OMX_
 	if (Settings::getInstance()->getBool("VideoOmxPlayer"))
 		mVideo = new VideoPlayerComponent(window, "");
 	else

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -1,13 +1,13 @@
 #include "views/gamelist/VideoGameListView.h"
 
 #include "animations/LambdaAnimation.h"
-#ifdef _RPI_
+#ifdef _OMX_
 #include "components/VideoPlayerComponent.h"
 #endif
 #include "components/VideoVlcComponent.h"
 #include "utils/FileSystemUtil.h"
 #include "views/ViewController.h"
-#ifdef _RPI_
+#ifdef _OMX_
 #include "Settings.h"
 #endif
 
@@ -30,7 +30,7 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 	const float padding = 0.01f;
 
 	// Create the correct type of video window
-#ifdef _RPI_
+#ifdef _OMX_
 	Utils::FileSystem::removeFile(getTitlePath());
 	if (Settings::getInstance()->getBool("VideoOmxPlayer"))
 		mVideo = new VideoPlayerComponent(window, "");

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -120,7 +120,7 @@ void Settings::setDefaults()
 	// This setting only applies to raspberry pi but set it for all platforms so
 	// we don't get a warning if we encounter it on a different platform
 	mBoolMap["VideoOmxPlayer"] = false;
-	#ifdef _RPI_
+	#ifdef _OMX_
 		// we're defaulting to OMX Player for full screen video on the Pi
 		mBoolMap["ScreenSaverOmxPlayer"] = true;
 		// use OMX Player defaults

--- a/es-core/src/components/VideoPlayerComponent.cpp
+++ b/es-core/src/components/VideoPlayerComponent.cpp
@@ -1,4 +1,4 @@
-#ifdef _RPI_
+#ifdef _OMX_
 #include "components/VideoPlayerComponent.h"
 
 #include "renderers/Renderer.h"

--- a/es-core/src/components/VideoPlayerComponent.h
+++ b/es-core/src/components/VideoPlayerComponent.h
@@ -1,4 +1,4 @@
-#ifdef _RPI_
+#ifdef _OMX_
 #pragma once
 #ifndef ES_CORE_COMPONENTS_VIDEO_PLAYER_COMPONENT_H
 #define ES_CORE_COMPONENTS_VIDEO_PLAYER_COMPONENT_H
@@ -38,4 +38,4 @@ private:
 };
 
 #endif // ES_CORE_COMPONENTS_VIDEO_PLAYER_COMPONENT_H
-#endif // _RPI_
+#endif // _OMX_


### PR DESCRIPTION
Modified the build options and source files to enable `omxplayer` for video previews only when the `OMX` option is used.
Updated the build instructions on RPI accordingly and added some notes about the deprecation of the BRCM GPU drivers in RasPI OS 'Bullseye'.

Previously, the `RPI` build option would be used to add both RPI specific audio settings/VRAM limits AND add `omxplayer` support. However, `omxplayer` does not work with the RPI KMS video driver (`vc4-kms-v3d`) or with a 64bit RPI system, due to the lack of OpenMAX (OMX) API support.
The new RasPi OS ('bullseye') has made the KMS driver the default [1] and doesn't offer `omxplayer` anymore (considered deprecated [2]).

Splitting the OMX support from the RPI option allows to set some default values for RPI systems without automatically adding the `omxplayer` bits.

[1] https://www.raspberrypi.com/news/raspberry-pi-os-debian-bullseye/
[2] https://github.com/popcornmix/omxplayer/commit/1f1d0ccd65

For RetroPie, we'll have to adjust the build options accordingly for the package(s).