### PR TITLE
input: remove useless XML node in the temporary output

### DIFF
--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -369,7 +369,6 @@ void InputManager::writeDeviceConfig(InputConfig* config)
 					path = getTemporaryConfigPath();
 					doc.reset();
 					root = doc.append_child("inputList");
-					root.append_copy(actionnode);
 				}
 				else
 				{


### PR DESCRIPTION
The `<inputAction>` node is useless for the temporary input configuration, so remove it.

Normally, because of the previous `reset` call of the parent document, it would be empty, but I've encountered situations when the memory is not cleared and there's (random binary) garbage added to the temporary configuration file. This results in a broken XML file and the auto-configuration scripts in RetroPie will all fail.