### PR TITLE
Add option to specify collection to store favorites from screensaver

### DIFF
--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -424,7 +424,7 @@ std::string CollectionSystemManager::getValidNewCollectionName(std::string inNam
 	return name;
 }
 
-void CollectionSystemManager::setEditMode(std::string collectionName)
+void CollectionSystemManager::setEditMode(std::string collectionName, bool quiet)
 {
 	if (mCustomCollectionSystemsData.find(collectionName) == mCustomCollectionSystemsData.cend())
 	{
@@ -442,18 +442,24 @@ void CollectionSystemManager::setEditMode(std::string collectionName)
 	// if it's bundled, this needs to be the bundle system
 	mEditingCollectionSystemData = sysData;
 
-	GuiInfoPopup* s = new GuiInfoPopup(mWindow, "Editing the '" + Utils::String::toUpper(collectionName) + "' Collection. Add/remove games with Y.", 10000);
-	mWindow->setInfoPopup(s);
+	if (!quiet) {
+		GuiInfoPopup* s = new GuiInfoPopup(mWindow, "Editing the '" + Utils::String::toUpper(collectionName) + "' Collection. Add/remove games with Y.", 10000);
+		mWindow->setInfoPopup(s);
+	}
 }
 
-void CollectionSystemManager::exitEditMode()
+void CollectionSystemManager::exitEditMode(bool quiet)
 {
-	GuiInfoPopup* s = new GuiInfoPopup(mWindow, "Finished editing the '" + mEditingCollection + "' Collection.", 4000);
-	mWindow->setInfoPopup(s);
-	mIsEditingCustom = false;
-	mEditingCollection = "Favorites";
+	if (!quiet) {
+		GuiInfoPopup* s = new GuiInfoPopup(mWindow, "Finished editing the '" + mEditingCollection + "' Collection.", 4000);
+		mWindow->setInfoPopup(s);
+	}
+	if (mIsEditingCustom) {
+		mIsEditingCustom = false;
+		mEditingCollection = "Favorites";
 
-	mEditingCollectionSystemData->system->onMetaDataSavePoint();
+		mEditingCollectionSystemData->system->onMetaDataSavePoint();
+	}
 }
 
 int CollectionSystemManager::getPressCountInDuration() {

--- a/es-app/src/CollectionSystemManager.h
+++ b/es-app/src/CollectionSystemManager.h
@@ -68,8 +68,8 @@ public:
 	bool isThemeCustomCollectionCompatible(std::vector<std::string> stringVector);
 	std::string getValidNewCollectionName(std::string name, int index = 0);
 
-	void setEditMode(std::string collectionName);
-	void exitEditMode();
+	void setEditMode(std::string collectionName, bool quiet = false);
+	void exitEditMode(bool quiet = false);
 	inline bool isEditing() { return mIsEditingCustom; };
 	inline std::string getEditingCollection() { return mEditingCollection; };
 	bool toggleGameInCollection(FileData* file);

--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -147,6 +147,7 @@ void SystemScreenSaver::setVideoScreensaver(std::string& path)
 	mVideoScreensaver->setScreensaverMode(true);
 	mVideoScreensaver->onShow();
 
+	setupScreenSaverEditingCollection();
 	PowerSaver::runningScreenSaver(true);
 	mTimer = 0;
 }
@@ -171,6 +172,7 @@ void SystemScreenSaver::setImageScreensaver(std::string& path)
 			mImageScreensaver->setMaxSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
 		}
 
+		setupScreenSaverEditingCollection();
 		PowerSaver::runningScreenSaver(true);
 		mTimer = 0;
 }
@@ -183,6 +185,31 @@ bool SystemScreenSaver::isFileVideo(std::string& path)
 	std::string pathFilter = Settings::getInstance()->getString("SlideshowScreenSaverVideoFilter");
 	std::string pathExtension = path.substr(path.find_last_of("."));
 	return pathFilter.find(pathExtension) != std::string::npos;
+}
+
+void SystemScreenSaver::setupScreenSaverEditingCollection()
+{
+	std::string screensaverCollection = Settings::getInstance()->getString("DefaultScreenSaverCollection");
+	std::string currentEditingCollection = CollectionSystemManager::get()->getEditingCollection();
+
+	// check if we need to change the screensaver collection
+	if (screensaverCollection != "") {
+		// check if we're starting the screensaver
+		if (isScreenSaverActive())
+		{		
+			// we're entering the screensaver, backup the currently actively editing collection
+			mRegularEditingCollection = CollectionSystemManager::get()->getEditingCollection();
+			CollectionSystemManager::get()->setEditMode(screensaverCollection, true);
+		}
+		else
+		{
+			// we're exiting the screensaver, restore the currently actively editing collection
+			CollectionSystemManager::get()->exitEditMode(true);
+			if (mRegularEditingCollection != "Favorites")
+				CollectionSystemManager::get()->setEditMode(mRegularEditingCollection, true);
+			mRegularEditingCollection = "";
+		}
+	}
 }
 
 void SystemScreenSaver::startScreenSaver(SystemData* system)
@@ -312,6 +339,7 @@ void SystemScreenSaver::stopScreenSaver(bool toResume)
 
 	// we need this to loop through different videos
 	mState = STATE_INACTIVE;
+	setupScreenSaverEditingCollection();
 	PowerSaver::runningScreenSaver(false);
 }
 

--- a/es-app/src/SystemScreenSaver.h
+++ b/es-app/src/SystemScreenSaver.h
@@ -42,6 +42,7 @@ private:
 	void getAllGamelistNodesForSystem(SystemData* system);
 	void backgroundIndexing();
 	void setBackground();
+	void setupScreenSaverEditingCollection();
 	void input(InputConfig* config, Input input);
 
 	enum STATE {
@@ -69,6 +70,7 @@ private:
 	int			mAllFilesSize;
 	std::thread*		mThread;
 	bool			mExit;
+	std::string 		mRegularEditingCollection;
 };
 
 #endif // ES_APP_SYSTEM_SCREEN_SAVER_H

--- a/es-app/src/guis/GuiCollectionSystemsOptions.h
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.h
@@ -28,6 +28,7 @@ private:
 	void exitEditMode();
 	std::shared_ptr< OptionListComponent<std::string> > autoOptionList;
 	std::shared_ptr< OptionListComponent<std::string> > customOptionList;
+	std::shared_ptr< OptionListComponent<std::string> > defaultScreenSaverCollection;
 	std::shared_ptr<SwitchComponent> sortAllSystemsSwitch;
 	std::shared_ptr<SwitchComponent> bundleCustomCollections;
 	std::shared_ptr<SwitchComponent> toggleSystemNameInCollections;

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -141,6 +141,7 @@ void Settings::setDefaults()
 	mStringMap["OMXAudioDev"] = "both";
 	mStringMap["CollectionSystemsAuto"] = "";
 	mStringMap["CollectionSystemsCustom"] = "";
+	mStringMap["DefaultScreenSaverCollection"] = "";
 	mBoolMap["CollectionShowSystemInfo"] = true;
 	mBoolMap["SortAllSystems"] = false;
 	mBoolMap["UseCustomCollectionsSystem"] = true;


### PR DESCRIPTION
- Add option in Game Collections menu to specify default collection to store games during screensaver
- Minor refactorings of the menu code
- Strengthening collections and menu code against edge cases from manual intervention in config files leading to crashes due to invalid values in these settings