### PR TITLE
Fix crash on game launch from screensaver

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -237,12 +237,13 @@ void SystemScreenSaver::stopScreenSaver()
 	delete mImageScreensaver;
 	mImageScreensaver = NULL;
 
-	// Exit the indexing thread
-	if (Settings::getInstance()->getBool("BackgroundIndexing"))
+	// Exit the indexing thread in case it's running. Check if thread still exists.
+	if (Settings::getInstance()->getBool("BackgroundIndexing") && mThread)
 	{
 		mExit = true;
 		mThread->join();
 		delete mThread;
+		mThread = NULL;
 	}
 
 	// we need this to loop through different videos


### PR DESCRIPTION
The recent fix to launching a game from the screensaver for OMXPlayer could now cause a crash on VLC because of multi-threaded execution, where depending on the execution order we could try to join the thread process where it would no longer exist. This should fix it.