### PR TITLE
Fix logfile closing when logfile is not opened

### DIFF
--- a/es-core/src/Log.cpp
+++ b/es-core/src/Log.cpp
@@ -53,6 +53,7 @@ void Log::flush()
 
 void Log::close()
 {
+	if(file == NULL) return;
 	fclose(file);
 	file = NULL;
 }


### PR DESCRIPTION
When ES is unable to open the logfile (for instance when the filesystem is readonly), it segfaults on closing because ES doesn't check if the file is open.