### PR TITLE
Refactorings to #857

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,10 +162,10 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 
     #set up compiler flags for GCC
     if (CMAKE_BUILD_TYPE MATCHES Debug)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-attributes -O0") #support C++11 for std::, optimize
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wno-attributes -O0") #support C++11 for std::, optimize
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O0")
     else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-attributes -O2") #support C++11 for std::, optimize
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wno-attributes -O2") #support C++11 for std::, optimize
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O2")  #-s = strip binary
 endif()
 endif()

--- a/es-app/src/CollectionSystemManager.cpp
+++ b/es-app/src/CollectionSystemManager.cpp
@@ -15,36 +15,6 @@
 #include <pugixml.hpp>
 #include <fstream>
 
-std::string myCollectionsName = "collections";
-std::string randomCollectionName = "random";
-
-#define LAST_PLAYED_MAX	50
-
-std::map<std::string, int> stringToRandomSettingsMap(std::string sourceStr) 
-{
-	std::map<std::string, int> results;
-	// we parse the comma-separated settings list in the format [system]:[setting]
-	std::vector<std::string> vectorSettings = Utils::String::delimitedStringToVector(sourceStr, ",", false);
-
-	// iterate the map
-	for(std::vector<std::string>::iterator it = vectorSettings.begin() ; it != vectorSettings.end() ; it++ )
-	{
-		if (!(*it).empty()) 
-		{
-			std::vector<std::string> systemSettings = Utils::String::delimitedStringToVector((*it), ":", false);
-			try 
-			{
-				results[systemSettings.at(0)] = std::stoi(systemSettings.at(1));
-			}
-			catch (std::exception& e)
-			{
-				LOG(LogError) << "Error parsing random collection settings: '" << (*it) << "' is in an invalid format.";
-			}
-		}
-	}
-	return results;
-}
-
 /* Handling the getting, initialization, deinitialization, saving and deletion of
  * a CollectionSystemManager Instance */
 CollectionSystemManager* CollectionSystemManager::sInstance = NULL;
@@ -52,12 +22,12 @@ CollectionSystemManager* CollectionSystemManager::sInstance = NULL;
 CollectionSystemManager::CollectionSystemManager(Window* window) : mWindow(window)
 {
 	CollectionSystemDecl systemDecls[] = {
-		//type                  name            long name            //default sort              // theme folder            // isCustom
-		{ AUTO_ALL_GAMES,       "all",          "all games",         "name, ascending",          "auto-allgames",           false },
-		{ AUTO_LAST_PLAYED,     "recent",       "last played",       "last played, descending",  "auto-lastplayed",         false },
-		{ AUTO_FAVORITES,       "favorites",    "favorites",         "name, ascending",          "auto-favorites",          false },
-		{ AUTO_RANDOM,          randomCollectionName, "random",      "name, ascending",          "auto-random",             false },
-		{ CUSTOM_COLLECTION,    myCollectionsName,  "collections",   "name, ascending",          "custom-collections",      true }
+		//type                  name             long name (display)  default sort (key, order)   theme folder            isCustom
+		{ AUTO_ALL_GAMES,       "all",           "all games",         "name, ascending",          "auto-allgames",        false },
+		{ AUTO_LAST_PLAYED,     "recent",        "last played",       "last played, descending",  "auto-lastplayed",      false },
+		{ AUTO_FAVORITES,       "favorites",     "favorites",         "name, ascending",          "auto-favorites",       false },
+		{ AUTO_RANDOM,          RANDOM_COLL_ID,  "random",            "name, ascending",          "auto-random",          false },
+		{ CUSTOM_COLLECTION,    CUSTOM_COLL_ID,  "collections",       "name, ascending",          "custom-collections",   true  }
 	};
 
 	// create a map
@@ -156,7 +126,7 @@ void CollectionSystemManager::saveCustomCollection(SystemData* sys)
 void CollectionSystemManager::loadCollectionSystems(bool async)
 {
 	initAutoCollectionSystems();
-	CollectionSystemDecl decl = mCollectionSystemDeclsIndex[myCollectionsName];
+	CollectionSystemDecl decl = mCollectionSystemDeclsIndex[CUSTOM_COLL_ID];
 	mCustomCollectionsBundle = createNewCollectionEntry(decl.name, decl, false);
 	// we will also load custom systems here
 	initCustomCollectionSystems();
@@ -225,7 +195,7 @@ void CollectionSystemManager::updateSystemsList()
 
 	if(mCustomCollectionsBundle->getRootFolder()->getChildren().size() > 0)
 	{
-		mCustomCollectionsBundle->getRootFolder()->sort(getSortTypeFromString(mCollectionSystemDeclsIndex[myCollectionsName].defaultSort));
+		mCustomCollectionsBundle->getRootFolder()->sort(getSortTypeFromString(mCollectionSystemDeclsIndex[CUSTOM_COLL_ID].defaultSort));
 		SystemData::sSystemVector.push_back(mCustomCollectionsBundle);
 	}
 
@@ -553,7 +523,7 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file)
 				rootFolder->addChild(newGame);
 				fileIndex->addToIndex(newGame);
 				// this is the biggest performance bottleneck for this process.
-				// this code has been here for 7 years, since this feature was added. 
+				// this code has been here for 7 years, since this feature was added.
 				// I might have been playing it safe back then, but it feels unnecessary, especially given following onFileChanged to sort
 				// Commenting this out for now.
 				//ViewController::get()->getGameListView(systemViewToUpdate)->onFileChanged(newGame, FILE_METADATA_CHANGED);
@@ -599,7 +569,7 @@ bool CollectionSystemManager::toggleGameInCollection(FileData* file)
 		{
 			s = new GuiInfoPopup(mWindow, "Removed '" + Utils::String::removeParenthesis(name) + "' from '" + Utils::String::toUpper(sysName) + "'", 4000);
 		}
-		
+
 		mWindow->setInfoPopup(s);
 		return true;
 	}
