### PR TITLE
Small corrections to WIN32 build documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,18 +129,18 @@ c:\src>.\vcpkg\vcpkg install rapidjson:x86-windows-static-md
 * Using the example shown below, configure environment variables to point to the libraries that were installed in the above steps. Please note that the below example intentionally uses forward slashes for compatibility with CMake.
 
 ```batchfile
-C:\src\EmulationStation>set VCPKG="C:/src/vcpkg/installed/x86-windows-static-md"
-C:\src\EmulationStation>set NUGET="C:/src/EmulationStation/nuget"
-C:\src\EmulationStation>set FREETYPE_DIR="%VCPKG%"
-C:\src\EmulationStation>set FREEIMAGE_HOME="%VCPKG%"
-C:\src\EmulationStation>set VLC_HOME="%NUGET%/VideoLAN.LibVLC.Windows/build/x86"
-C:\src\EmulationStation>set RAPIDJSON_INCLUDE_DIRS="%VCPKG%/include"
-C:\src\EmulationStation>set CURL_INCLUDE_DIR="%VCPKG%/include"
-C:\src\EmulationStation>set SDL2_INCLUDE_DIR="%VCPKG%/include/SDL2"
-C:\src\EmulationStation>set VLC_INCLUDE_DIR="%VLC_HOME%/include"
-C:\src\EmulationStation>set CURL_LIBRARY="%VCPKG%/lib/*.lib"
-C:\src\EmulationStation>set SDL2_LIBRARY="%VCPKG%/lib/manual-link/SDL2main.lib"
-C:\src\EmulationStation>set VLC_LIBRARIES="%VLC_HOME%/libvlc*.lib"
+C:\src\EmulationStation>set VCPKG=C:/src/vcpkg/installed/x86-windows-static-md
+C:\src\EmulationStation>set NUGET=C:/src/EmulationStation/nuget
+C:\src\EmulationStation>set FREETYPE_DIR=%VCPKG%
+C:\src\EmulationStation>set FREEIMAGE_HOME=%VCPKG%
+C:\src\EmulationStation>set VLC_HOME=%NUGET%/VideoLAN.LibVLC.Windows/build/x86
+C:\src\EmulationStation>set RAPIDJSON_INCLUDE_DIRS=%VCPKG%/include
+C:\src\EmulationStation>set CURL_INCLUDE_DIR=%VCPKG%/include
+C:\src\EmulationStation>set SDL2_INCLUDE_DIR=%VCPKG%/include/SDL2
+C:\src\EmulationStation>set VLC_INCLUDE_DIR=%VLC_HOME%/include
+C:\src\EmulationStation>set CURL_LIBRARY=%VCPKG%/lib/*.lib
+C:\src\EmulationStation>set SDL2_LIBRARY=%VCPKG%/lib/manual-link/SDL2main.lib
+C:\src\EmulationStation>set VLC_LIBRARIES=%VLC_HOME%/libvlc*.lib
 C:\src\EmulationStation>set VLC_VERSION=3.0.11
 ```
 


### PR DESCRIPTION
Correcting my previous updates to "README.md" on building for WIN32. More specifically, removing the double quotes when setting the environment variables for CMAKE. The double quotes can break the ability for CMAKE to find the required packages. This change also matches the corresponding GitHub Action ([win32.yml](https://github.com/RetroPie/EmulationStation/blob/master/.github/workflows/win32.yml)) which correctly does not include the double quotes.