### PR TITLE
Add support for a Random collection

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -35,6 +35,7 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiScraperStart.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiGamelistFilter.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiCollectionSystemsOptions.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRandomCollectionOptions.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiInfoPopup.h
 
     # Scrapers
@@ -93,6 +94,7 @@ set(ES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiScraperStart.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiGamelistFilter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiCollectionSystemsOptions.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRandomCollectionOptions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiInfoPopup.cpp
 
     # Scrapers

--- a/es-app/src/CollectionSystemManager.h
+++ b/es-app/src/CollectionSystemManager.h
@@ -11,12 +11,18 @@ class FileData;
 class SystemData;
 class Window;
 struct SystemEnvironmentData;
+class FileFilterIndex;
+
+#define RANDOM_SYSTEM_MAX 5
+#define DEFAULT_RANDOM_SYSTEM_GAMES 1
+#define DEFAULT_RANDOM_COLLECTIONS_GAMES 0
 
 enum CollectionSystemType
 {
 	AUTO_ALL_GAMES,
 	AUTO_LAST_PLAYED,
 	AUTO_FAVORITES,
+	AUTO_RANDOM,
 	CUSTOM_COLLECTION
 };
 
@@ -39,6 +45,8 @@ struct CollectionSystemData
 	bool needsSave;
 };
 
+std::map<std::string, int> stringToRandomSettingsMap(std::string sourceStr);
+
 class CollectionSystemManager
 {
 public:
@@ -57,10 +65,12 @@ public:
 	void refreshCollectionSystems(FileData* file);
 	void updateCollectionSystem(FileData* file, CollectionSystemData sysData);
 	void deleteCollectionFiles(FileData* file);
+	void recreateCollection(SystemData* sysData);
 
 	inline std::map<std::string, CollectionSystemData> getAutoCollectionSystems() { return mAutoCollectionSystemsData; };
 	inline std::map<std::string, CollectionSystemData> getCustomCollectionSystems() { return mCustomCollectionSystemsData; };
 	inline SystemData* getCustomCollectionsBundle() { return mCustomCollectionsBundle; };
+	inline SystemData* getRandomCollection() { return mRandomCollection; };
 	std::vector<std::string> getUnusedSystemsFromTheme();
 	SystemData* addNewCustomCollection(std::string name);
 
@@ -79,6 +89,8 @@ public:
 
 	SystemData* getAllGamesCollection();
 
+	void trimCollectionCount(FileData* rootFolder, int limit, bool shuffle);
+
 private:
 	static CollectionSystemManager* sInstance;
 	SystemEnvironmentData* mCollectionEnvData;
@@ -96,17 +108,18 @@ private:
 	SystemData* createNewCollectionEntry(std::string name, CollectionSystemDecl sysDecl, bool index = true);
 	void populateAutoCollection(CollectionSystemData* sysData);
 	void populateCustomCollection(CollectionSystemData* sysData);
+	void addRandomGames(SystemData* newSys, SystemData* sourceSystem, FileData* rootFolder, FileFilterIndex* index,
+		std::map<std::string, int> settingsValues, int defaultValue);
+	void populateRandomCollectionFromCollections(std::map<std::string, int> settingsValues);
 
 	void removeCollectionsFromDisplayedSystems();
-	void addEnabledCollectionsToDisplayedSystems(std::map<std::string, CollectionSystemData>* colSystemData);
+	void addEnabledCollectionsToDisplayedSystems(std::map<std::string, CollectionSystemData>* colSystemData, bool processRandom);
 
 	std::vector<std::string> getSystemsFromConfig();
 	std::vector<std::string> getSystemsFromTheme();
 	std::vector<std::string> getCollectionsFromConfigFolder();
 	std::vector<std::string> getCollectionThemeFolders(bool custom);
 	std::vector<std::string> getUserCollectionThemeFolders();
-
-	void trimCollectionCount(FileData* rootFolder, int limit);
 
 	bool themeFolderExists(std::string folder);
 
@@ -116,6 +129,7 @@ private:
 	int getPressCountInDuration();
 
 	SystemData* mCustomCollectionsBundle;
+	SystemData* mRandomCollection;
 
 	static const int DOUBLE_PRESS_DETECTION_DURATION = 1500; // millis
 };

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -2,6 +2,7 @@
 
 #include "components/OptionListComponent.h"
 #include "components/SwitchComponent.h"
