### PR TITLE
Add and document WIN32 build support

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,6 +1,7 @@
 name: C/C++ CI
 
-on: [push]
+on:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/win32.yml
+++ b/.github/workflows/win32.yml
@@ -1,0 +1,141 @@
+name: Build ES for Win32
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on:
+      # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
+      windows-2022
+
+    env:
+      # Build parameters for CMake
+      BUILD_TYPE: Release
+      Platform: Win32
+
+    defaults:
+      run:
+        shell: cmd
+
+    steps:
+      # Create directories for build (used by CMake) and nuget
+      - name: Set up directories
+        working-directory: ${{runner.workspace}}
+        run: mkdir build nuget
+
+      # Check-out repository under $GITHUB_WORKSPACE
+      # https://github.com/actions/checkout
+      - name: Check-out repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      # Discover location of MSBuild tool and to PATH environment variables
+      # https://github.com/microsoft/setup-msbuild
+      - name: Locate MSBuild
+        uses: microsoft/setup-msbuild@v1.3.1
+
+      # Use NuGet to download the latest libVLC.
+      - name: Download libVLC
+        working-directory: ${{runner.workspace}}/nuget
+        run: nuget install -ExcludeVersion VideoLAN.LibVLC.Windows
+
+      # Use vcpkg to download and build the latest cURL
+      - name: Build cURL static library
+        run: vcpkg install curl:x86-windows-static-md
+
+      # Use vcpkg to download and build the latest FreeImage
+      - name: Build FreeImage static library
+        run: vcpkg install freeimage:x86-windows-static-md
+
+      # Use vcpkg to download and build the latest FreeType2
+      - name: Build FreeType2 static library
+        run: vcpkg install freetype:x86-windows-static-md
+
+      # Use vcpkg to download and build the latest SDL2
+      - name: Build SDL2 static library
+        run: vcpkg install sdl2:x86-windows-static-md
+
+      # Use vcpkg to download and build the latest RapidJSON
+      - name: Build RapidJSON static library
+        run: vcpkg install rapidjson:x86-windows-static-md
+
+      # Setup environment variables for subsequent steps
+      # Note: Forward slashes are used for CMake compatibility
+      - name: Set up environment
+        run: |
+          set VCPKG=%VCPKG_INSTALLATION_ROOT%/installed/x86-windows-static-md
+          set "VCPKG=%VCPKG:\=/%"
+          set NUGET=${{runner.workspace}}/nuget
+          set "NUGET=%NUGET:\=/%"
+          set VLC_HOME=%NUGET%/VideoLAN.LibVLC.Windows/build/x86
+          echo VCPKG=%VCPKG%>> %GITHUB_ENV%
+          echo NUGET=%NUGET%>> %GITHUB_ENV%
+          echo FREETYPE_DIR=%VCPKG%>> %GITHUB_ENV%
+          echo FREEIMAGE_HOME=%VCPKG%>> %GITHUB_ENV%
+          echo VLC_HOME=%VLC_HOME%>> %GITHUB_ENV%
+          echo RAPIDJSON_INCLUDE_DIRS=%VCPKG%/include>> %GITHUB_ENV%
+          echo CURL_INCLUDE_DIR=%VCPKG%/include>> %GITHUB_ENV%
+          echo SDL2_INCLUDE_DIR=%VCPKG%/include/SDL2>> %GITHUB_ENV%
+          echo VLC_INCLUDE_DIR=%VLC_HOME%/include>> %GITHUB_ENV%
+          echo CURL_LIBRARY=%VCPKG%/lib/*.lib>> %GITHUB_ENV%
+          echo SDL2_LIBRARY=%VCPKG%/lib/manual-link/SDL2main.lib>> %GITHUB_ENV%
+          echo VLC_LIBRARIES=%VLC_HOME%/libvlc*.lib>> %GITHUB_ENV%
+          echo VLC_VERSION=3.0.11>> %GITHUB_ENV%
+
+      # Use CMake to create Visual Studio project in build folder
+      - name: Create Visual Studio project
+        working-directory: ${{runner.workspace}}
+        run: cmake ${{github.workspace}}
+          -B build
+          -A %Platform%
+          -DRAPIDJSON_INCLUDE_DIRS=%RAPIDJSON_INCLUDE_DIRS%
+          -DCURL_INCLUDE_DIR=%CURL_INCLUDE_DIR%
+          -DSDL2_INCLUDE_DIR=%SDL2_INCLUDE_DIR%
+          -DVLC_INCLUDE_DIR=%VLC_INCLUDE_DIR%
+          -DCURL_LIBRARY=%CURL_LIBRARY%
+          -DSDL2_LIBRARY=%SDL2_LIBRARY%
+          -DVLC_LIBRARIES=%VLC_LIBRARIES%
+          -DVLC_VERSION=%VLC_VERSION%
+          -DCMAKE_EXE_LINKER_FLAGS=/SAFESEH:NO
+
+      # Use CMake to build project
+      - name: Build EmulationStation
+        working-directory: ${{runner.workspace}}
+        run: cmake --build build --config %BUILD_TYPE%
+
+      # Copy all other dependencies into Release folder
+      # Note: Forward slashes are replaced with back slashes for this step
+      - name: Collect dependencies
+        working-directory: ${{github.workspace}}/Release
+        run: |
+          set "VLC_ROOT=%VLC_HOME:/=\%"
+          mkdir .emulationstation
+          xcopy ..\resources .\resources /h /i /c /k /e /r /y
+          copy %VLC_ROOT%\*.dll .
+          xcopy %VLC_ROOT%\plugins .\plugins /h /i /c /k /e /r /y
+
+      # Create systems configuration file
+      - name: Create systems configuration file
+        working-directory: ${{github.workspace}}/Release/.emulationstation
+        run: |
+          echo ^<!-- This is the EmulationStation Systems configuration file.> es_systems.cfg
+          echo All systems must be contained within the ^<systemList^> tag.--^>>> es_systems.cfg
+          echo:>> es_systems.cfg
+          echo ^<systemList^>>> es_systems.cfg
+          echo:>> es_systems.cfg
+          echo ^</systemList^>>> es_systems.cfg
+
+      # Uploads artifacts from workflow
+      # https://github.com/actions/upload-artifact
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: EmulationStation
+          path: |
+            ${{github.workspace}}\Release\*.exe
+            ${{github.workspace}}\Release\*.dll
+            ${{github.workspace}}\Release\resources\
+            ${{github.workspace}}\Release\plugins\
+            ${{github.workspace}}\Release\.emulationstation\

--- a/CMake/Packages/FindRapidJSON.cmake
+++ b/CMake/Packages/FindRapidJSON.cmake
@@ -61,11 +61,11 @@ mark_as_advanced(RAPIDJSON_INCLUDE_DIRS)
 # handle the QUIETLY and REQUIRED arguments and set RAPIDJSON_FOUND to TRUE if
 # all listed variables are TRUE
 include("FindPackageHandleStandardArgs")
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(Rapidjson
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(RapidJSON
   REQUIRED_VARS RAPIDJSON_INCLUDE_DIRS
-  FOUND_VAR Rapidjson_FOUND
+  FOUND_VAR RapidJSON_FOUND
 )
 
-if(Rapidjson_FOUND)
-    set(RAPIDJSON_FOUND ${Rapidjson_FOUND})
+if(RapidJSON_FOUND)
+    set(RAPIDJSON_FOUND ${RapidJSON_FOUND})
 endif()

--- a/CMake/Utils/FindPkgMacros.cmake
+++ b/CMake/Utils/FindPkgMacros.cmake
@@ -70,7 +70,9 @@ endmacro(clear_if_changed)
 
 # Try to get some hints from pkg-config, if available
 macro(use_pkgconfig PREFIX PKGNAME)
-  find_package(PkgConfig)
+  if(NOT WIN32)
+    find_package(PkgConfig)
+  endif(NOT WIN32)
   if (PKG_CONFIG_FOUND)
     pkg_check_modules(${PREFIX} ${PKGNAME})
   endif ()
@@ -96,7 +98,7 @@ macro(get_debug_names PREFIX)
   endforeach(i)
 endmacro(get_debug_names)
 
-# Add the parent dir from DIR to VAR 
+# Add the parent dir from DIR to VAR
 macro(add_parent_dir VAR DIR)
   get_filename_component(${DIR}_TEMP "${${DIR}}/.." ABSOLUTE)
   set(${VAR} ${${VAR}} ${${DIR}_TEMP})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
+# Note: Visual Studio 2022 generator requires CMake 3.21 or greater.
 
 option(GLES "Set to ON if targeting Embedded OpenGL" ${GLES})
 option(GL "Set to ON if targeting Desktop OpenGL" ${GL})
@@ -137,8 +138,16 @@ if(MSVC)
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
     add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
     add_definitions(-DNOMINMAX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP") #multi-processor compilation
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP") #multi-processor compilation
+
+    # multi-processor compilation
+    # disable warning c4018 - signed/unsigned mismatch
+    # disable warning c4244 - conversion, possible loss of data
+    # disable warning c4996 - use of deprecated function/member/variable/typedef
+    # Use extended ASCII character set
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /wd4018 /wd4244 /wd4996 /source-charset:437")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP /wd4018 /wd4244 /wd4996 /source-charset:437")
+    set(CMAKE_EXE_LINKER_FLAGS "/SAFESEH:NO")
 
     # Set the start-up project to in VS to 'emulationstation'
     set(VS_STARTUP_PROJECT "emulationstation")
@@ -238,7 +247,12 @@ endif()
 
 if(MSVC)
     LIST(APPEND COMMON_LIBRARIES
+        Crypt32
+        Imm32
+        Setupapi
+        Version
         winmm
+        Wldap32
     )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -7,25 +7,26 @@ EmulationStation is a cross-platform graphical front-end for emulators with cont
 Building
 ========
 
-**Building on Linux**
+Building on Linux
+-----------------
 
 EmulationStation uses some C++11 code, which means you'll need to use at least g++-4.7 on Linux, or VS2010 on Windows, to compile.
 
 EmulationStation has a few dependencies. For building, you'll need CMake, SDL2, FreeImage, FreeType, cURL and RapidJSON.  You also should probably install the `fonts-droid` package which contains fallback fonts for Chinese/Japanese/Korean characters, but ES will still work fine without it (this package is only used at run-time).
 
-**On Debian/Ubuntu:**
+### On Debian/Ubuntu:
 All of this be easily installed with `apt-get`:
 ```bash
 sudo apt-get install libsdl2-dev libfreeimage-dev libfreetype6-dev libcurl4-openssl-dev rapidjson-dev \
   libasound2-dev libgles2-mesa-dev build-essential cmake fonts-droid-fallback libvlc-dev \
   libvlccore-dev vlc-bin
 ```
-**On Fedora:**
+### On Fedora:
 All of this be easily installed with `dnf` (with rpmfusion activated) :
 ```bash
 sudo dnf install SDL2-devel freeimage-devel freetype-devel curl-devel \
   alsa-lib-devel mesa-libGL-devel cmake \
-  vlc-devel rapidjson-devel 
+  vlc-devel rapidjson-devel
 ```
 
 **Note**: this repository uses a git submodule - to checkout the source and all submodules, use
@@ -34,7 +35,7 @@ sudo dnf install SDL2-devel freeimage-devel freetype-devel curl-devel \
 git clone --recursive https://github.com/RetroPie/EmulationStation.git
 ```
 
-or 
+or
 
 ```bash
 git clone https://github.com/RetroPie/EmulationStation.git
@@ -54,7 +55,7 @@ NOTE: to generate a `Debug` build on Unix/Linux, run the Makefile generation ste
 cmake -DCMAKE_BUILD_TYPE=Debug .
 ```
 
-**On the Raspberry Pi**
+### On the Raspberry Pi:
 
 * Choosing a GLES implementation.
 
@@ -71,23 +72,110 @@ cmake -DCMAKE_BUILD_TYPE=Debug .
 
  If your system doesn't have a working GLESv2 implementation, the GLESv1 legacy renderer can be compiled in by adding `-DUSE_GLES1=On` to the build options.
 
-**Building on Windows**
+Building on Windows
+-------------------
 
-[FreeImage](http://downloads.sourceforge.net/freeimage/FreeImage3154Win32.zip)
+* Install [Visual Studio 2022](https://visualstudio.microsoft.com/vs/community/). At a minimum, install the "Desktop development with C++" workload with the default list of optional items.
 
-[FreeType2](http://download.savannah.gnu.org/releases/freetype/freetype-2.4.9.tar.bz2) (you'll need to compile)
+* Install the latest version of [CMake](https://cmake.org/download/) (e.g., [cmake-3.27.1-windows-x86_64.msi](https://github.com/Kitware/CMake/releases/download/v3.27.1/cmake-3.27.1-windows-x86_64.msi)). CMake is used for generating the Visual Studio project.
 
-[SDL2](http://www.libsdl.org/release/SDL2-devel-2.0.8-VC.zip)
+* Use git to clone [vcpkg](https://vcpkg.io/en/), then run the bootstrap script as shown below to build vcpkg . This is a C/C++ dependency manager from Microsoft.
 
-[cURL](http://curl.haxx.se/download.html) (you'll need to compile or get the pre-compiled DLL version)
+```batchfile
+C:\src>git clone https://github.com/Microsoft/vcpkg.git
+C:\src>.\vcpkg\bootstrap-vcpkg.bat
+```
 
-[RapisJSON](https://github.com/tencent/rapidjson) (you'll need the `include/rapidsjon` added to the include path)
+* Download the latest [nuget.exe](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) to a folder that is in your Windows PATH. NuGet is a .NET package manager.
 
-(Remember to copy necessary .DLLs into the same folder as the executable: probably FreeImage.dll, freetype6.dll, SDL2.dll, libcurl.dll, and zlib1.dll. Exact list depends on if you built your libraries in "static" mode or not.)
+* Use NuGet to download the latest [libVLC](https://www.videolan.org/vlc/libvlc.html). This library is used to play video snaps.
 
-[CMake](http://www.cmake.org/cmake/resources/software.html) (this is used for generating the Visual Studio project)
+```batchfile
+C:\src\EmulationStation>mkdir nuget
+C:\src\EmulationStation>cd nuget
+C:\src\EmulationStation\nuget>nuget install -ExcludeVersion VideoLAN.LibVLC.Windows
+```
 
-(If you don't know how to use CMake, here are some hints: run cmake-gui and point it at your EmulationStation folder.  Point the "build" directory somewhere - I use EmulationStation/build.  Click configure, choose "Visual Studio [year] Project", fill in red fields as they appear and keep clicking Configure (you may need to check "Advanced"), then click Generate.)
+* Use vcpkg to download the latest pre-compiled [cURL](http://curl.haxx.se/download.html). This is a library for transferring data with URLs.
+
+```batchfile
+c:\src>.\vcpkg\vcpkg install curl:x86-windows-static-md
+```
+
+* Use vcpkg to download the latest [FreeImage](https://freeimage.sourceforge.io/index.html). This library supports popular graphics image formats.
+
+```batchfile
+c:\src\>.\vcpkg\vcpkg install freeimage:x86-windows-static-md
+```
+
+* Use vcpkg to download the latest pre-compiled [FreeType2](https://freetype.org/). This library is used to render fonts.
+
+```batchfile
+c:\src>.\vcpkg\vcpkg install freetype:x86-windows-static-md
+```
+
+* Use vcpkg to download the latest [SDL2](http://www.libsdl.org/). Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
+
+```batchfile
+c:\src>.\vcpkg\vcpkg install sdl2:x86-windows-static-md
+```
+
+* Use vcpkg to download the latest [RapidJSON](http://rapidjson.org/). This library provides a fast JSON parser/generator for C++ with both SAX/DOM style API.
+
+```batchfile
+c:\src>.\vcpkg\vcpkg install rapidjson:x86-windows-static-md
+```
+
+* Using the example shown below, configure environment variables to point to the libraries that were installed in the above steps. Please note that the below example intentionally uses forward slashes for compatibility with CMake.
+
+```batchfile
+C:\src\EmulationStation>set VCPKG="C:/src/vcpkg/installed/x86-windows-static-md"
+C:\src\EmulationStation>set NUGET="C:/src/EmulationStation/nuget"
+C:\src\EmulationStation>set FREETYPE_DIR="%VCPKG%"
+C:\src\EmulationStation>set FREEIMAGE_HOME="%VCPKG%"
+C:\src\EmulationStation>set VLC_HOME="%NUGET%/VideoLAN.LibVLC.Windows/build/x86"
+C:\src\EmulationStation>set RAPIDJSON_INCLUDE_DIRS="%VCPKG%/include"
+C:\src\EmulationStation>set CURL_INCLUDE_DIR="%VCPKG%/include"
+C:\src\EmulationStation>set SDL2_INCLUDE_DIR="%VCPKG%/include/SDL2"
+C:\src\EmulationStation>set VLC_INCLUDE_DIR="%VLC_HOME%/include"
+C:\src\EmulationStation>set CURL_LIBRARY="%VCPKG%/lib/*.lib"
+C:\src\EmulationStation>set SDL2_LIBRARY="%VCPKG%/lib/manual-link/SDL2main.lib"
+C:\src\EmulationStation>set VLC_LIBRARIES="%VLC_HOME%/libvlc*.lib"
+C:\src\EmulationStation>set VLC_VERSION=3.0.11
+```
+
+* Use CMake to generate the Visual Studio project.
+
+```batchfile
+C:\src\EmulationStation>mkdir build
+C:\src\EmulationStation>cmake . -B build -A Win32 ^
+-DRAPIDJSON_INCLUDE_DIRS=%RAPIDJSON_INCLUDE_DIRS% ^
+-DCURL_INCLUDE_DIR=%CURL_INCLUDE_DIR% ^
+-DSDL2_INCLUDE_DIR=%SDL2_INCLUDE_DIR% ^
+-DVLC_INCLUDE_DIR=%VLC_INCLUDE_DIR% ^
+-DCURL_LIBRARY=%CURL_LIBRARY% ^
+-DSDL2_LIBRARY=%SDL2_LIBRARY% ^
+-DVLC_LIBRARIES=%VLC_LIBRARIES% ^
+-DVLC_VERSION=%VLC_VERSION% ^
+-DCMAKE_EXE_LINKER_FLAGS=/SAFESEH:NO
+```
+
+* Use CMake to build the Visual Studio project.
+
+```batchfile
+C:\src\EmulationStation>cmake --build build --config Release
+```
+
+* Using the example shown below, copy the newly built binaries and other needed files to destination folder.
+
+```batchfile
+C:\src\EmulationStation>mkdir -p C:\apps\EmulationStation\.emulationstation
+C:\src\EmulationStation>xcopy C:\src\EmulationStation\resources C:\apps\EmulationStation\resources /h /i /c /k /e /r /y
+C:\src\EmulationStation>copy C:\src\EmulationStation\Release\*.exe C:\apps\EmulationStation /Y
+C:\src\EmulationStation>copy C:\src\EmulationStation\nuget\VideoLAN.LibVLC.Windows\build\x86\*.dll C:\apps\EmulationStation /Y
+C:\src\EmulationStation>xcopy C:\src\EmulationStation\nuget\VideoLAN.LibVLC.Windows\build\x86\plugins C:\apps\EmulationStation\plugins /h /i /c /k /e /r /y
+
+```
 
 
 Configuring

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -5,6 +5,10 @@
 #include "utils/StringUtil.h"
 #include "PowerSaver.h"
 #include "Settings.h"
+#ifdef WIN32
+ #include <basetsd.h>
+ typedef SSIZE_T ssize_t;
+#endif
 #include <vlc/vlc.h>
 #include <SDL_mutex.h>
 


### PR DESCRIPTION
This **pull request** (PR) provides the ability to build a **WIN32** version of _RetroPie's_ **EmulationStation**. This PR contains a minimal number of code changes as to not impact building **EmulationStation** for the various **Linux** distros. Detailed documentation for building **EmulationStation** for **Windows** was added to the **README.MD** file (preview [HERE](https://github.com/WiltonMicroSystems/EmulationStation/blob/WIN32/README.md)). In addition, a **GitHub Action** was added to automate the **WIN32** build process using a _free_ **Windows 2022** runner containing the current generation of tooling (e.g., **Visual Studio 2022**).

A compiled **WIN32** build from this PR can be downloaded from [HERE](https://github.com/WiltonMicroSystems/EmulationStation/releases/tag/v2.12.0-win32).