### PR TITLE
Fix VLC not unmuting itself after initialization

### DIFF
--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -345,7 +345,7 @@ void VideoVlcComponent::setMuteMode()
 {
 	Settings *cfg = Settings::getInstance();
 	if (!cfg->getBool("VideoAudio") || (cfg->getBool("ScreenSaverVideoMute") && mScreensaverMode))
-	{
 		libvlc_audio_set_mute(mMediaPlayer, 1);
-	}
+	else
+		libvlc_audio_set_mute(mMediaPlayer, 0);
 }


### PR DESCRIPTION
The VLC video player would not update its audio state after initialization, so if the user would change the audio preferences in settings this would fail.