+#include "guis/GuiRandomCollectionOptions.h"
 #include "guis/GuiSettings.h"
 #include "guis/GuiTextEditPopup.h"
 #include "utils/StringUtil.h"
@@ -19,11 +20,12 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	addChild(&mMenu);
 
 	// get collections
-
 	addSystemsToMenu();
 
-	// add "Create New Custom Collection from Theme"
+	// manage random collection
+	addEntry("RANDOM COLLECTION SETTINGS", 0x777777FF, true, [this] { openRandomCollectionSettings(); });
 
+	// add "Create New Custom Collection from Theme"
 	std::vector<std::string> unusedFolders = CollectionSystemManager::get()->getUnusedSystemsFromTheme();
 	if (unusedFolders.size() > 0)
 	{
@@ -133,7 +135,8 @@ void GuiCollectionSystemsOptions::addEntry(const char* name, unsigned int color,
 	mMenu.addRow(row);
 }
 
-void GuiCollectionSystemsOptions::createCollection(std::string inName) {
+void GuiCollectionSystemsOptions::createCollection(std::string inName) 
+{
 	std::string name = CollectionSystemManager::get()->getValidNewCollectionName(inName);
 	SystemData* newSys = CollectionSystemManager::get()->addNewCustomCollection(name);
 	customOptionList->add(name, name, true);
@@ -147,6 +150,11 @@ void GuiCollectionSystemsOptions::createCollection(std::string inName) {
 	while(window->peekGui() && window->peekGui() != ViewController::get())
 		delete window->peekGui();
 	return;
+}
+
+void GuiCollectionSystemsOptions::openRandomCollectionSettings() 
+{
+	mWindow->pushGui(new GuiRandomCollectionOptions(mWindow));
 }
 
 void GuiCollectionSystemsOptions::exitEditMode()

--- a/es-app/src/guis/GuiCollectionSystemsOptions.h
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.h
@@ -26,6 +26,7 @@ private:
 	void updateSettings(std::string newAutoSettings, std::string newCustomSettings);
 	void createCollection(std::string inName);
 	void exitEditMode();
+	void openRandomCollectionSettings();
 	std::shared_ptr< OptionListComponent<std::string> > autoOptionList;
 	std::shared_ptr< OptionListComponent<std::string> > customOptionList;
 	std::shared_ptr< OptionListComponent<std::string> > defaultScreenSaverCollection;

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -132,6 +132,14 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 		mMenu.addRow(row);
 	}
 
+	if(UIModeController::getInstance()->isUIModeFull() && system == CollectionSystemManager::get()->getRandomCollection())
+	{
+		row.elements.clear();
+		row.addElement(std::make_shared<TextComponent>(mWindow, "GET NEW RANDOM GAMES", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+		row.makeAcceptInputHandler(std::bind(&GuiGamelistOptions::recreateCollection, this));
+		mMenu.addRow(row);
+	}
+
 	if (UIModeController::getInstance()->isUIModeFull() && !mFromPlaceholder && !(mSystem->isCollection() && file->getType() == FOLDER))
 	{
 		row.elements.clear();
@@ -195,6 +203,12 @@ void GuiGamelistOptions::openGamelistFilter()
 	mFiltersChanged = true;
 	GuiGamelistFilter* ggf = new GuiGamelistFilter(mWindow, mSystem);
 	mWindow->pushGui(ggf);
+}
+
+void GuiGamelistOptions::recreateCollection()
+{
+	CollectionSystemManager::get()->recreateCollection(mSystem);
+	delete this;
 }
 
 void GuiGamelistOptions::startEditMode()

--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -25,6 +25,7 @@ private:
 	bool launchSystemScreenSaver();
 	void openMetaDataEd();
 	void startEditMode();
+	void recreateCollection();
 	void exitEditMode();
 	void jumpToLetter();
 

--- a/es-app/src/guis/GuiRandomCollectionOptions.cpp
+++ b/es-app/src/guis/GuiRandomCollectionOptions.cpp
@@ -1,0 +1,210 @@
+#include "guis/GuiRandomCollectionOptions.h"
+
+#include "components/OptionListComponent.h"
+#include "components/SwitchComponent.h"
+#include "guis/GuiSettings.h"
+#include "guis/GuiTextEditPopup.h"
+#include "utils/StringUtil.h"
+#include "views/ViewController.h"
+#include "CollectionSystemManager.h"
+#include "SystemData.h"
+#include "Window.h"
+
+GuiRandomCollectionOptions::GuiRandomCollectionOptions(Window* window) : GuiComponent(window), mMenu(window, "RANDOM GAME COLLECTION SETTINGS")
+{
+	customCollectionLists.clear();
+	autoCollectionLists.clear();
+	systemLists.clear();
+	mNeedsCollectionRefresh = false;
+	
+	initializeMenu();
+}
+
+void GuiRandomCollectionOptions::initializeMenu()
+{
+	// get collections
+	addEntry("SYSTEMS", 0x777777FF, true, [this] { selectSystems(); });
+	addEntry("AUTOMATIC COLLECTIONS", 0x777777FF, true, [this] { selectAutoCollections(); });
+	addEntry("CUSTOM COLLECTIONS", 0x777777FF, true, [this] { selectCustomCollections(); });
+	
+	// Add option to trim random collection items
+	trimRandom = std::make_shared< OptionListComponent<std::string> >(mWindow, "MAX ITEMS", false);
+	
+	// Add default entry
+	trimRandom->add("ALL", "", Settings::getInstance()->getString("RandomCollectionMaxItems") == "");
+	
+	// add all enabled Custom Systems
+	for(int i = 5; i <= 50; i = i+5)
+	{
+		trimRandom->add(std::to_string(i), std::to_string(i), Settings::getInstance()->getString("RandomCollectionMaxItems") == std::to_string(i));
+	}
+
+	mMenu.addWithLabel("MAX ITEMS", trimRandom);
+
+	addChild(&mMenu);
+
+	mMenu.addButton("OK", "ok", std::bind(&GuiRandomCollectionOptions::saveSettings, this));
+	mMenu.addButton("CANCEL", "cancel", [&] { delete this; });
+
+	mMenu.setPosition((Renderer::getScreenWidth() - mMenu.getSize().x()) / 2, Renderer::getScreenHeight() * 0.15f);
+}
+
+void GuiRandomCollectionOptions::addEntry(const char* name, unsigned int color, bool add_arrow, const std::function<void()>& func)
+{
+	std::shared_ptr<Font> font = Font::get(FONT_SIZE_MEDIUM);
+
+	// populate the list
+	ComponentListRow row;
+	row.addElement(std::make_shared<TextComponent>(mWindow, name, font, color), true);
+
+	if(add_arrow)
+	{
+		std::shared_ptr<ImageComponent> bracket = makeArrow(mWindow);
+		row.addElement(bracket, false);
+	}
+
+	row.makeAcceptInputHandler(func);
+
+	mMenu.addRow(row);
+}
+
+void GuiRandomCollectionOptions::selectSystems()
+{
+	std::map<std::string, CollectionSystemData> systems;
+	for(auto sysIt = SystemData::sSystemVector.cbegin(); sysIt != SystemData::sSystemVector.cend(); sysIt++)
+	{
+		// we won't iterate all collections
+		if ((*sysIt)->isGameSystem() && !(*sysIt)->isCollection()) 
+		{
+			CollectionSystemDecl sysDecl;
+			sysDecl.name = (*sysIt)->getName();
+			sysDecl.longName = (*sysIt)->getFullName();
+
+			CollectionSystemData newCollectionData;
+			newCollectionData.system = (*sysIt);
+			newCollectionData.decl = sysDecl;
+			newCollectionData.isEnabled = true;
+			
+			systems[sysDecl.name] = newCollectionData;
+		}
+	}
+	selectEntries(systems, "RandomCollectionSystems", DEFAULT_RANDOM_SYSTEM_GAMES, &systemLists);
+}
+
+void GuiRandomCollectionOptions::selectAutoCollections()
+{
+	selectEntries(CollectionSystemManager::get()->getAutoCollectionSystems(), "RandomCollectionSystemsAuto", DEFAULT_RANDOM_COLLECTIONS_GAMES, &autoCollectionLists);
+}
+
+void GuiRandomCollectionOptions::selectCustomCollections()
+{
+	selectEntries(CollectionSystemManager::get()->getCustomCollectionSystems(), "RandomCollectionSystemsCustom", DEFAULT_RANDOM_COLLECTIONS_GAMES, &customCollectionLists);
+}
+
+GuiRandomCollectionOptions::~GuiRandomCollectionOptions()
+{
+
+}
+
+std::string GuiRandomCollectionOptions::collectionListsToString(std::vector< SystemGames> collectionLists) {
+	std::string result;
+	for (std::vector< SystemGames>::const_iterator it = collectionLists.cbegin(); it != collectionLists.cend(); it++)
+	{
+		if (it != collectionLists.cbegin())
+			result += ",";
+
+		result += (*it).name + ":" + std::to_string((*it).gamesSelection->getSelected());
+	}
+	return result;
+}
+
+void GuiRandomCollectionOptions::selectEntries(std::map<std::string, CollectionSystemData> collection, std::string settingsLabel, int defaultValue, std::vector< SystemGames>* results) {
+	auto s = new GuiSettings(mWindow, "GAMES FROM SYSTEMS");
+	
+	std::map<std::string, int> settingsValues = stringToRandomSettingsMap(Settings::getInstance()->getString(settingsLabel));
+
+	results->clear();
+
+	// add Auto Systems
+	for(std::map<std::string, CollectionSystemData>::const_iterator it = collection.cbegin() ; it != collection.cend() ; it++ )
+	{
+		if (it->second.system != CollectionSystemManager::get()->getRandomCollection())
+		{
+			ComponentListRow row;
+
+			std::string label = it->second.decl.longName;
+			int selectedValue = defaultValue; 
+
+			if (settingsValues.find(label) != settingsValues.end()) 
+				selectedValue = Math::min(RANDOM_SYSTEM_MAX, settingsValues[label]);
+
+			std::shared_ptr<NumberList> colItems = std::make_shared<NumberList>(mWindow, label, false);
+			for (int i = 0; i <= RANDOM_SYSTEM_MAX; i++)
+			{
+				colItems->add(std::to_string(i), i, i == selectedValue);
+			}
+			row.addElement(std::make_shared<TextComponent>(mWindow, Utils::String::toUpper(label), Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+			row.addElement(colItems, false);
+
+			s->addRow(row);
+			SystemGames sys;
+			sys.name = label;
+			sys.gamesSelection = colItems;
+			results->push_back(sys);
+		}
+
+	}
+	
+	setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
+	s->setPosition((mSize.x() - s->getSize().x()) / 2, (mSize.y() - s->getSize().y()) / 2);
+	s->addSaveFunc([this, settingsLabel, results] { applyGroupSettings(settingsLabel, results); });
+	mWindow->pushGui(s);
+}
+
+void GuiRandomCollectionOptions::applyGroupSettings(std::string settingsLabel, std::vector< SystemGames>* results)
+{
+	std::string curOptions = GuiRandomCollectionOptions::collectionListsToString((*results));
+	std::string prevOptions = Settings::getInstance()->getString(settingsLabel);
+	
+	if (!curOptions.empty() && curOptions != prevOptions) 
+	{
+		Settings::getInstance()->setString(settingsLabel, curOptions);
+		mNeedsCollectionRefresh = true;
+	}
+}
+
+void GuiRandomCollectionOptions::saveSettings()
+{
+	std::string curTrim = trimRandom->getSelected();
+	std::string prevTrim = Settings::getInstance()->getString("RandomCollectionMaxItems");
+	Settings::getInstance()->setString("RandomCollectionMaxItems", curTrim);
+
+	mNeedsCollectionRefresh |= (curTrim != prevTrim);
+
+	if (mNeedsCollectionRefresh) 
+	{
+		Settings::getInstance()->saveFile();
+		CollectionSystemManager::get()->recreateCollection(CollectionSystemManager::get()->getRandomCollection());
+	}
+
+	delete this;
+}
+
+bool GuiRandomCollectionOptions::input(InputConfig* config, Input input)
+{
+	bool consumed = GuiComponent::input(config, input);
+	if(consumed)
+		return true;
+
+	if(config->isMappedTo("b", input) && input.value != 0)
+		saveSettings();
+
+	return false;
+}
+
+std::vector<HelpPrompt> GuiRandomCollectionOptions::getHelpPrompts()
+{
+	std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
+	prompts.push_back(HelpPrompt("b", "back"));
+	return prompts;
+}

--- a/es-app/src/guis/GuiRandomCollectionOptions.h
+++ b/es-app/src/guis/GuiRandomCollectionOptions.h
@@ -1,0 +1,54 @@
+#pragma once
+#ifndef ES_APP_GUIS_GUI_RANDOM_COLLECTION_OPTIONS_H
+#define ES_APP_GUIS_GUI_RANDOM_COLLECTION_OPTIONS_H
+
+#include "components/MenuComponent.h"
+
+template<typename T>
+class OptionListComponent;
+class SwitchComponent;
+class SystemData;
+class GuiSettings;
+struct CollectionSystemData;
+
+typedef OptionListComponent<int> NumberList;
+struct SystemGames
+{
+	std::string name;
+	std::shared_ptr<NumberList> gamesSelection;
+};
+
+class GuiRandomCollectionOptions : public GuiComponent
+{
+public:
+	GuiRandomCollectionOptions(Window* window);
+	~GuiRandomCollectionOptions();
+	bool input(InputConfig* config, Input input) override;
+
+	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+
+private:
+	void initializeMenu();
+	void saveSettings();
+	void applyGroupSettings(std::string settingsLabel, std::vector< SystemGames>* results);
+	void addSystemsToMenu();
+	void addEntry(const char* name, unsigned int color, bool add_arrow, const std::function<void()>& func);
+	void selectEntries(std::map<std::string, CollectionSystemData> collection, std::string settingsLabel, int defaultValue, std::vector< SystemGames>* results);
+
+	void selectSystems();
+	void selectAutoCollections();
+	void selectCustomCollections();
+
+	std::string collectionListsToString(std::vector< SystemGames> collectionLists);
+
+	bool mNeedsCollectionRefresh;
+
+	std::vector< SystemGames> customCollectionLists;
+	std::vector< SystemGames> autoCollectionLists;
+	std::vector< SystemGames> systemLists;
+	std::shared_ptr< OptionListComponent<std::string> > trimRandom;
+	MenuComponent mMenu;
+	SystemData* mSystem;
+};
+
+#endif // ES_APP_GUIS_GUI_RANDOM_COLLECTION_OPTIONS_H

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -139,6 +139,10 @@ void Settings::setDefaults()
 	mStringMap["VlcScreenSaverResolution"] = "original";
 	// Audio out device for Video playback using OMX player.
 	mStringMap["OMXAudioDev"] = "both";
+	mStringMap["RandomCollectionMaxItems"] = "";
+	mStringMap["RandomCollectionSystemsAuto"] = "";
+	mStringMap["RandomCollectionSystemsCustom"] = "";
+	mStringMap["RandomCollectionSystems"] = "";
 	mStringMap["CollectionSystemsAuto"] = "";
 	mStringMap["CollectionSystemsCustom"] = "";
 	mStringMap["DefaultScreenSaverCollection"] = "";


### PR DESCRIPTION
- Add an automatic Random collection.
- Menu allows user to select which systems to use as source, how many games from each system, and a maximum size for the collection, should they choose to.
- This requires changes to the themes, if users enable it.