### PR TITLE
Resolved compiler warnings using clang 14.0.0 on Ubuntu-22.04.3

### DIFF
--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -21,8 +21,8 @@ public:
 
 	virtual FileData* getCursor() override;
 	virtual void setCursor(FileData*) override;
-	virtual void setViewportTop(int index) { ; }
-	virtual int getViewportTop() { return -1; }
+	virtual void setViewportTop(int index) override { ; }
+	virtual int getViewportTop() override { return -1; }
 
 	virtual bool input(InputConfig* config, Input input) override;
 


### PR DESCRIPTION
This pull request addresses 2 compiler warnings related to overrides.

```
In file included from /home/devel/git/EmulationStation/es-app/src/views/gamelist/GridGameListView.cpp:1:
/home/devel/git/EmulationStation/es-app/src/views/gamelist/GridGameListView.h:24:15: warning: 'setViewportTop' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        virtual void setViewportTop(int index) { ; }
                     ^
/home/devel/git/EmulationStation/es-app/src/views/gamelist/ISimpleGameListView.h:28:15: note: overridden virtual function is here
        virtual void setViewportTop(int index) override = 0;
                     ^
In file included from /home/devel/git/EmulationStation/es-app/src/views/gamelist/GridGameListView.cpp:1:
/home/devel/git/EmulationStation/es-app/src/views/gamelist/GridGameListView.h:25:14: warning: 'getViewportTop' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        virtual int getViewportTop() { return -1; }
                    ^
/home/devel/git/EmulationStation/es-app/src/views/gamelist/ISimpleGameListView.h:27:14: note: overridden virtual function is here
        virtual int getViewportTop() override = 0;
                    ^
```