### PR TITLE
Only recreate GameList View if it can change type

### DIFF
--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -330,6 +330,24 @@ void ViewController::removeGameListView(SystemData* system)
 	}
 }
 
+ViewController::GameListViewType ViewController::getGameListViewType()
+{
+	//decide type
+	GameListViewType selectedViewType = AUTOMATIC;
+
+	std::string viewPreference = Settings::getInstance()->getString("GamelistViewStyle");
+	if (viewPreference.compare("basic") == 0)
+		selectedViewType = BASIC;
+	if (viewPreference.compare("detailed") == 0)
+		selectedViewType = DETAILED;
+	if (viewPreference.compare("grid") == 0)
+		selectedViewType = GRID;
+	if (viewPreference.compare("video") == 0)
+		selectedViewType = VIDEO;
+
+	return selectedViewType;
+}
+
 std::shared_ptr<IGameListView> ViewController::getGameListView(SystemData* system)
 {
 	//if we already made one, return that one
@@ -344,17 +362,7 @@ std::shared_ptr<IGameListView> ViewController::getGameListView(SystemData* syste
 	bool themeHasVideoView = system->getTheme()->hasView("video");
 
 	//decide type
-	GameListViewType selectedViewType = AUTOMATIC;
-
-	std::string viewPreference = Settings::getInstance()->getString("GamelistViewStyle");
-	if (viewPreference.compare("basic") == 0)
-		selectedViewType = BASIC;
-	if (viewPreference.compare("detailed") == 0)
-		selectedViewType = DETAILED;
-	if (viewPreference.compare("grid") == 0)
-		selectedViewType = GRID;
-	if (viewPreference.compare("video") == 0)
-		selectedViewType = VIDEO;
+	GameListViewType selectedViewType = getGameListViewType();
 
 	if (selectedViewType == AUTOMATIC)
 	{

--- a/es-app/src/views/ViewController.h
+++ b/es-app/src/views/ViewController.h
@@ -65,6 +65,8 @@ public:
 		VIDEO
 	};
 
+	ViewController::GameListViewType getGameListViewType();
+
 	struct State
 	{
 		ViewMode viewing;

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -31,8 +31,15 @@ void BasicGameListView::onFileChanged(FileData* file, FileChangeType change)
 {
 	if(change == FILE_METADATA_CHANGED)
 	{
-		// might switch to a detailed view
-		ViewController::get()->reloadGameListView(this);
+		// might switch to a detailed view, 
+		// so, to avoid recreating the view when not needed, we check if we are on auto and 
+		// -- on basic (if we add details, might move to detailed)
+		// -- on detailed (if we add video, might upgrade to video)
+		// which are the only cases when an upgrade would happen, I believe?
+
+		if(ViewController::get()->getGameListViewType() == ViewController::AUTOMATIC && 
+			(this->getName() == "basic" || this->getName() == "detailed"))
+			ViewController::get()->reloadGameListView(this);
 		return;
 	}
 


### PR DESCRIPTION
Add logic to only recreate view if automatic, or in a view type that can be upgraded with metadata details.

I'd love a second opinion on this.