### PR TITLE
Update VLC Mute logic

### DIFF
--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -344,8 +344,7 @@ void VideoVlcComponent::stopVideo()
 void VideoVlcComponent::setMuteMode()
 {
 	Settings *cfg = Settings::getInstance();
-	if (!cfg->getBool("VideoAudio") || (cfg->getBool("ScreenSaverVideoMute") && mScreensaverMode))
-		libvlc_audio_set_mute(mMediaPlayer, 1);
-	else
-		libvlc_audio_set_mute(mMediaPlayer, 0);
+	if (!cfg->getBool("VideoAudio") || (cfg->getBool("ScreenSaverVideoMute") && mScreensaverMode)) {
+		libvlc_media_add_option(mMedia, ":no-audio");
+	}
 }


### PR DESCRIPTION
Per the specs, libvlc_audio_set_mute() doesn't always work.

https://videolan.videolan.me/vlc-3.0/group__libvlc__audio.html#ga438620a3c817b8b4faceb77c476b89fe

This makes it more reliable in muring the video when needed in several scenarios, including digital passthrough and when using other mixers (pipewire, etc).