### PR TITLE
system: don't lowercase the extensions during parsing

### DIFF
--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -105,7 +105,7 @@ void SystemData::populateFolder(FileData* folder)
 
 		//this is a little complicated because we allow a list of extensions to be defined (delimited with a space)
 		//we first get the extension of the file itself:
-		extension = Utils::String::toLower(Utils::FileSystem::getExtension(filePath));
+		extension = Utils::FileSystem::getExtension(filePath);
 
 		//fyi, folders *can* also match the extension and be added as games - this is mostly just to support higan
 		//see issue #75: https://github.com/Aloshi/EmulationStation/issues/75
@@ -187,7 +187,7 @@ SystemData* SystemData::loadSystem(pugi::xml_node system)
 
 	for (auto extension = list.cbegin(); extension != list.cend(); extension++)
 	{
-		std::string xt = Utils::String::toLower(*extension);
+		std::string xt = std::string(*extension);
 		if (std::find(extensions.begin(), extensions.end(), xt) == extensions.end())
 			extensions.push_back(xt);
 	}


### PR DESCRIPTION
This reverts the changes in 5349be1dcebd35c0f9d5698b0508caeba61ed1a5 that lower-cased the extension of the files listed and the system registered extensions.

On case-sensitive filesystems (i.e. Linux), this restores the ability to 'hide' certain files from being shown just be changing the case of the files' extension. This ability is used by certain RetroPie users to hide unwanted files, without them showin up in the gamelist, by modifying `es_systems.cfg` and removing the uppercase extension of the files.