@@ -628,17 +598,17 @@ SystemData* CollectionSystemManager::getSystemToView(SystemData* sys)
 void CollectionSystemManager::recreateCollection(SystemData* sysData)
 {
 	CollectionSystemData* colSysData;
-	if (mAutoCollectionSystemsData.find(sysData->getName()) != mAutoCollectionSystemsData.end()) 
+	if (mAutoCollectionSystemsData.find(sysData->getName()) != mAutoCollectionSystemsData.end())
 	{
 		// it's an auto collection
 		colSysData = &mAutoCollectionSystemsData[sysData->getName()];
 	}
-	else if (mCustomCollectionSystemsData.find(sysData->getName()) != mCustomCollectionSystemsData.end()) 
+	else if (mCustomCollectionSystemsData.find(sysData->getName()) != mCustomCollectionSystemsData.end())
 	{
 		// it's a custom collection
 		colSysData = &mCustomCollectionSystemsData[sysData->getName()];
 	}
-	else 
+	else
 	{
 		LOG(LogDebug) << "Couldn't find collection to recreate in either custom or auto collections: " << sysData->getName();
 		return;
@@ -657,13 +627,13 @@ void CollectionSystemManager::recreateCollection(SystemData* sysData)
 	// while there are games there, remove them from the view and system
 	while(rootFolder->getChildrenByFilename().size() > 0)
 		ViewController::get()->getGameListView(systemViewToUpdate).get()->remove(rootFolder->getChildrenByFilename().begin()->second, false, false);
-	
+
 	colSysData->isPopulated = false;
 	if (sysDecl.isCustom)
 		populateCustomCollection(colSysData);
 	else
 		populateAutoCollection(colSysData);
-	
+
 	rootFolder->sort(getSortTypeFromString(colSysData->decl.defaultSort));
 	ViewController::get()->onFileChanged(systemViewToUpdate->getRootFolder(), FILE_SORTED);
 
@@ -785,7 +755,7 @@ SystemData* CollectionSystemManager::getAllGamesCollection()
 
 SystemData* CollectionSystemManager::addNewCustomCollection(std::string name)
 {
-	CollectionSystemDecl decl = mCollectionSystemDeclsIndex[myCollectionsName];
+	CollectionSystemDecl decl = mCollectionSystemDeclsIndex[CUSTOM_COLL_ID];
 	decl.themeFolder = name;
 	decl.name = name;
 	decl.longName = name;
@@ -819,15 +789,21 @@ SystemData* CollectionSystemManager::createNewCollectionEntry(std::string name, 
 	return newSys;
 }
 
-void CollectionSystemManager::addRandomGames(SystemData* newSys, SystemData* sourceSystem, FileData* rootFolder, 
-	FileFilterIndex* index, std::map<std::string, int> settingsValues, int defaultValue) 
+void CollectionSystemManager::addRandomGames(SystemData* newSys, SystemData* sourceSystem, FileData* rootFolder,
+	FileFilterIndex* index, std::map<std::string, std::map<std::string, std::any>> mapsForRandomColl, int defaultValue)
 {
-	
+
 	int gamesForSourceSystem = defaultValue;
-	if (settingsValues.find(sourceSystem->getFullName()) != settingsValues.end()) 
+	for (auto& [key, collMap] : mapsForRandomColl)
 	{
-		// we won't add more than the max
-		gamesForSourceSystem = Math::min(RANDOM_SYSTEM_MAX, settingsValues[sourceSystem->getFullName()]);
+		if (collMap.find(sourceSystem->getFullName()) != collMap.end())
+		{
+			std::any vv = collMap[sourceSystem->getFullName()];
+			int v = std::any_cast<int>(vv);
+			// we won't add more than the max and less than 0
+			gamesForSourceSystem = Math::max(Math::min(RANDOM_SYSTEM_MAX, v), 0);
+			break;
+		}
 	}
 
 	// load exclusion collection
@@ -836,7 +812,8 @@ void CollectionSystemManager::addRandomGames(SystemData* newSys, SystemData* sou
 	auto sysDataIt = mCustomCollectionSystemsData.find(exclusionCollection);
 
 	if (!exclusionCollection.empty() && sysDataIt != mCustomCollectionSystemsData.end()) {
-		if (!sysDataIt->second.isPopulated) {
+		if (!sysDataIt->second.isPopulated)
+		{
 			populateCustomCollection(&(sysDataIt->second));
 		}
 
@@ -845,13 +822,13 @@ void CollectionSystemManager::addRandomGames(SystemData* newSys, SystemData* sou
 	}
 
 	// we do this to avoid trying to add more games than there are in the system
-	gamesForSourceSystem = Math::min(gamesForSourceSystem, sourceSystem->getRootFolder()->getFilesRecursive(GAME).size()); 
-	
+	gamesForSourceSystem = Math::min(gamesForSourceSystem, sourceSystem->getRootFolder()->getFilesRecursive(GAME).size());
+
 	int startCount = rootFolder->getFilesRecursive(GAME).size();
 	int endCount = startCount + gamesForSourceSystem;
 	int retryCount = 10;
 
-	for (int iterCount = startCount; iterCount < endCount; )
+	for (int iterCount = startCount; iterCount < endCount;)
 	{
 		FileData* randomGame = sourceSystem->getRandomGame()->getSourceFileData();
 		CollectionFileData* newGame = NULL;
@@ -863,8 +840,8 @@ void CollectionSystemManager::addRandomGames(SystemData* newSys, SystemData* sou
 			rootFolder->addChild(newGame);
 			index->addToIndex(newGame);
 		}
-		
-		if (rootFolder->getFilesRecursive(GAME).size() > iterCount) 
+
+		if (rootFolder->getFilesRecursive(GAME).size() > iterCount)
 		{
 			// added game, proceed
 			iterCount++;
@@ -876,7 +853,7 @@ void CollectionSystemManager::addRandomGames(SystemData* newSys, SystemData* sou
 			LOG(LogDebug) << "Clash: " << randomGame->getName() << " already exists or in exclusion list. Deleting and trying again";
 			delete newGame;
 			retryCount--;
-			if (retryCount == 0) 
+			if (retryCount == 0)
 			{
 				// we give up. Either we were very unlucky, or all the games in this system are already there.
 				LOG(LogDebug) << "Giving up retrying: cannot add this game. Deleting and moving on.";
@@ -886,38 +863,38 @@ void CollectionSystemManager::addRandomGames(SystemData* newSys, SystemData* sou
 	}
 }
 
-void CollectionSystemManager::populateRandomCollectionFromCollections(std::map<std::string, int> settingsValues) 
+void CollectionSystemManager::populateRandomCollectionFromCollections(std::map<std::string, std::map<std::string, std::any>> mapsForRandomColl)
 {
-	CollectionSystemData* sysData = &mAutoCollectionSystemsData[randomCollectionName];
+	CollectionSystemData* sysData = &mAutoCollectionSystemsData[RANDOM_COLL_ID];
 	SystemData* newSys = sysData->system;
 	CollectionSystemDecl sysDecl = sysData->decl;
 	FileData* rootFolder = newSys->getRootFolder();
 	FileFilterIndex* index = newSys->getIndex();
 
 	// iterate the auto collections map
-	for(std::map<std::string, CollectionSystemData>::iterator it = mAutoCollectionSystemsData.begin() ; it != mAutoCollectionSystemsData.end() ; it++ )
+	for(auto &[_, csd] : mAutoCollectionSystemsData)
 	{
 		// we can't add games from the random collection to the random collection
-		if (it->second.decl.type != AUTO_RANDOM) 
+		if (csd.decl.type != AUTO_RANDOM)
 		{
 			// collections might not be populated
-			if (!it->second.isPopulated) 
-				populateAutoCollection(&(it->second));
+			if (!csd.isPopulated)
+				populateAutoCollection(&csd);
 
-			if (it->second.isPopulated)
-				addRandomGames(newSys, it->second.system, rootFolder, index, settingsValues, DEFAULT_RANDOM_COLLECTIONS_GAMES);
+			if (csd.isPopulated)
+				addRandomGames(newSys, csd.system, rootFolder, index, mapsForRandomColl, DEFAULT_RANDOM_COLLECTIONS_GAMES);
 		}
 	}
-	
+
 	// iterate the custom collections map
-	for(std::map<std::string, CollectionSystemData>::iterator it = mCustomCollectionSystemsData.begin() ; it != mCustomCollectionSystemsData.end() ; it++ )
+	for(auto &[_, csd] : mCustomCollectionSystemsData)
 	{
 		// collections might not be populated
-		if (!it->second.isPopulated) 
-			populateCustomCollection(&(it->second));
-		
-		if (it->second.isPopulated) 
-			addRandomGames(newSys, it->second.system, rootFolder, index, settingsValues, DEFAULT_RANDOM_COLLECTIONS_GAMES);
+		if (!csd.isPopulated)
+			populateCustomCollection(&csd);
+
+		if (csd.isPopulated)
+			addRandomGames(newSys, csd.system, rootFolder, index, mapsForRandomColl, DEFAULT_RANDOM_COLLECTIONS_GAMES);
 	}
 }
 
@@ -929,13 +906,16 @@ void CollectionSystemManager::populateAutoCollection(CollectionSystemData* sysDa
 	FileData* rootFolder = newSys->getRootFolder();
 	FileFilterIndex* index = newSys->getIndex();
 
-	std::map<std::string, int> settingsValues;
-	if (sysDecl.type == AUTO_RANDOM) 
+	std::map<std::string, std::map<std::string, std::any>> mapsForRandomColl;
+	if (sysDecl.type == AUTO_RANDOM)
 	{
-		std::string randomSystems = Settings::getInstance()->getString("RandomCollectionSystems");
-		std::string randomCollections = Settings::getInstance()->getString("RandomCollectionSystemsAuto") + "," +
-			Settings::getInstance()->getString("RandomCollectionSystemsCustom");
-		settingsValues = stringToRandomSettingsMap(randomSystems + "," + randomCollections);
+		// user may have defined a custom collection with the same name as a system name, thus keeping maps in another map
+		std::map<std::string, std::any> randomSystems = Settings::getInstance()->getMap("RandomCollectionSystems");
+		mapsForRandomColl["RandomCollectionSystems"] = randomSystems;
+		std::map<std::string, std::any> randomAutoColl = Settings::getInstance()->getMap("RandomCollectionSystemsAuto");
+		mapsForRandomColl["RandomCollectionSystemsAuto"] = randomAutoColl;
+		std::map<std::string, std::any> randomCustColl = Settings::getInstance()->getMap("RandomCollectionSystemsCustom");
+		mapsForRandomColl["RandomCollectionSystemsCustom"] = randomCustColl;
 	}
 	// Only iterate through game systems, not collections yet
 	for(auto sysIt = SystemData::sSystemVector.cbegin(); sysIt != SystemData::sSystemVector.cend(); sysIt++)
@@ -945,7 +925,7 @@ void CollectionSystemManager::populateAutoCollection(CollectionSystemData* sysDa
 		{
 			if (sysDecl.type == AUTO_RANDOM)
 			{
-				addRandomGames(newSys, (*sysIt), rootFolder, index, settingsValues, DEFAULT_RANDOM_SYSTEM_GAMES);
+				addRandomGames(newSys, (*sysIt), rootFolder, index, mapsForRandomColl, DEFAULT_RANDOM_SYSTEM_GAMES);
 			}
 			else
 			{
@@ -964,7 +944,6 @@ void CollectionSystemManager::populateAutoCollection(CollectionSystemData* sysDa
 							break;
 						case AUTO_ALL_GAMES:
 							break;
-						case AUTO_RANDOM:
 						default:
 							// No-op to prevent compiler warnings
 							// Getting here means that the file is not part of a pre-defined collection.
@@ -972,7 +951,7 @@ void CollectionSystemManager::populateAutoCollection(CollectionSystemData* sysDa
 							break;
 					}
 
-					if (include) 
+					if (include)
 					{
 						CollectionFileData* newGame = new CollectionFileData(*gameIt, newSys);
 						rootFolder->addChild(newGame);
@@ -988,10 +967,10 @@ void CollectionSystemManager::populateAutoCollection(CollectionSystemData* sysDa
 	std::string trimRandom = Settings::getInstance()->getString("RandomCollectionMaxItems");
 	if (!trimRandom.empty() && sysDecl.type == AUTO_RANDOM)
 		trimValue = std::stoi(trimRandom);
-		
+
 	// here we finish populating the Random collection based on other Collections
 	if (sysDecl.type == AUTO_RANDOM)
-		populateRandomCollectionFromCollections(settingsValues);
+		populateRandomCollectionFromCollections(mapsForRandomColl);
 
 	// sort before optional trimming
 	rootFolder->sort(getSortTypeFromString(sysDecl.defaultSort));
@@ -1028,7 +1007,7 @@ void CollectionSystemManager::populateCustomCollection(CollectionSystemData* sys
 	for(std::string gameKey; getline(input, gameKey); )
 	{
 		std::unordered_map<std::string,FileData*>::const_iterator it = allFilesMap.find(gameKey);
-		if (it != allFilesMap.cend()) 
+		if (it != allFilesMap.cend())
 		{
 			CollectionFileData* newGame = new CollectionFileData(it->second, newSys);
 			rootFolder->addChild(newGame);
@@ -1093,10 +1072,10 @@ void CollectionSystemManager::addEnabledCollectionsToDisplayedSystems(std::map<s
 				{
 					if(it->second.decl.isCustom)
 						populateCustomCollection(&(it->second));
-					else 
-						populateAutoCollection(&(it->second));	
+					else
+						populateAutoCollection(&(it->second));
 				}
-				
+
 				// check if it has its own view
 				if(!it->second.decl.isCustom || themeFolderExists(it->first) || !Settings::getInstance()->getBool("UseCustomCollectionsSystem"))
 				{
@@ -1304,7 +1283,7 @@ bool CollectionSystemManager::includeFileInAutoCollections(FileData* file)
 
 
 bool CollectionSystemManager::needDoublePress(int presscount) {
-	if (Settings::getInstance()->getBool("DoublePressRemovesFromFavs") && presscount < 2) 
+	if (Settings::getInstance()->getBool("DoublePressRemovesFromFavs") && presscount < 2)
 	{
 		GuiInfoPopup* toast = new GuiInfoPopup(mWindow, "Press again to remove from '" + Utils::String::toUpper(mEditingCollection)
 		+ "'", DOUBLE_PRESS_DETECTION_DURATION, 100, 200);

--- a/es-app/src/CollectionSystemManager.h
+++ b/es-app/src/CollectionSystemManager.h
@@ -3,6 +3,7 @@
 #define ES_APP_COLLECTION_SYSTEM_MANAGER_H
 
 #include <map>
+#include <any>
 #include <SDL_timer.h>
 #include <string>
 #include <vector>
@@ -13,9 +14,13 @@ class Window;
 struct SystemEnvironmentData;
 class FileFilterIndex;
 
-#define RANDOM_SYSTEM_MAX 5
-#define DEFAULT_RANDOM_SYSTEM_GAMES 1
-#define DEFAULT_RANDOM_COLLECTIONS_GAMES 0
+inline const std::string CUSTOM_COLL_ID = "collections";
+inline const std::string RANDOM_COLL_ID = "random";
+constexpr int LAST_PLAYED_MAX = 50;
+
+constexpr int RANDOM_SYSTEM_MAX = 5;
+constexpr int DEFAULT_RANDOM_SYSTEM_GAMES = 1;
+constexpr int DEFAULT_RANDOM_COLLECTIONS_GAMES = 0;
 
 enum CollectionSystemType
 {
@@ -44,8 +49,6 @@ struct CollectionSystemData
 	bool isPopulated;
 	bool needsSave;
 };
-
-std::map<std::string, int> stringToRandomSettingsMap(std::string sourceStr);
 
 class CollectionSystemManager
 {
@@ -109,8 +112,8 @@ private:
 	void populateAutoCollection(CollectionSystemData* sysData);
 	void populateCustomCollection(CollectionSystemData* sysData);
 	void addRandomGames(SystemData* newSys, SystemData* sourceSystem, FileData* rootFolder, FileFilterIndex* index,
-		std::map<std::string, int> settingsValues, int defaultValue);
-	void populateRandomCollectionFromCollections(std::map<std::string, int> settingsValues);
+		std::map<std::string, std::map<std::string, std::any>> mapsForRandomColl, int defaultValue);
+	void populateRandomCollectionFromCollections(std::map<std::string, std::map<std::string, std::any>> mapsForRandomColl);
 
 	void removeCollectionsFromDisplayedSystems();
 	void addEnabledCollectionsToDisplayedSystems(std::map<std::string, CollectionSystemData>* colSystemData, bool processRandom);

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -23,7 +23,7 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	addSystemsToMenu();
 
 	// manage random collection
-	addEntry("RANDOM GAME COLL. SETTINGS", 0x777777FF, true, [this] { openRandomCollectionSettings(); });
+	addEntry("RANDOM GAME COLLECTION SETTINGS", 0x777777FF, true, [this] { openRandomCollectionSettings(); });
 
 	// add "Create New Custom Collection from Theme"
 	std::vector<std::string> unusedFolders = CollectionSystemManager::get()->getUnusedSystemsFromTheme();
@@ -89,7 +89,7 @@ void GuiCollectionSystemsOptions::initializeMenu()
 
 	// Add option to select default collection for screensaver
 	defaultScreenSaverCollection = std::make_shared< OptionListComponent<std::string> >(mWindow, "DEFAULT COLLECTION TO ADD SCREENSAVER GAMES TO", false);
-	
+
 	// Add default option
 	defaultScreenSaverCollection->add("<DEFAULT>", "", Settings::getInstance()->getString("DefaultScreenSaverCollection") == "");
 
@@ -102,7 +102,7 @@ void GuiCollectionSystemsOptions::initializeMenu()
 	}
 
 	mMenu.addWithLabel("DEFAULT COLLECTION TO ADD SCREENSAVER GAMES TO", defaultScreenSaverCollection);
-	
+
 	if(CollectionSystemManager::get()->isEditing())
 	{
 		row.elements.clear();
@@ -135,7 +135,7 @@ void GuiCollectionSystemsOptions::addEntry(const char* name, unsigned int color,
 	mMenu.addRow(row);
 }
 
-void GuiCollectionSystemsOptions::createCollection(std::string inName) 
+void GuiCollectionSystemsOptions::createCollection(std::string inName)
 {
 	std::string name = CollectionSystemManager::get()->getValidNewCollectionName(inName);
 	SystemData* newSys = CollectionSystemManager::get()->addNewCustomCollection(name);
@@ -152,7 +152,7 @@ void GuiCollectionSystemsOptions::createCollection(std::string inName)
 	return;
 }
 
-void GuiCollectionSystemsOptions::openRandomCollectionSettings() 
+void GuiCollectionSystemsOptions::openRandomCollectionSettings()
 {
 	mWindow->pushGui(new GuiRandomCollectionOptions(mWindow));
 }
@@ -226,7 +226,7 @@ void GuiCollectionSystemsOptions::applySettings()
 	Settings::getInstance()->setBool("DoublePressRemovesFromFavs", doublePressToRemoveFavs->getState());
 	bool needRefreshCollectionSettings = prevAuto != outAuto || prevCustom != outCustom || outSort != prevSort || outBundle != prevBundle
 		|| prevShow != outShow;
-	
+
 	if (needRefreshCollectionSettings)
 	{
 		updateSettings(outAuto, outCustom);
@@ -235,7 +235,7 @@ void GuiCollectionSystemsOptions::applySettings()
 	{
 		Settings::getInstance()->saveFile();
 	}
-	
+
 	Settings::getInstance()->saveFile();
 	delete this;
 }

--- a/es-app/src/guis/GuiRandomCollectionOptions.cpp
+++ b/es-app/src/guis/GuiRandomCollectionOptions.cpp
@@ -16,20 +16,20 @@ GuiRandomCollectionOptions::GuiRandomCollectionOptions(Window* window) : GuiComp
 	autoCollectionLists.clear();
 	systemLists.clear();
 	mNeedsCollectionRefresh = false;
-	
+
 	initializeMenu();
 }
 
 void GuiRandomCollectionOptions::initializeMenu()
 {
 	// get collections
-	addEntry("INCLUDED SYSTEMS", 0x777777FF, true, [this] { selectSystems(); });
-	addEntry("INCLUDED AUTO COLLECTIONS", 0x777777FF, true, [this] { selectAutoCollections(); });
-	addEntry("INCLUDED CUSTOM COLLECTIONS", 0x777777FF, true, [this] { selectCustomCollections(); });
-	
+	addEntry("INCLUDE SYSTEMS", 0x777777FF, true, [this] { selectSystems(); });
+	addEntry("INCLUDE AUTO COLLECTIONS", 0x777777FF, true, [this] { selectAutoCollections(); });
+	addEntry("INCLUDE CUSTOM COLLECTIONS", 0x777777FF, true, [this] { selectCustomCollections(); });
+
 	// Add option to exclude games from a collection
 	exclusionCollection = std::make_shared< OptionListComponent<std::string> >(mWindow, "EXCLUDE GAMES FROM", false);
-	
+
 	// Add default option
 	exclusionCollection->add("<NONE>", "", Settings::getInstance()->getString("RandomCollectionExclusionCollection") == "");
 
@@ -41,21 +41,20 @@ void GuiRandomCollectionOptions::initializeMenu()
 	}
 
 	mMenu.addWithLabel("EXCLUDE GAMES FROM", exclusionCollection);
-	
 
 	// Add option to trim random collection items
 	trimRandom = std::make_shared< OptionListComponent<std::string> >(mWindow, "MAX GAMES", false);
-	
+
 	// Add default entry
 	trimRandom->add("ALL", "", Settings::getInstance()->getString("RandomCollectionMaxItems") == "");
-	
-	// add all enabled Custom Systems
+
+	// add limit values for size of random collection
 	for(int i = 5; i <= 50; i = i+5)
 	{
 		trimRandom->add(std::to_string(i), std::to_string(i), Settings::getInstance()->getString("RandomCollectionMaxItems") == std::to_string(i));
 	}
 
-	mMenu.addWithLabel("MAX ITEMS", trimRandom);
+	mMenu.addWithLabel("MAX GAMES", trimRandom);
 
 	addChild(&mMenu);
 
@@ -87,20 +86,20 @@ void GuiRandomCollectionOptions::addEntry(const char* name, unsigned int color, 
 void GuiRandomCollectionOptions::selectSystems()
 {
 	std::map<std::string, CollectionSystemData> systems;
-	for(auto sysIt = SystemData::sSystemVector.cbegin(); sysIt != SystemData::sSystemVector.cend(); sysIt++)
+	for(auto &sys : SystemData::sSystemVector)
 	{
 		// we won't iterate all collections
-		if ((*sysIt)->isGameSystem() && !(*sysIt)->isCollection()) 
+		if (sys->isGameSystem() && !sys->isCollection())
 		{
 			CollectionSystemDecl sysDecl;
-			sysDecl.name = (*sysIt)->getName();
-			sysDecl.longName = (*sysIt)->getFullName();
+			sysDecl.name = sys->getName();
+			sysDecl.longName = sys->getFullName();
 
 			CollectionSystemData newCollectionData;
-			newCollectionData.system = (*sysIt);
+			newCollectionData.system = sys;
 			newCollectionData.decl = sysDecl;
 			newCollectionData.isEnabled = true;
-			
+
 			systems[sysDecl.name] = newCollectionData;
 		}
 	}
@@ -122,37 +121,31 @@ GuiRandomCollectionOptions::~GuiRandomCollectionOptions()
 
 }
 
-std::string GuiRandomCollectionOptions::collectionListsToString(std::vector< SystemGames> collectionLists) {
-	std::string result;
-	for (std::vector< SystemGames>::const_iterator it = collectionLists.cbegin(); it != collectionLists.cend(); it++)
-	{
-		if (it != collectionLists.cbegin())
-			result += ",";
-
-		result += (*it).name + ":" + std::to_string((*it).gamesSelection->getSelected());
-	}
-	return result;
-}
-
 void GuiRandomCollectionOptions::selectEntries(std::map<std::string, CollectionSystemData> collection, std::string settingsLabel, int defaultValue, std::vector< SystemGames>* results) {
 	auto s = new GuiSettings(mWindow, "INCLUDE GAMES FROM");
-	
-	std::map<std::string, int> settingsValues = stringToRandomSettingsMap(Settings::getInstance()->getString(settingsLabel));
+
+	std::map<std::string, std::any> initValues = Settings::getInstance()->getMap(settingsLabel);
 
 	results->clear();
 
-	// add Auto Systems
-	for(std::map<std::string, CollectionSystemData>::const_iterator it = collection.cbegin() ; it != collection.cend() ; it++ )
+	for(auto &[_, csd] : collection)
 	{
-		if (it->second.system != CollectionSystemManager::get()->getRandomCollection())
+		if (csd.system != CollectionSystemManager::get()->getRandomCollection())
 		{
 			ComponentListRow row;
 
-			std::string label = it->second.decl.longName;
-			int selectedValue = defaultValue; 
+			std::string label = csd.decl.longName;
+			int selectedValue = defaultValue;
 
-			if (settingsValues.find(label) != settingsValues.end()) 
-				selectedValue = Math::min(RANDOM_SYSTEM_MAX, settingsValues[label]);
+			if (initValues.find(label) != initValues.end())
+			{
+				int v = std::any_cast<int>(initValues[label]);
+				// we won't add more than the max and less than 0
+				selectedValue = Math::max(Math::min(RANDOM_SYSTEM_MAX, v), 0);
+				mNeedsCollectionRefresh |= selectedValue != v;
+			}
+
+			initValues[label] = selectedValue;
 
 			std::shared_ptr<NumberList> colItems = std::make_shared<NumberList>(mWindow, label, false);
 			for (int i = 0; i <= RANDOM_SYSTEM_MAX; i++)
@@ -170,22 +163,34 @@ void GuiRandomCollectionOptions::selectEntries(std::map<std::string, CollectionS
 		}
 
 	}
-	
+
 	setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
 	s->setPosition((mSize.x() - s->getSize().x()) / 2, (mSize.y() - s->getSize().y()) / 2);
-	s->addSaveFunc([this, settingsLabel, results] { applyGroupSettings(settingsLabel, results); });
+	s->addSaveFunc([this, settingsLabel, initValues, results] { applyGroupSettings(settingsLabel, initValues, results); });
 	mWindow->pushGui(s);
 }
 
-void GuiRandomCollectionOptions::applyGroupSettings(std::string settingsLabel, std::vector< SystemGames>* results)
+
+template <typename Map>
+bool GuiRandomCollectionOptions::equal(Map const &_this, Map const &_that)
 {
-	std::string curOptions = GuiRandomCollectionOptions::collectionListsToString((*results));
-	std::string prevOptions = Settings::getInstance()->getString(settingsLabel);
-	
-	if (!curOptions.empty() && curOptions != prevOptions) 
+    return _this.size() == _that.size() // map key count
+		&& std::equal(_this.begin(), _this.end(), _that.begin(), [] (auto a, auto b) { return a.first == b.first; }) // map keys
+		&& std::equal(_this.begin(), _this.end(), _that.begin(), [] (auto a, auto b) { return std::any_cast<int>(a.second) == std::any_cast<int>(b.second); }); // map values
+}
+
+
+void GuiRandomCollectionOptions::applyGroupSettings(std::string settingsLabel, const std::map<std::string, std::any> &initialValues, std::vector<SystemGames> *results)
+{
+	std::map<std::string,std::any> currentValues;
+	for (auto it = results->begin(); it != results->end(); ++it)
 	{
-		Settings::getInstance()->setString(settingsLabel, curOptions);
+		currentValues[(*it).name] = (*it).gamesSelection->getSelected();
+	}
+	if (!equal(currentValues, initialValues))
+	{
 		mNeedsCollectionRefresh = true;
+		Settings::getInstance()->setMap(settingsLabel, currentValues);
 	}
 }
 
@@ -195,14 +200,13 @@ void GuiRandomCollectionOptions::saveSettings()
 	std::string prevTrim = Settings::getInstance()->getString("RandomCollectionMaxItems");
 	Settings::getInstance()->setString("RandomCollectionMaxItems", curTrim);
 
-
 	std::string curExclusion = exclusionCollection->getSelected();
 	std::string prevExclusion = Settings::getInstance()->getString("RandomCollectionExclusionCollection");
 	Settings::getInstance()->setString("RandomCollectionExclusionCollection", curExclusion);
 
 	mNeedsCollectionRefresh |= (curTrim != prevTrim || curExclusion != prevExclusion);
 
-	if (mNeedsCollectionRefresh) 
+	if (mNeedsCollectionRefresh)
 	{
 		Settings::getInstance()->saveFile();
 		CollectionSystemManager::get()->recreateCollection(CollectionSystemManager::get()->getRandomCollection());

--- a/es-app/src/guis/GuiRandomCollectionOptions.h
+++ b/es-app/src/guis/GuiRandomCollectionOptions.h
@@ -4,6 +4,8 @@
 
 #include "components/MenuComponent.h"
 
+#include <any>
+
 template<typename T>
 class OptionListComponent;
 class SwitchComponent;
@@ -30,7 +32,7 @@ public:
 private:
 	void initializeMenu();
 	void saveSettings();
-	void applyGroupSettings(std::string settingsLabel, std::vector< SystemGames>* results);
+	void applyGroupSettings(std::string settingsLabel, const std::map<std::string, std::any> &initialValues, std::vector<SystemGames>* results);
 	void addSystemsToMenu();
 	void addEntry(const char* name, unsigned int color, bool add_arrow, const std::function<void()>& func);
 	void selectEntries(std::map<std::string, CollectionSystemData> collection, std::string settingsLabel, int defaultValue, std::vector< SystemGames>* results);
@@ -39,7 +41,8 @@ private:
 	void selectAutoCollections();
 	void selectCustomCollections();
 
-	std::string collectionListsToString(std::vector< SystemGames> collectionLists);
+	template <typename Map>
+	bool equal(Map const &_this, Map const &_that);
 
 	bool mNeedsCollectionRefresh;
 

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -3,6 +3,7 @@
 #define ES_CORE_SETTINGS_H
 
 #include <map>
+#include <any>
 #include <string>
 
 //This is a singleton for storing settings.
@@ -20,11 +21,13 @@ public:
 	int getInt(const std::string& name);
 	float getFloat(const std::string& name);
 	const std::string& getString(const std::string& name);
+	const std::map<std::string, std::any> getMap(const std::string& name);
 
 	void setBool(const std::string& name, bool value);
 	void setInt(const std::string& name, int value);
 	void setFloat(const std::string& name, float value);
 	void setString(const std::string& name, const std::string& value);
+	void setMap(const std::string& name, const std::map<std::string, std::any>& map);
 
 private:
 	static Settings* sInstance;
@@ -40,6 +43,7 @@ private:
 	std::map<std::string, int> mIntMap;
 	std::map<std::string, float> mFloatMap;
 	std::map<std::string, std::string> mStringMap;
+	std::map<std::string, std::map<std::string, std::any>> mMapMap;
 };
 
 #endif // ES_CORE_SETTINGS_H


### PR DESCRIPTION
Overall I left the flow and design as-is. The feature is still cool, @pjft don't be scared by the numerous changes. :)

I have put the map save/load into `Settings.cpp`, for generic map usage, reflecting the map in xml. IMHO it is more suitable in this class. The switch to C++ 17 was mainly to std::any used for the generic map storage and other improvements. It came also with other benefits (eg., compacter for loops when iterating).

For the population of the random collection I had to put the three maps (auto, systems and customs colls.) into another map as otherwise there might be collisions if user defines a collection with a name which already exists in the built-in collections or defined systems. (see: `CollectionSystemManager::populateAutoCollection()`)

One minor corner case addressed: Check if the count value from the settings per system/collection is not lower than 0.

I did a good amount of testing, and I did not detect any regressions.
