### PR TITLE
Gamelist bugfix: don't show un-registered extensions

### DIFF
--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -85,6 +85,7 @@ void parseGamelist(SystemData* system)
 {
 	bool trustGamelist = Settings::getInstance()->getBool("ParseGamelistOnly");
 	std::string xmlpath = system->getGamelistPath(false);
+	const std::vector<std::string> allowedExtensions = system->getExtensions();
 
 	if(!Utils::FileSystem::exists(xmlpath))
 		return;
@@ -122,6 +123,13 @@ void parseGamelist(SystemData* system)
 			if(!trustGamelist && !Utils::FileSystem::exists(path))
 			{
 				LOG(LogWarning) << "File \"" << path << "\" does not exist! Ignoring.";
+				continue;
+			}
+
+			// Check whether the file's extension is allowed in the system
+			if (std::find(allowedExtensions.cbegin(), allowedExtensions.cend(), Utils::FileSystem::getExtension(path)) == allowedExtensions.cend())
+			{
+				LOG(LogDebug) << "file " << path << " found in gamelist, but has unregistered extension";
 				continue;
 			}
 


### PR DESCRIPTION
Updated the parsing of an existing gamelist to exclude entries without an extension present in `es_systems.cfg`. 

This can happen when the list of extensions is updated and some extensions are removed, but the `gamelist.xml` entries are not removed. EmulationStation would still consider the excluded extension's entries as valid gamelist entries, without filtering them out.

Some perf. testing done with _ProfilingUtil_ doesn't show a meaningful impact over the previous code.