### PR TITLE
Fixes the null selection for ROMs starting with Unicode or Umlauts

### DIFF
--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -30,9 +30,12 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 		char startChar = '!';
 		char endChar = '_';
 
+		bool outOfRange = false;
 		char curChar = (char)toupper(getGamelist()->getCursor()->getSortName()[0]);
-		if(curChar < startChar || curChar > endChar)
-			curChar = startChar;
+		if(curChar < startChar || curChar > endChar) {
+			// most likely 8 bit ASCII or Unicode (Prefix: 0xc2 or 0xe2) value
+			outOfRange = true;
+		}
 
 		mJumpToLetterList = std::make_shared<LetterList>(mWindow, "JUMP TO...", false);
 		for (char c = startChar; c <= endChar; c++)
@@ -44,7 +47,8 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 				char candidate = (char)toupper(file->getSortName()[0]);
 				if (c == candidate)
 				{
-					mJumpToLetterList->add(std::string(1, c), c, c == curChar);
+					mJumpToLetterList->add(std::string(1, c), c, (c == curChar) || outOfRange);
+					outOfRange = false; // only override selection on very first c == candidate match
 					break;
 				}
 			}


### PR DESCRIPTION
The null selection will then on confirming "Jump to ..." in the Gamelist Options menu crash ES (assertion failed in https://github.com/RetroPie/EmulationStation/blob/44df564dcfa30dc07781edb90491b3d2acb85e1c/es-core/src/components/OptionListComponent.h#L238)

How to reproduce:
1. Rename a Rom filename or when using a gamelist name a rom via <name> or <sortname> and use as first character either a whitespace, a tilde, or an Umlaut/8-Bit ASCII value or similar (I stumbled across this bug with the name Ō in Ōkamiden).
2. Restart ES or reload gamelist
3. Navigate to the just renamed ROM and highlight it with the cursor
4. Press _Select_ to open "Gamelist Options Menu"
5. Notice the null selection (only the arrows are displayed in "Jump to ..."
6. Confirm the null selection in  "Jump to ..." with _A_
7. ES will terminate

Expected:
- The selection in "Jump to ..." is always valid even when the cursor highlights a ROM starting with an Umlaut or similar.