### PR TITLE
timeutil: fix building with recent `gcc` versions.

### DIFF
--- a/es-core/src/utils/TimeUtil.h
+++ b/es-core/src/utils/TimeUtil.h
@@ -3,6 +3,7 @@
 #define ES_CORE_UTILS_TIME_UTIL_H
 
 #include <string>
+#include <time.h>
 
 namespace Utils
 {


### PR DESCRIPTION
Included `time.h` to get the declarations of `time_t` and `struct tm`.
Should fix building with `gcc` 12.x.

Should fix #804.