### PR TITLE
Fixes ES crash after boot on stale SDL joy add/remove events.

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -7,6 +7,7 @@
 #include "CollectionSystemManager.h"
 #include "FileFilterIndex.h"
 #include "FileSorts.h"
+#include "InputManager.h"
 #include "Log.h"
 #include "MameNames.h"
 #include "platform.h"
@@ -272,6 +273,7 @@ void FileData::launchGame(Window* window)
 
 	AudioManager::getInstance()->deinit();
 	VolumeControl::getInstance()->deinit();
+	InputManager::getInstance()->deinit();
 	window->deinit();
 
 	std::string command = mEnvData->mLaunchCommand;
@@ -298,6 +300,7 @@ void FileData::launchGame(Window* window)
 	Scripting::fireEvent("game-end");
 
 	window->init();
+	InputManager::getInstance()->init();
 	VolumeControl::getInstance()->init();
 	window->normalizeNextUpdate();
 

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -393,6 +393,8 @@ int main(int argc, char* argv[])
 	if(splashScreen)
 		window.renderLoadingScreen("Done.");
 
+	InputManager::getInstance()->init();
+
 	//choose which GUI to open depending on if an input configuration already exists
 	if(errorMsg == NULL)
 	{
@@ -402,16 +404,6 @@ int main(int argc, char* argv[])
 		}else{
 			window.pushGui(new GuiDetectDevice(&window, true, [] { ViewController::get()->goToStart(); }));
 		}
-	}
-
-	// flush any queued events before showing the UI and starting the input handling loop
-	const Uint32 event_list[] = {
-			SDL_JOYAXISMOTION, SDL_JOYBALLMOTION, SDL_JOYHATMOTION, SDL_JOYBUTTONDOWN, SDL_JOYBUTTONUP,
-			SDL_KEYDOWN, SDL_KEYUP
-		};
-	SDL_PumpEvents();
-	for(Uint32 ev_type: event_list) {
-		SDL_FlushEvent(ev_type);
 	}
 
 	int lastTime = SDL_GetTicks();
@@ -473,6 +465,8 @@ int main(int argc, char* argv[])
 
 	while(window.peekGui() != ViewController::get())
 		delete window.peekGui();
+
+	InputManager::getInstance()->deinit();
 	window.deinit();
 
 	MameNames::deinit();

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -84,7 +84,8 @@ void InputManager::init()
 
 void InputManager::addJoystickByDeviceIndex(int id)
 {
-	assert(id >= 0 && id < SDL_NumJoysticks());
+	assert(id > -1);
+	assert(id < SDL_NumJoysticks());
 
 	// open joystick & add to our list
 	SDL_Joystick* joy = SDL_JoystickOpen(id);
@@ -101,9 +102,9 @@ void InputManager::addJoystickByDeviceIndex(int id)
 	mInputConfigs[joyId] = new InputConfig(joyId, SDL_JoystickName(joy), guid);
 	if(!loadInputConfig(mInputConfigs[joyId]))
 	{
-		LOG(LogInfo) << "Added unconfigured joystick " << SDL_JoystickName(joy) << " (GUID: " << guid << ", instance ID: " << joyId << ", device index: " << id << ").";
+		LOG(LogInfo) << "Added unconfigured joystick '" << SDL_JoystickName(joy) << "' (GUID: " << guid << ", instance ID: " << joyId << ", device index: " << id << ").";
 	}else{
-		LOG(LogInfo) << "Added known joystick " << SDL_JoystickName(joy) << " (instance ID: " << joyId << ", device index: " << id << ")";
+		LOG(LogInfo) << "Added known joystick '" << SDL_JoystickName(joy) << "' (instance ID: " << joyId << ", device index: " << id << ")";
 	}
 
 	// set up the prevAxisValues
@@ -128,13 +129,9 @@ void InputManager::removeJoystickByJoystickID(SDL_JoystickID joyId)
 
 	// close the joystick
 	auto joyIt = mJoysticks.find(joyId);
-	if(joyIt != mJoysticks.cend())
-	{
-		SDL_JoystickClose(joyIt->second);
-		mJoysticks.erase(joyIt);
-	}else{
-		LOG(LogError) << "Could not find joystick to close (instance ID: " << joyId << ")";
-	}
+	LOG(LogInfo) << "Removed joystick '" << SDL_JoystickName(joyIt->second) << "' (instance ID: " << joyId << ")";
+	SDL_JoystickClose(joyIt->second);
+	mJoysticks.erase(joyIt);
 }
 
 void InputManager::deinit()

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -4,7 +4,6 @@
 #include "components/ImageComponent.h"
 #include "resources/Font.h"
 #include "resources/TextureResource.h"
-#include "InputManager.h"
 #include "Log.h"
 #include "Scripting.h"
 #include <algorithm>
@@ -78,8 +77,6 @@ bool Window::init()
 		return false;
 	}
 
-	InputManager::getInstance()->init();
-
 	ResourceManager::getInstance()->reloadAll();
 
 	//keep a reference to the default fonts, so they don't keep getting destroyed/recreated
@@ -107,7 +104,6 @@ void Window::deinit()
 	{
 		(*i)->onHide();
 	}
-	InputManager::getInstance()->deinit();
 	ResourceManager::getInstance()->unloadAll();
 	Renderer::deinit();
 }


### PR DESCRIPTION
This happens whenever a joystick is remved during ES splashscreen. Putting the PR here after initial discussion in forum:

https://retropie.org.uk/forum/topic/33014/failed-assertion-on-connected-joysticks-terminates-emulationstation-on-specific-conditions