### PR TITLE
Improve random video/image screensaver controls

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -456,8 +456,18 @@ void CollectionSystemManager::exitEditMode()
 	mEditingCollectionSystemData->system->onMetaDataSavePoint();
 }
 
+int CollectionSystemManager::getPressCountInDuration() {
+	Uint32 now = SDL_GetTicks();
+	if (now - mFirstPressMs < DOUBLE_PRESS_DETECTION_DURATION) {
+		return 2;
+	} else {
+		mFirstPressMs = now;
+		return 1;
+	}
+}
+
 // adds or removes a game from a specific collection
-bool CollectionSystemManager::toggleGameInCollection(FileData* file, int presscount)
+bool CollectionSystemManager::toggleGameInCollection(FileData* file)
 {
 	if (file->getType() == GAME)
 	{
@@ -483,7 +493,7 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file, int pressco
 			SystemData* systemViewToUpdate = getSystemToView(sysData);
 
 			if (found) {
-				if (needDoublePress(presscount)) {
+				if (needDoublePress(getPressCountInDuration())) {
 					return true;
 				}
 				adding = false;
@@ -527,7 +537,7 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file, int pressco
 			}
 			else
 			{
-				if (needDoublePress(presscount)) {
+				if (needDoublePress(getPressCountInDuration())) {
 					return true;
 				}
 				adding = false;
@@ -547,6 +557,7 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file, int pressco
 		{
 			s = new GuiInfoPopup(mWindow, "Removed '" + Utils::String::removeParenthesis(name) + "' from '" + Utils::String::toUpper(sysName) + "'", 4000);
 		}
+		
 		mWindow->setInfoPopup(s);
 		return true;
 	}
@@ -1061,7 +1072,7 @@ bool CollectionSystemManager::includeFileInAutoCollections(FileData* file)
 bool CollectionSystemManager::needDoublePress(int presscount) {
 	if (Settings::getInstance()->getBool("DoublePressRemovesFromFavs") && presscount < 2) {
 		GuiInfoPopup* toast = new GuiInfoPopup(mWindow, "Press again to remove from '" + Utils::String::toUpper(mEditingCollection)
-		+ "'", ISimpleGameListView::DOUBLE_PRESS_DETECTION_DURATION, 100, 200);
+		+ "'", DOUBLE_PRESS_DETECTION_DURATION, 100, 200);
 		mWindow->setInfoPopup(toast);
 		return true;
 	}

--- a/es-app/src/CollectionSystemManager.h
+++ b/es-app/src/CollectionSystemManager.h
@@ -3,6 +3,7 @@
 #define ES_APP_COLLECTION_SYSTEM_MANAGER_H
 
 #include <map>
+#include <SDL_timer.h>
 #include <string>
 #include <vector>
 
@@ -71,7 +72,7 @@ public:
 	void exitEditMode();
 	inline bool isEditing() { return mIsEditingCustom; };
 	inline std::string getEditingCollection() { return mEditingCollection; };
-	bool toggleGameInCollection(FileData* file, int presscount);
+	bool toggleGameInCollection(FileData* file);
 
 	SystemData* getSystemToView(SystemData* sys);
 	void updateCollectionFolderMetadata(SystemData* sys);
@@ -88,6 +89,7 @@ private:
 	bool mIsEditingCustom;
 	std::string mEditingCollection;
 	CollectionSystemData* mEditingCollectionSystemData;
+	Uint32 mFirstPressMs = 0;
 
 	void initAutoCollectionSystems();
 	void initCustomCollectionSystems();
@@ -111,8 +113,11 @@ private:
 	bool includeFileInAutoCollections(FileData* file);
 
 	bool needDoublePress(int presscount);
+	int getPressCountInDuration();
 
 	SystemData* mCustomCollectionsBundle;
+
+	static const int DOUBLE_PRESS_DETECTION_DURATION = 1500; // millis
 };
 
 std::string getCustomCollectionConfigPath(std::string collectionName);

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -16,8 +16,8 @@ public:
 	SystemScreenSaver(Window* window);
 	virtual ~SystemScreenSaver();
 
-	virtual void startScreenSaver();
-	virtual void stopScreenSaver();
+	virtual void startScreenSaver(SystemData* system=NULL);
+	virtual void stopScreenSaver(bool toResume=false);
 	virtual void nextMediaItem();
 	virtual void renderScreenSaver();
 	virtual bool allowSleep();
@@ -25,7 +25,7 @@ public:
 	virtual bool isScreenSaverActive();
 
 	virtual FileData* getCurrentGame();
-	virtual void launchGame();
+	virtual void selectGame(bool launch);
 
 private:
 	void pickGameListNode(const char *nodeName, std::string& path);
@@ -36,7 +36,8 @@ private:
 	void setImageScreensaver(std::string& path);
 	bool isFileVideo(std::string& path);
 	std::vector<std::string> getCustomMediaFiles(const std::string &mediaDir);
-	std::vector<FileData*> getAllGamelistNodes();
+	void getAllGamelistNodes();
+	void getAllGamelistNodesForSystem(SystemData* system);
 	void backgroundIndexing();
 	void setBackground();
 	void input(InputConfig* config, Input input);
@@ -52,6 +53,7 @@ private:
 	VideoComponent*		mVideoScreensaver;
 	ImageComponent*		mImageScreensaver;
 	Window*			mWindow;
+	SystemData*		mSystem;
 	STATE			mState;
 	float			mOpacity;
 	int			mTimer;

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -18,7 +18,6 @@ public:
 
 	virtual void startScreenSaver(SystemData* system=NULL);
 	virtual void stopScreenSaver(bool toResume=false);
-	virtual void nextMediaItem();
 	virtual void renderScreenSaver();
 	virtual bool allowSleep();
 	virtual void update(int deltaTime);
@@ -26,11 +25,14 @@ public:
 
 	virtual FileData* getCurrentGame();
 	virtual void selectGame(bool launch);
+	virtual bool inputDuringScreensaver(InputConfig* config, Input input);
 
 private:
-	void pickGameListNode(const char *nodeName, std::string& path);
-	void pickRandomVideo(std::string& path);
-	void pickRandomGameListImage(std::string& path);
+	void changeMediaItem(bool next = true);
+	void pickGameListNode(const char *nodeName);
+	void prepareScreenSaverMedia(const char *nodeName, std::string& path);
+	void pickRandomVideo(std::string& path, bool keepSame = false);
+	void pickRandomGameListImage(std::string& path, bool keepSame = false);
 	void pickRandomCustomMedia(std::string& path);
 	void setVideoScreensaver(std::string& path);
 	void setImageScreensaver(std::string& path);
@@ -58,6 +60,7 @@ private:
 	float			mOpacity;
 	int			mTimer;
 	FileData*		mCurrentGame;
+	FileData*		mPreviousGame;
 	int			mSwapTimeout;
 	std::shared_ptr<Sound>	mBackgroundAudio;
 	bool			mStopBackgroundAudio;

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -23,7 +23,6 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 	ComponentListRow row;
 
 	// add launch system screensaver 
-
 	std::string screensaver_behavior = Settings::getInstance()->getString("ScreenSaverBehavior");
 
 	if (screensaver_behavior == "random video" || (screensaver_behavior == "slideshow" && !Settings::getInstance()->getBool("SlideshowScreenSaverCustomMediaSource"))) {

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -22,6 +22,17 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 	mFromPlaceholder = file->isPlaceHolder();
 	ComponentListRow row;
 
+	// add launch system screensaver 
+
+	std::string screensaver_behavior = Settings::getInstance()->getString("ScreenSaverBehavior");
+
+	if (screensaver_behavior == "random video" || (screensaver_behavior == "slideshow" && !Settings::getInstance()->getBool("SlideshowScreenSaverCustomMediaSource"))) {
+		row.elements.clear();
+		row.addElement(std::make_shared<TextComponent>(mWindow, "LAUNCH SYSTEM SCREENSAVER", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+		row.makeAcceptInputHandler(std::bind(&GuiGamelistOptions::launchSystemScreenSaver, this));
+		mMenu.addRow(row);
+	}
+
 	if (!mFromPlaceholder) {
 		row.elements.clear();
 
@@ -156,6 +167,27 @@ GuiGamelistOptions::~GuiGamelistOptions()
 			getGamelist()->onFileChanged(root, FILE_SORTED);
 		}
 	}
+}
+
+bool GuiGamelistOptions::launchSystemScreenSaver()
+{
+	SystemData* system = mSystem;
+	std::string editingSystem = system->getName();
+	// need to check if we're in a folder inside the collections bundle, to launch from there
+	if(editingSystem == CollectionSystemManager::get()->getCustomCollectionsBundle()->getName())
+	{
+		FileData* file = getGamelist()->getCursor();
+		// do we have the cursor on a specific collection?
+		if (file->getType() == GAME)
+		{
+			// we are inside a specific collection. We want to launch for that one.
+			system = file->getSystem();
+		}
+	}
+	mWindow->startScreenSaver(system);
+
+	delete this;
+	return true;	
 }
 
 void GuiGamelistOptions::openGamelistFilter()

--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -22,6 +22,7 @@ public:
 
 private:
 	void openGamelistFilter();
+	bool launchSystemScreenSaver();
 	void openMetaDataEd();
 	void startEditMode();
 	void exitEditMode();

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -7,7 +7,6 @@
 #include "Settings.h"
 #include "Sound.h"
 #include "SystemData.h"
-#include <SDL_timer.h>
 
 ISimpleGameListView::ISimpleGameListView(Window* window, FileData* root) : IGameListView(window, root),
 	mHeaderText(window), mHeaderImage(window), mBackground(window)
@@ -152,8 +151,7 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 		{
 			if(mRoot->getSystem()->isGameSystem())
 			{
-				int presscount = getPressCountInDuration();
-				if (CollectionSystemManager::get()->toggleGameInCollection(getCursor(), presscount))
+				if (CollectionSystemManager::get()->toggleGameInCollection(getCursor()))
 				{
 					return true;
 				}
@@ -171,15 +169,4 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 	    Scripting::fireEvent("game-select", "NULL", "NULL", "NULL", "input");
 	}
 	return IGameListView::input(config, input);
-}
-
-
-int ISimpleGameListView::getPressCountInDuration() {
-	Uint32 now = SDL_GetTicks();
-	if (now - firstPressMs < DOUBLE_PRESS_DETECTION_DURATION) {
-		return 2;
-	} else {
-		firstPressMs = now;
-		return 1;
-	}
 }

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -30,8 +30,6 @@ public:
 	virtual bool input(InputConfig* config, Input input) override;
 	virtual void launch(FileData* game) override = 0;
 
-	static const int DOUBLE_PRESS_DETECTION_DURATION = 1500; // millis
-
 protected:
 	static const int DESCRIPTION_SCROLL_DELAY = 5 * 1000; // five secs
 
@@ -49,7 +47,6 @@ protected:
 
 private:
 	int getPressCountInDuration();
-	Uint32 firstPressMs = 0;
 };
 
 #endif // ES_APP_VIEWS_GAME_LIST_ISIMPLE_GAME_LIST_VIEW_H

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -117,8 +117,9 @@ void Window::textInput(const char* text)
 void Window::input(InputConfig* config, Input input)
 {
 	if (mScreenSaver && mScreenSaver->isScreenSaverActive() && Settings::getInstance()->getBool("ScreenSaverControls")
-		&& inputDuringScreensaver(config, input))
+		&& mScreenSaver->inputDuringScreensaver(config, input))
 	{
+		mTimeSinceLastInput = 0;
 		return;
 	}
 
@@ -154,40 +155,6 @@ void Window::input(InputConfig* config, Input input)
 	{
 		this->peekGui()->input(config, input); // this is where the majority of inputs will be consumed: the GuiComponent Stack
 	}
-}
-
-bool Window::inputDuringScreensaver(InputConfig* config, Input input)
-{
-	bool input_consumed = false;
-	std::string screensaver_type = Settings::getInstance()->getString("ScreenSaverBehavior");
-
-	if (!mSleeping && (screensaver_type == "random video" || screensaver_type == "slideshow"))
-	{
-		bool is_next_input = config->isMappedLike("right", input) || config->isMappedTo("select", input);
-		bool is_start_input = config->isMappedTo("start", input);
-		bool is_select_game_input =  config->isMappedTo("a", input);
-		bool slideshow_custom_media = Settings::getInstance()->getBool("SlideshowScreenSaverCustomMediaSource");
-
-		if (is_next_input)
-		{
-			if (input.value != 0) {
-				mScreenSaver->nextMediaItem();
-				// user input resets sleep time counter
-				mTimeSinceLastInput = 0;
-			}
-			// avoid to disable screensaver
-			input_consumed = true;
-		}
-		else if ((is_start_input || is_select_game_input) && !slideshow_custom_media && input.value != 0)
-		{
-			mScreenSaver->selectGame(is_start_input);
-		}
-		else if (config->getMappedTo(input).size() == 0) {
-			// catch invalid inputs here to prevent screensaver from stopping
-			input_consumed = true;
-		}
-	}
-	return input_consumed;
 }
 
 void Window::update(int deltaTime)
@@ -274,7 +241,7 @@ void Window::render()
 	// or not because it may perform a fade on transition
 	renderScreenSaver();
 
-	if(!mRenderScreenSaver && mInfoPopup)
+	if(mInfoPopup)
 	{
 		mInfoPopup->render(transform);
 	}

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -26,13 +26,13 @@ public:
 	public:
 		virtual void startScreenSaver(SystemData* system=NULL) = 0;
 		virtual void stopScreenSaver(bool toResume=false) = 0;
-		virtual void nextMediaItem() = 0;
 		virtual void renderScreenSaver() = 0;
 		virtual bool allowSleep() = 0;
 		virtual void update(int deltaTime) = 0;
 		virtual bool isScreenSaverActive() = 0;
 		virtual FileData* getCurrentGame() = 0;
 		virtual void selectGame(bool launch) = 0;
+		virtual bool inputDuringScreensaver(InputConfig* config, Input input) = 0;
 	};
 
 	class InfoPopup {
@@ -80,7 +80,6 @@ public:
 private:
 	void onSleep();
 	void onWake();
-	bool inputDuringScreensaver(InputConfig* config, Input input);
 
 	// Returns true if at least one component on the stack is processing
 	bool isProcessing();

--- a/es-core/src/Window.h
+++ b/es-core/src/Window.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+class SystemData;
 class FileData;
 class Font;
 class GuiComponent;
@@ -23,15 +24,15 @@ class Window
 public:
 	class ScreenSaver {
 	public:
-		virtual void startScreenSaver() = 0;
-		virtual void stopScreenSaver() = 0;
+		virtual void startScreenSaver(SystemData* system=NULL) = 0;
+		virtual void stopScreenSaver(bool toResume=false) = 0;
 		virtual void nextMediaItem() = 0;
 		virtual void renderScreenSaver() = 0;
 		virtual bool allowSleep() = 0;
 		virtual void update(int deltaTime) = 0;
 		virtual bool isScreenSaverActive() = 0;
 		virtual FileData* getCurrentGame() = 0;
-		virtual void launchGame() = 0;
+		virtual void selectGame(bool launch) = 0;
 	};
 
 	class InfoPopup {
@@ -72,7 +73,7 @@ public:
 	void setInfoPopup(InfoPopup* infoPopup) { delete mInfoPopup; mInfoPopup = infoPopup; }
 	inline void stopInfoPopup() { if (mInfoPopup) mInfoPopup->stop(); };
 
-	void startScreenSaver();
+	void startScreenSaver(SystemData* system=NULL);
 	bool cancelScreenSaver();
 	void renderScreenSaver();
 


### PR DESCRIPTION
Added functionality:
- Launch random screensaver from within a system, limiting the media to that system
- Add "back" and "favourites" control to screensaver, to play the previous video, and/or to add video to favourites (or currently selected collection, as if one had pressed the favourites button in the gamelist).

Changes:
- Refactored some code, namely moving the input handling code for the screensaver from the Window class to the actual SystemScreenSaver class, and auxiliary code that was there as well;
- Adjusted code for the random screensaver not to pick a new random game (for the case when you're going back, you want to feed it a game to load);
- Added option to Select menu to launch screensaver, when applicable.