### PR TITLE
Make short descriptions wrap to next line instead of adding ellipsis.

### DIFF
--- a/es-core/src/components/TextComponent.cpp
+++ b/es-core/src/components/TextComponent.cpp
@@ -158,11 +158,9 @@ void TextComponent::calculateExtent()
 	if(mAutoCalcExtent.x())
 	{
 		mSize = mFont->sizeText(mUppercase ? Utils::String::toUpper(mText) : mText, mLineSpacing);
-	}else{
-		if(mAutoCalcExtent.y())
-		{
-			mSize[1] = mFont->sizeWrappedText(mUppercase ? Utils::String::toUpper(mText) : mText, getSize().x(), mLineSpacing).y();
-		}
+	}else if(mAutoCalcExtent.y())
+	{
+		mSize.y() = mFont->sizeWrappedText(mUppercase ? Utils::String::toUpper(mText) : mText, getSize().x(), mLineSpacing).y();
 	}
 }
 
@@ -179,8 +177,7 @@ void TextComponent::onTextChanged()
 	std::string text = mUppercase ? Utils::String::toUpper(mText) : mText;
 
 	std::shared_ptr<Font> f = mFont;
-	const bool isMultiline = (mSize.y() == 0 || mSize.y() > f->getHeight()*1.2f);
-
+	const bool isMultiline = (mSize.y() == 0 || mSize.y() > f->getHeight(mLineSpacing));
 	bool addAbbrev = false;
 	if(!isMultiline)
 	{

--- a/es-core/src/resources/Font.cpp
+++ b/es-core/src/resources/Font.cpp
@@ -526,7 +526,11 @@ std::string Font::wrapText(std::string text, float maxWidth)
 			}
 		}
 
-		if(cursor == text.length()) // arrived at end of text.
+		if(cursor == text.length() && lineWidth <= maxWidth)
+		// arrived at end of text while being in bounds of textbox
+		// second clause is mandatory for short descriptions which coincidentially
+		// ending with cursor at text end but slightly overrunning the bounding box
+		// to be wrapped on the next line, thus have to hit the else branch
 		{
 			out += text;
 			text.erase();


### PR DESCRIPTION
The ellipsis effect instead of wrapping to a new line had two causes:
1. A short description ends slightly after the x-bounding value of the textcomponent (can happen in any theme).
2. Themes with a linespacing with less than 1.2 (120% of highest character) get a wrong flag set for detecting if it is a multi line text. Carbon uses 1.5 linespacing by default thus this case never to carbon.

Fixes:
1. An additional clause in Font.cpp::wrapText() was added to fix this effect and to force wrapping instead of adding ellipsis.
2. The evaluation of the variable isMultiline in TextComponent::onTextChanged() takes the actual linespacing for calculation instead of the "magic float" of 1.2.

Resolves #796.
cf. https://retropie.org.uk/forum/topic/32893/very-short-descriptions-don-t-wrap