### PR TITLE
Fix pugixml include paths and make submodule optional

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -12,7 +12,7 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include "ThemeData.h"
-#include <pugixml/src/pugixml.hpp>
+#include <pugixml.hpp>
 #include <fstream>
 
 std::string myCollectionsName = "collections";

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -8,7 +8,7 @@
 #include "Log.h"
 #include "Settings.h"
 #include "SystemData.h"
-#include <pugixml/src/pugixml.hpp>
+#include <pugixml.hpp>
 
 FileData* findOrCreateFile(SystemData* system, const std::string& path, FileType type)
 {

--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -2,7 +2,7 @@
 
 #include "utils/FileSystemUtil.h"
 #include "Log.h"
-#include <pugixml/src/pugixml.hpp>
+#include <pugixml.hpp>
 
 MetaDataDecl gameDecls[] = {
 	// key,         type,                   default,            statistic,  name in GuiMetaDataEd,  prompt in GuiMetaDataEd

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include <pugixml/src/pugixml.hpp>
+#include <pugixml.hpp>
 
 class FileData;
 class FileFilterIndex;

--- a/es-app/src/scrapers/GamesDBJSONScraper.cpp
+++ b/es-app/src/scrapers/GamesDBJSONScraper.cpp
@@ -10,7 +10,7 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include "utils/TimeUtil.h"
-#include <pugixml/src/pugixml.hpp>
+#include <pugixml.hpp>
 
 /* When raspbian will get an up to date version of rapidjson we'll be
    able to have it throw in case of error with the following:

--- a/es-app/src/scrapers/ScreenScraper.cpp
+++ b/es-app/src/scrapers/ScreenScraper.cpp
@@ -7,7 +7,7 @@
 #include "PlatformId.h"
 #include "Settings.h"
 #include "SystemData.h"
-#include <pugixml/src/pugixml.hpp>
+#include <pugixml.hpp>
 #include <cstring>
 
 using namespace PlatformIds;

--- a/es-core/src/InputConfig.cpp
+++ b/es-core/src/InputConfig.cpp
@@ -2,7 +2,7 @@
 
 #include "Log.h"
 #include "utils/StringUtil.h"
-#include <pugixml/src/pugixml.hpp>
+#include <pugixml.hpp>
 
 //some util functions
 std::string inputTypeToString(InputType type)

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -6,7 +6,7 @@
 #include "platform.h"
 #include "Scripting.h"
 #include "Window.h"
-#include <pugixml/src/pugixml.hpp>
+#include <pugixml.hpp>
 #include <SDL.h>
 #include <iostream>
 #include <assert.h>

--- a/es-core/src/MameNames.cpp
+++ b/es-core/src/MameNames.cpp
@@ -3,7 +3,7 @@
 #include "resources/ResourceManager.h"
 #include "utils/FileSystemUtil.h"
 #include "Log.h"
-#include <pugixml/src/pugixml.hpp>
+#include <pugixml.hpp>
 #include <string.h>
 
 MameNames* MameNames::sInstance = nullptr;

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -4,7 +4,7 @@
 #include "Log.h"
 #include "Scripting.h"
 #include "platform.h"
-#include <pugixml/src/pugixml.hpp>
+#include <pugixml.hpp>
 #include <algorithm>
 #include <vector>
 

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -7,7 +7,7 @@
 #include "Log.h"
 #include "platform.h"
 #include "Settings.h"
-#include <pugixml/src/pugixml.hpp>
+#include <pugixml.hpp>
 #include <algorithm>
 
 std::vector<std::string> ThemeData::sSupportedViews { { "system" }, { "basic" }, { "detailed" }, { "grid" }, { "video" } };

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -2,4 +2,9 @@
 # package managers are included with the project (in the 'external' folder)
 
 add_subdirectory("nanosvg")
-add_subdirectory("pugixml")
+
+find_package(pugixml)
+
+if(NOT pugixml_FOUND)
+  add_subdirectory("pugixml")
+endif()


### PR DESCRIPTION
This PR corrects the pugixml include paths to the paths that pugixml is ought to be included from when installed as a package.
These also work when pugixml is built locally from source.

In addition to that, i added a conditional that builds pugixml from source if it is not available as a system-wide installation.