### PR TITLE
Fix rendering of opaque rating textures

### DIFF
--- a/es-app/src/components/RatingComponent.cpp
+++ b/es-app/src/components/RatingComponent.cpp
@@ -110,11 +110,11 @@ void RatingComponent::render(const Transform4x4f& parentTrans)
 	Transform4x4f trans = parentTrans * getTransform();
 	Renderer::setMatrix(trans);
 
-	mFilledTexture->bind();
-	Renderer::drawTriangleStrips(&mVertices[0], 4);
-
 	mUnfilledTexture->bind();
 	Renderer::drawTriangleStrips(&mVertices[4], 4);
+
+	mFilledTexture->bind();
+	Renderer::drawTriangleStrips(&mVertices[0], 4);
 
 	renderChildren(trans);
 }


### PR DESCRIPTION
Change order so we render the filled texture top of the filled texture. This showed up in themes where the ratings image had been customized.