### PR TITLE
Fix crash during collection updates

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -513,6 +513,7 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file, int pressco
 					systemViewToUpdate->getIndex()->addToIndex(newGame);
 				}
 			}
+			sysData->setShuffledCacheDirty();
 			updateCollectionFolderMetadata(sysData);
 		}
 		else

--- a/es-app/src/SystemData.cpp
+++ b/es-app/src/SystemData.cpp
@@ -557,6 +557,11 @@ SystemData* SystemData::getRandomSystem()
 	return random_system;
 }
 
+void SystemData::setShuffledCacheDirty()
+{
+	mGamesShuffled.clear();
+}
+
 FileData* SystemData::getRandomGame()
 {
 	if (mGamesShuffled.empty())

--- a/es-app/src/SystemData.h
+++ b/es-app/src/SystemData.h
@@ -76,6 +76,7 @@ public:
 
 	FileFilterIndex* getIndex() { return mFilterIndex; };
 	void onMetaDataSavePoint();
+	void setShuffledCacheDirty();
 
 private:
 	static SystemData* loadSystem(pugi::xml_node system);


### PR DESCRIPTION
The last random method updates from 2021 could keep in memory a vector of pointers to objects that had since been removed, causing a crash when updating the collection metadata. Reported in the forums as well.