### PR TITLE
renderer: Add build option for OpenGL 2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ option(PROFILING "Set to ON to enable profiling" ${PROFILING})
 option(USE_MESA_GLES "Set to ON to select the MESA OpenGL ES driver" ${USE_MESA_GLES})
 option(USE_GLES1 "Set to ON to force usage of the OpenGLES v1 renderer" ${USE_GLES1})
 
+# GL implementation overrides
+option(USE_GL21 "Set to ON to force usage of the OpenGL v2.1 renderer" ${USE_GL21})
+
 # OpenGL library preference (https://cmake.org/cmake/help/git-stage/policy/CMP0072.html)
 # Set it to OLD to appease older proprietary drivers without libglvnd support
 if(POLICY CMP0072)
@@ -73,7 +76,11 @@ set_property(CACHE GLSystem PROPERTY STRINGS "Desktop OpenGL" "Embedded OpenGL")
 
 if(${GLSystem} MATCHES "Desktop OpenGL")
     find_package(OpenGL REQUIRED)
-    add_definitions(-DUSE_OPENGL_14)
+    if(NOT USE_GL21)
+        add_definitions(-DUSE_OPENGL_14)
+    else()
+        add_definitions(-DUSE_OPENGL_21)
+    endif()
 else()
     if(NOT USE_GLES1)
         find_package(OpenGLES2 QUIET REQUIRED)


### PR DESCRIPTION
Add option USE_GL21 to enable OpenGL 2.1 renderer which can be activated with „-DUSE_GL21=On“. Use
OpenGL 1.4 by default for backward compatibility.