### PR TITLE
Ignore unmapped windows during screensaver controls

### DIFF
--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -181,6 +181,10 @@ bool Window::inputDuringScreensaver(InputConfig* config, Input input)
 		{
 			mScreenSaver->launchGame();
 		}
+		else if (config->getMappedTo(input).size() == 0) {
+			// catch invalid inputs here to prevent screensaver from stopping
+			input_consumed = true;
+		}
 	}
 	return input_consumed;
 }


### PR DESCRIPTION
Some controllers send ghost inputs at times (slight analog movements, or others) that would wake up the video screensaver when expecting other controls. This change ignores any unmapped input in that context (video/image screensaver, and screensaver controls ON).

I didn't expand it to other screensaver modes as I don't know how widespread or annoying ghost inputs are on other setups, and didn't want to break potentially expected behaviors (i.e. pressing any key whatsoever to wake up from screensaver, even if it's not mapped in EmulationStation).