### PR TITLE
Address warning when exiting screensaver

### DIFF
--- a/es-app/src/SystemScreenSaver.cpp
+++ b/es-app/src/SystemScreenSaver.cpp
@@ -205,7 +205,7 @@ void SystemScreenSaver::handleScreenSaverEditingCollection()
 		{
 			// we're exiting the screensaver, restore the currently actively editing collection
 			CollectionSystemManager::get()->exitEditMode(true);
-			if (mRegularEditingCollection != "Favorites")
+			if (mRegularEditingCollection != "Favorites" && mRegularEditingCollection != "")
 				CollectionSystemManager::get()->setEditMode(mRegularEditingCollection, true);
 			mRegularEditingCollection = "";
 		}


### PR DESCRIPTION
The latest screensaver updates were causing a harmless warning for setting an empty collection to edit.

Fixing the cause that led to the warning.