### PR TITLE
Reduces callcount to TextComponent.onTextChanged()

### DIFF
--- a/es-core/src/components/TextComponent.h
+++ b/es-core/src/components/TextComponent.h
@@ -49,7 +49,7 @@ protected:
 	std::shared_ptr<Font> mFont;
 
 private:
-	void calculateExtent();
+	std::string calculateExtent();
 
 	void onColorChanged();
 


### PR DESCRIPTION
This is a optimization followup to PR #803.
Main changes are to call `calculateExtent();` only when text is present and keep the text once rendered/calculated for screen size instead of recalculating it everytime.

It is a refactoring to optimize the runtime/call count of `TextComponent.onTextChanged()`

I ran the `ProfilingUtil` on the method before...

```
Aug 17 14:45:45 lvl3: 	Message                     	       Calls	  Total Time	    Avg Time	    Min Time	    Max Time	 Internal Total Time	   Internal Avg Time
Aug 17 14:45:45 lvl3: 	TextComponent::onTextChanged	        6328	    1.594224	    0.000252	    0.000000	    0.027193	            1.594224	            0.000252
```

...and after (~60% less calls and ~15% faster per call):
```
Aug 18 23:16:25 lvl3: 	Message                     	       Calls	  Total Time	    Avg Time	    Min Time	    Max Time	 Internal Total Time	   Internal Avg Time
Aug 18 23:16:25 lvl3: 	TextComponent::onTextChanged	        2719	    0.593239	    0.000218	    0.000000	    0.028728	            0.593239	            0.000218
```

I did not detect any changes in the rendered layout of ES.
