### PR TITLE
Changes to maintain and persist <folder/> information in a gamelist:

### DIFF
--- a/es-app/src/MetaData.cpp
+++ b/es-app/src/MetaData.cpp
@@ -1,6 +1,7 @@
 #include "MetaData.h"
 
 #include "utils/FileSystemUtil.h"
+#include "utils/TimeUtil.h"
 #include "Log.h"
 #include <pugixml.hpp>
 
@@ -27,6 +28,12 @@ MetaDataDecl gameDecls[] = {
 };
 const std::vector<MetaDataDecl> gameMDD(gameDecls, gameDecls + sizeof(gameDecls) / sizeof(gameDecls[0]));
 
+const inline std::string blankDate() {
+	// blank date (1970-01-02) is used to render "" (see DateTimeComponent.cpp) for
+	// folder metadata when no date is provided (=default case)
+	return Utils::Time::timeToString(Utils::Time::BLANK_DATE, "%Y%m%d");
+}
+
 MetaDataDecl folderDecls[] = {
 	{"name",        MD_STRING,              "",                 false,      "name",                 "enter game name"},
 	{"sortname",    MD_STRING,              "",                 false,      "sortname",             "enter game sort name"},
@@ -35,12 +42,12 @@ MetaDataDecl folderDecls[] = {
 	{"thumbnail",   MD_PATH,                "",                 false,      "thumbnail",            "enter path to thumbnail"},
 	{"video",       MD_PATH,                "",                 false,      "video",                "enter path to video"},
 	{"marquee",     MD_PATH,                "",                 false,      "marquee",              "enter path to marquee"},
-	{"rating",      MD_RATING,              "0.000000",         false,      "rating",               "enter rating"},
-	{"releasedate", MD_DATE,                "not-a-date-time",  false,      "release date",         "enter release date"},
-	{"developer",   MD_STRING,              "unknown",          false,      "developer",            "enter game developer"},
-	{"publisher",   MD_STRING,              "unknown",          false,      "publisher",            "enter game publisher"},
-	{"genre",       MD_STRING,              "unknown",          false,      "genre",                "enter game genre"},
-	{"players",     MD_INT,                 "1",                false,      "players",              "enter number of players"}
+	{"rating",      MD_RATING,              "",                 false,      "rating",               "enter rating"},
+	{"releasedate", MD_DATE,                blankDate(),        true,       "release date",         "enter release date"},
+	{"developer",   MD_STRING,              "",                 false,      "developer",            "enter game developer"},
+	{"publisher",   MD_STRING,              "",                 false,      "publisher",            "enter game publisher"},
+	{"genre",       MD_STRING,              "",                 false,      "genre",                "enter game genre"},
+	{"players",     MD_INT,                 "",                 false,      "players",              "enter number of players"}
 };
 const std::vector<MetaDataDecl> folderMDD(folderDecls, folderDecls + sizeof(folderDecls) / sizeof(folderDecls[0]));
 

--- a/es-app/src/MetaData.h
+++ b/es-app/src/MetaData.h
@@ -29,7 +29,7 @@ struct MetaDataDecl
 	std::string key;
 	MetaDataType type;
 	std::string defaultValue;
-	bool isStatistic; //if true, ignore scraper values for this metadata
+	bool isStatistic; // if true: ignore in scraping and hide in metadata edits for this key
 	std::string displayName; // displayed as this in editors
 	std::string displayPrompt; // phrase displayed in editors when prompted to enter value (currently only for strings)
 };

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -121,7 +121,10 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 	if (UIModeController::getInstance()->isUIModeFull() && !mFromPlaceholder && !(mSystem->isCollection() && file->getType() == FOLDER))
 	{
 		row.elements.clear();
-		row.addElement(std::make_shared<TextComponent>(mWindow, "EDIT THIS GAME'S METADATA", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+		std::string lblTxt = std::string("EDIT THIS ");
+		lblTxt += std::string((file->getType() == FOLDER ? "FOLDER" : "GAME"));
+		lblTxt += std::string("'S METADATA");
+		row.addElement(std::make_shared<TextComponent>(mWindow, lblTxt, Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
 		row.addElement(makeArrow(mWindow), false);
 		row.makeAcceptInputHandler(std::bind(&GuiGamelistOptions::openMetaDataEd, this));
 		mMenu.addRow(row);

--- a/es-app/src/guis/GuiMetaDataEd.h
+++ b/es-app/src/guis/GuiMetaDataEd.h
@@ -26,6 +26,7 @@ private:
 	void fetch();
 	void fetchDone(const ScraperSearchResult& result);
 	void close(bool closeAllWindows);
+	bool hasChanges(); 
 
 	NinePatchComponent mBackground;
 	ComponentGrid mGrid;

--- a/es-core/src/components/DateTimeComponent.cpp
+++ b/es-core/src/components/DateTimeComponent.cpp
@@ -4,15 +4,17 @@
 #include "Log.h"
 #include "Settings.h"
 
+#include <ctime>
+
 DateTimeComponent::DateTimeComponent(Window* window) : TextComponent(window), mDisplayRelative(false)
 {
-	setFormat("%m/%d/%Y");
+	setFormat(getDateformat());
 }
 
 DateTimeComponent::DateTimeComponent(Window* window, const std::string& text, const std::shared_ptr<Font>& font, unsigned int color, Alignment align,
 	Vector3f pos, Vector2f size, unsigned int bgcolor) : TextComponent(window, text, font, color, align, pos, size, bgcolor), mDisplayRelative(false)
 {
-	setFormat("%m/%d/%Y");
+	setFormat(getDateformat());
 }
 
 void DateTimeComponent::setValue(const std::string& val)
@@ -47,9 +49,13 @@ void DateTimeComponent::onTextChanged()
 
 std::string DateTimeComponent::getDisplayString() const
 {
+	if(std::difftime(mTime.getTime(), Utils::Time::BLANK_DATE) == 0.0) {
+		return "";
+	}
+
 	if (mDisplayRelative) {
 		//relative time
-		if(mTime.getTime() == 0)
+		if(mTime.getTime() == Utils::Time::NOT_A_DATE_TIME)
 			return "never";
 
 		Utils::Time::DateTime now(Utils::Time::now());
@@ -69,7 +75,7 @@ std::string DateTimeComponent::getDisplayString() const
 		return std::string(buf);
 	}
 
-	if(mTime.getTime() == 0)
+	if(mTime.getTime() == Utils::Time::NOT_A_DATE_TIME)
 		return "unknown";
 
 	return Utils::Time::timeToString(mTime.getTime(), mFormat);

--- a/es-core/src/components/DateTimeComponent.h
+++ b/es-core/src/components/DateTimeComponent.h
@@ -25,6 +25,9 @@ public:
 
 	virtual void applyTheme(const std::shared_ptr<ThemeData>& theme, const std::string& view, const std::string& element, unsigned int properties) override;
 
+	static std::string getDateformat() { return "%m/%d/%Y"; }
+	static std::string getDateformatTip() { return "MM/DD/YYYY"; }
+
 protected:
 	void onTextChanged() override;
 

--- a/es-core/src/components/DateTimeEditComponent.cpp
+++ b/es-core/src/components/DateTimeEditComponent.cpp
@@ -1,5 +1,6 @@
 #include "components/DateTimeEditComponent.h"
 
+#include "DateTimeComponent.h"
 #include "resources/Font.h"
 #include "utils/StringUtil.h"
 
@@ -196,17 +197,17 @@ std::string DateTimeEditComponent::getDisplayString(DisplayMode mode) const
 	switch(mode)
 	{
 	case DISP_DATE:
-		fmt = "%m/%d/%Y";
+		fmt = DateTimeComponent::getDateformat();
 		break;
 	case DISP_DATE_TIME:
-		if(mTime.getTime() == 0)
+		if(mTime.getTime() == Utils::Time::NOT_A_DATE_TIME)
 			return "unknown";
-		fmt = "%m/%d/%Y %H:%M:%S";
+		fmt = DateTimeComponent::getDateformat() + " %H:%M:%S";
 		break;
 	case DISP_RELATIVE_TO_NOW:
 		{
 			//relative time
-			if(mTime.getTime() == 0)
+			if(mTime.getTime() == Utils::Time::NOT_A_DATE_TIME)
 				return "never";
 
 			Utils::Time::DateTime now(Utils::Time::now());

--- a/es-core/src/utils/TimeUtil.h
+++ b/es-core/src/utils/TimeUtil.h
@@ -9,7 +9,13 @@ namespace Utils
 {
 	namespace Time
 	{
+		static inline time_t blankDate() {
+			// 1970-01-02
+			tm timeStruct = { 0, 0, 0, 2, 0, 70, 0, 0, -1 };
+			return mktime(&timeStruct);
+		}
 		static int NOT_A_DATE_TIME = 0;
+		static time_t BLANK_DATE = blankDate();
 
 		class DateTime
 		{


### PR DESCRIPTION
1. folder elements are loaded when present in a gamelist and if they match the filesystem representation
2. missing optional folder elements are rendered empty in theme (and not "unknown")
3. As before non-existing folder elements are generated by ES, with mandatory elements `<path/>` and `<name/>`, but with this PR, whenever metadata is edited for this folder object (FileData class) it is persisted
4. Editiing metadata on existing `<folder/>` gets persisted too
5. UI metadata edit: layout fix that renders entered metadata not centered when returning from editing
6. UI metadata edit: format tooltip for date format in release date field