### PR TITLE
Handle cURL library deprecation for redirect options

### DIFF
--- a/es-core/src/HttpReq.cpp
+++ b/es-core/src/HttpReq.cpp
@@ -77,7 +77,13 @@ HttpReq::HttpReq(const std::string& url)
 	}
 
 	//set curl restrict redirect protocols
+	//starting with 7.85.0, CURLOPT_REDIR_PROTOCOLS is deprecated
+	// and CURLOPT_REDIR_PROTOCOLS_STR should be used instead
+#if CURL_AT_LEAST_VERSION(7,85,0)
+	err = curl_easy_setopt(mHandle, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
+#else
 	err = curl_easy_setopt(mHandle, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
 	if(err != CURLE_OK)
 	{
 		mStatus = REQ_IO_ERROR;


### PR DESCRIPTION
Starting with 7.85, `CURLOPT_REDIR_PROTOCOLS` is deprecated [1] and `CURL_REDIR_PROTOCOLS_STR` [2] should be used instead. The changes modify the option used depending on the (compile time) libcurl version.

[1] https://curl.se/libcurl/c/CURLOPT_REDIR_PROTOCOLS.html
[2] https://curl.se/libcurl/c/CURLOPT_REDIR_PROTOCOLS_STR.html

This is a proper fix instead of https://github.com/RetroPie/EmulationStation/pull/836.
Closed #836.