### PR TITLE
ViewController: improves bulk removal of entries

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -260,7 +260,7 @@ void CollectionSystemManager::updateCollectionSystem(FileData* file, CollectionS
 			// found and we are removing
 			if (name == "favorites" && file->metadata.get("favorite") == "false") {
 				// need to check if still marked as favorite, if not remove
-				ViewController::get()->getGameListView(curSys).get()->remove(collectionEntry, false);
+				ViewController::get()->getGameListView(curSys).get()->remove(collectionEntry, false, true);
 			}
 			else
 			{
@@ -298,8 +298,9 @@ void CollectionSystemManager::trimCollectionCount(FileData* rootFolder, int limi
 	while ((int)rootFolder->getChildrenListToDisplay().size() > limit)
 	{
 		CollectionFileData* gameToRemove = (CollectionFileData*)rootFolder->getChildrenListToDisplay().back();
-		ViewController::get()->getGameListView(curSys).get()->remove(gameToRemove, false);
+		ViewController::get()->getGameListView(curSys).get()->remove(gameToRemove, false, false);
 	}
+	ViewController::get()->onFileChanged(rootFolder, FILE_REMOVED);
 }
 
 // deletes all collection files from collection systems related to the source file
@@ -323,7 +324,7 @@ void CollectionSystemManager::deleteCollectionFiles(FileData* file)
 				sysDataIt->second.needsSave = true;
 				FileData* collectionEntry = children.at(key);
 				SystemData* systemViewToUpdate = getSystemToView(sysDataIt->second.system);
-				ViewController::get()->getGameListView(systemViewToUpdate).get()->remove(collectionEntry, false);
+				ViewController::get()->getGameListView(systemViewToUpdate).get()->remove(collectionEntry, false, true);
 			}
 		}
 	}
@@ -495,7 +496,7 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file, int pressco
 				{
 					systemViewToUpdate->getIndex()->removeFromIndex(collectionEntry);
 				}
-				ViewController::get()->getGameListView(systemViewToUpdate).get()->remove(collectionEntry, false);
+				ViewController::get()->getGameListView(systemViewToUpdate).get()->remove(collectionEntry, false, true);
 			}
 			else
 			{

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -194,7 +194,7 @@ void GuiGamelistOptions::openMetaDataEd()
 	{
 		deleteBtnFunc = [this, file] {
 			CollectionSystemManager::get()->deleteCollectionFiles(file);
-			ViewController::get()->getGameListView(file->getSystem()).get()->remove(file, true);
+			ViewController::get()->getGameListView(file->getSystem()).get()->remove(file, true, true);
 		};
 	}
 

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -112,7 +112,7 @@ void BasicGameListView::launch(FileData* game)
 	ViewController::get()->launch(game);
 }
 
-void BasicGameListView::remove(FileData *game, bool deleteFile)
+void BasicGameListView::remove(FileData *game, bool deleteFile, bool refreshView)
 {
 	if (deleteFile)
 	{
@@ -184,7 +184,8 @@ void BasicGameListView::remove(FileData *game, bool deleteFile)
 		addPlaceholder();
 	}
 	delete game;                                 // remove before repopulating (removes from parent)
-	onFileChanged(parent, FILE_REMOVED);           // update the view, with game removed
+	if(refreshView)
+		onFileChanged(parent, FILE_REMOVED);     // update the view, with game removed
 }
 
 std::vector<HelpPrompt> BasicGameListView::getHelpPrompts()

--- a/es-app/src/views/gamelist/BasicGameListView.h
+++ b/es-app/src/views/gamelist/BasicGameListView.h
@@ -29,7 +29,7 @@ protected:
 	virtual std::string getQuickSystemSelectRightButton() override;
 	virtual std::string getQuickSystemSelectLeftButton() override;
 	virtual void populateList(const std::vector<FileData*>& files) override;
-	virtual void remove(FileData* game, bool deleteFile) override;
+	virtual void remove(FileData* game, bool deleteFile, bool refreshView=true) override;
 	virtual void addPlaceholder();
 
 	TextListComponent<FileData*> mList;

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -411,7 +411,7 @@ void GridGameListView::launch(FileData* game)
 
 }
 
-void GridGameListView::remove(FileData *game, bool deleteFile)
+void GridGameListView::remove(FileData *game, bool deleteFile, bool refreshView)
 {
 	if (deleteFile)
 		Utils::FileSystem::removeFile(game->getPath());  // actually delete the file on the filesystem
@@ -437,7 +437,9 @@ void GridGameListView::remove(FileData *game, bool deleteFile)
 		addPlaceholder();
 	}
 	delete game;                                 // remove before repopulating (removes from parent)
-	onFileChanged(parent, FILE_REMOVED);           // update the view, with game removed
+
+	if(refreshView)
+		onFileChanged(parent, FILE_REMOVED);     // update the view, with game removed
 }
 
 std::vector<TextComponent*> GridGameListView::getMDLabels()

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -36,7 +36,7 @@ protected:
 	virtual std::string getQuickSystemSelectRightButton() override;
 	virtual std::string getQuickSystemSelectLeftButton() override;
 	virtual void populateList(const std::vector<FileData*>& files) override;
-	virtual void remove(FileData* game, bool deleteFile) override;
+	virtual void remove(FileData* game, bool deleteFile, bool refreshView=true) override;
 	virtual void addPlaceholder();
 
 	ImageGridComponent<FileData*> mGrid;

--- a/es-app/src/views/gamelist/IGameListView.h
+++ b/es-app/src/views/gamelist/IGameListView.h
@@ -33,7 +33,7 @@ public:
 	virtual void setCursor(FileData*) = 0;
 
 	virtual bool input(InputConfig* config, Input input) override;
-	virtual void remove(FileData* game, bool deleteFile) = 0;
+	virtual void remove(FileData* game, bool deleteFile, bool refreshView=true) = 0;
 
 	virtual const char* getName() const = 0;
 	virtual void launch(FileData* game) = 0;


### PR DESCRIPTION
Added an extra parameter for the `remove` call, hinting that a refresh of the View is not desired.
This skips any `onFileChanged` event called at the end of `remove`, leaving it to the caller to explicitely call the `onFileChanged` method. The skip decreases the time spent in `remove`.

The sole usage - right now - is during the initial built-in collections creation, when the `recent` collection trimming can take a long time when it has >>50 entries.