### PR TITLE
deprecated in cURL (7.85.0 or later)

### DIFF
--- a/es-core/src/HttpReq.cpp
+++ b/es-core/src/HttpReq.cpp
@@ -77,7 +77,7 @@ HttpReq::HttpReq(const std::string& url)
 	}
 
 	//set curl restrict redirect protocols
-	err = curl_easy_setopt(mHandle, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+	err = curl_easy_setopt(mHandle, CURLOPT_REDIR_PROTOCOLS_STR, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 	if(err != CURLE_OK)
 	{
 		mStatus = REQ_IO_ERROR;


### PR DESCRIPTION
The warning suggests that this option is deprecated in the version of cURL (7.85.0 or later). The warning recommends using CURLOPT_REDIR_PROTOCOLS_STR instead. However, this could potentially introduce compatibility issues with older versions of cURL.