### PR TITLE
Helpstyle: fix remaining inconsistent layout alignment and styling

### DIFF
--- a/es-app/src/components/ScraperSearchComponent.cpp
+++ b/es-app/src/components/ScraperSearchComponent.cpp
@@ -8,10 +8,12 @@
 #include "components/TextComponent.h"
 #include "guis/GuiMsgBox.h"
 #include "guis/GuiTextEditPopup.h"
+#include "views/ViewController.h"
 #include "resources/Font.h"
 #include "utils/StringUtil.h"
 #include "FileData.h"
 #include "Log.h"
+#include "SystemData.h"
 #include "Window.h"
 
 ScraperSearchComponent::ScraperSearchComponent(Window* window, SearchType type) : GuiComponent(window),
@@ -456,7 +458,8 @@ void ScraperSearchComponent::openInputScreen(ScraperSearchParams& params)
 	mWindow->pushGui(new GuiTextEditPopup(mWindow, "SEARCH FOR",
 		// initial value is last search if there was one, otherwise the clean path name
 		params.nameOverride.empty() ? params.game->getCleanName() : params.nameOverride,
-		searchForFunc, false, "SEARCH"));
+		searchForFunc, false, "SEARCH",
+		ViewController::get()->getState().getSystem()->getTheme()));
 }
 
 std::vector<HelpPrompt> ScraperSearchComponent::getHelpPrompts()

--- a/es-app/src/guis/GuiCollectionSystemsOptions.cpp
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.cpp
@@ -8,6 +8,7 @@
 #include "utils/StringUtil.h"
 #include "views/ViewController.h"
 #include "CollectionSystemManager.h"
+#include "SystemData.h"
 #include "Window.h"
 
 GuiCollectionSystemsOptions::GuiCollectionSystemsOptions(Window* window) : GuiComponent(window), mMenu(window, "GAME COLLECTION SETTINGS")
@@ -64,7 +65,14 @@ void GuiCollectionSystemsOptions::initializeMenu()
 		createCollection(name);
 	};
 	row.makeAcceptInputHandler([this, createCustomCollection] {
-		mWindow->pushGui(new GuiTextEditPopup(mWindow, "New Collection Name", "", createCustomCollection, false));
+		mWindow->pushGui(new GuiTextEditPopup(
+			mWindow,
+			"New Collection Name",
+			"",
+			createCustomCollection,
+			false, "OK",
+			ViewController::get()->getState().getSystem()->getTheme()
+		));
 	});
 
 	mMenu.addRow(row);
@@ -274,6 +282,13 @@ bool GuiCollectionSystemsOptions::input(InputConfig* config, Input input)
 
 
 	return false;
+}
+
+HelpStyle GuiCollectionSystemsOptions::getHelpStyle()
+{
+	HelpStyle style = HelpStyle();
+	style.applyTheme(ViewController::get()->getState().getSystem()->getTheme(), "system");
+	return style;
 }
 
 std::vector<HelpPrompt> GuiCollectionSystemsOptions::getHelpPrompts()

--- a/es-app/src/guis/GuiCollectionSystemsOptions.h
+++ b/es-app/src/guis/GuiCollectionSystemsOptions.h
@@ -17,6 +17,7 @@ public:
 	bool input(InputConfig* config, Input input) override;
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+	HelpStyle getHelpStyle() override;
 
 private:
 	void initializeMenu();

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -220,7 +220,8 @@ void GuiMenu::openUISettings()
 					LOG(LogDebug) << "Setting UI mode to " << selectedMode;
 					Settings::getInstance()->setString("UIMode", selectedMode);
 					Settings::getInstance()->saveFile();
-			}, "NO",nullptr));
+			}, "NO", nullptr,
+			"", nullptr, ViewController::get()->getState().getSystem()->getTheme()));
 		}
 	});
 
@@ -503,10 +504,14 @@ void GuiMenu::openOtherSettings()
 void GuiMenu::openConfigInput()
 {
 	Window* window = mWindow;
-	window->pushGui(new GuiMsgBox(window, "ARE YOU SURE YOU WANT TO CONFIGURE INPUT?", "YES",
+	window->pushGui(new GuiMsgBox(
+		window, "ARE YOU SURE YOU WANT TO CONFIGURE INPUT?", "YES",
 		[window] {
-		window->pushGui(new GuiDetectDevice(window, false, nullptr));
-	}, "NO", nullptr)
+			window->pushGui(new GuiDetectDevice(window, false, nullptr));
+		},
+		"NO", nullptr,
+		"", nullptr,
+		ViewController::get()->getState().getSystem()->getTheme())
 	);
 
 }
@@ -532,7 +537,13 @@ void GuiMenu::openQuitMenu()
 
 		if (confirm_quit) {
 			row.makeAcceptInputHandler([window] {
-				window->pushGui(new GuiMsgBox(window, "REALLY RESTART?", "YES", restart_es_fx, "NO", nullptr));
+				window->pushGui(new GuiMsgBox(
+					window, "REALLY RESTART?", "YES",
+					restart_es_fx,
+					"NO", nullptr,
+					"", nullptr,
+					ViewController::get()->getState().getSystem()->getTheme()
+				));
 			});
 		} else {
 			row.makeAcceptInputHandler(restart_es_fx);
@@ -550,7 +561,13 @@ void GuiMenu::openQuitMenu()
 			row.elements.clear();
 			if (confirm_quit) {
 				row.makeAcceptInputHandler([window] {
-					window->pushGui(new GuiMsgBox(window, "REALLY QUIT?", "YES", quit_es_fx, "NO", nullptr));
+					window->pushGui(new GuiMsgBox(
+						window, "REALLY QUIT?", "YES",
+						quit_es_fx,
+						"NO", nullptr,
+						"", nullptr,
+						ViewController::get()->getState().getSystem()->getTheme()
+					));
 				});
 			} else {
 				row.makeAcceptInputHandler(quit_es_fx);
@@ -571,7 +588,13 @@ void GuiMenu::openQuitMenu()
 	row.elements.clear();
 	if (confirm_quit) {
 		row.makeAcceptInputHandler([window] {
-			window->pushGui(new GuiMsgBox(window, "REALLY RESTART?", "YES", {reboot_sys_fx}, "NO", nullptr));
+			window->pushGui(new GuiMsgBox(
+				window, "REALLY RESTART?", "YES",
+				{reboot_sys_fx},
+				"NO", nullptr,
+				"", nullptr,
+				ViewController::get()->getState().getSystem()->getTheme()
+			));
 		});
 	} else {
 		row.makeAcceptInputHandler(reboot_sys_fx);
@@ -590,7 +613,13 @@ void GuiMenu::openQuitMenu()
 	row.elements.clear();
 	if (confirm_quit) {
 		row.makeAcceptInputHandler([window] {
-			window->pushGui(new GuiMsgBox(window, "REALLY SHUTDOWN?", "YES", shutdown_sys_fx, "NO", nullptr));
+			window->pushGui(new GuiMsgBox(
+				window, "REALLY SHUTDOWN?", "YES",
+				shutdown_sys_fx,
+				"NO", nullptr,
+				"", nullptr,
+				ViewController::get()->getState().getSystem()->getTheme()
+			));
 		});
 	} else {
 		row.makeAcceptInputHandler(shutdown_sys_fx);

--- a/es-app/src/guis/GuiRandomCollectionOptions.cpp
+++ b/es-app/src/guis/GuiRandomCollectionOptions.cpp
@@ -220,6 +220,13 @@ bool GuiRandomCollectionOptions::input(InputConfig* config, Input input)
 	return false;
 }
 
+HelpStyle GuiRandomCollectionOptions::getHelpStyle()
+{
+	HelpStyle style = HelpStyle();
+	style.applyTheme(ViewController::get()->getState().getSystem()->getTheme(), "system");
+	return style;
+}
+
 std::vector<HelpPrompt> GuiRandomCollectionOptions::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();

--- a/es-app/src/guis/GuiRandomCollectionOptions.h
+++ b/es-app/src/guis/GuiRandomCollectionOptions.h
@@ -27,6 +27,7 @@ public:
 	bool input(InputConfig* config, Input input) override;
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+	HelpStyle getHelpStyle() override;
 
 private:
 	void initializeMenu();

--- a/es-app/src/guis/GuiScraperMulti.cpp
+++ b/es-app/src/guis/GuiScraperMulti.cpp
@@ -143,11 +143,24 @@ void GuiScraperMulti::finish()
 			ss << "\n" << mTotalSkipped << " GAME" << ((mTotalSkipped > 1) ? "S" : "") << " SKIPPED.";
 	}
 
-	mWindow->pushGui(new GuiMsgBox(mWindow, ss.str(),
-		"OK", [&] { delete this; }));
+	mWindow->pushGui(new GuiMsgBox(
+		mWindow, ss.str(),
+		"OK", [&]
+		{ delete this; },
+		"", nullptr,
+		"", nullptr,
+		ViewController::get()->getState().getSystem()->getTheme()
+	));
 
 	mIsProcessing = false;
 	PowerSaver::resume();
+}
+
+HelpStyle GuiScraperMulti::getHelpStyle()
+{
+	HelpStyle style = HelpStyle();
+	style.applyTheme(ViewController::get()->getState().getSystem()->getTheme(), "system");
+	return style;
 }
 
 std::vector<HelpPrompt> GuiScraperMulti::getHelpPrompts()

--- a/es-app/src/guis/GuiScraperMulti.h
+++ b/es-app/src/guis/GuiScraperMulti.h
@@ -18,6 +18,7 @@ public:
 
 	void onSizeChanged() override;
 	std::vector<HelpPrompt> getHelpPrompts() override;
+	HelpStyle getHelpStyle() override;
 
 private:
 	void acceptResult(const ScraperSearchResult& result);

--- a/es-app/src/guis/GuiScraperStart.cpp
+++ b/es-app/src/guis/GuiScraperStart.cpp
@@ -119,6 +119,13 @@ bool GuiScraperStart::input(InputConfig* config, Input input)
 	return false;
 }
 
+HelpStyle GuiScraperStart::getHelpStyle()
+{
+	HelpStyle style = HelpStyle();
+	style.applyTheme(ViewController::get()->getState().getSystem()->getTheme(), "system");
+	return style;
+}
+
 std::vector<HelpPrompt> GuiScraperStart::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();

--- a/es-app/src/guis/GuiScraperStart.h
+++ b/es-app/src/guis/GuiScraperStart.h
@@ -24,6 +24,7 @@ public:
 	bool input(InputConfig* config, Input input) override;
 
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+	HelpStyle getHelpStyle() override;
 
 private:
 	void pressedStart();

--- a/es-app/src/guis/GuiScreensaverOptions.cpp
+++ b/es-app/src/guis/GuiScreensaverOptions.cpp
@@ -89,7 +89,15 @@ void GuiScreensaverOptions::addEditableTextComponent(ComponentListRow row, const
 
 	auto updateVal = [ed](const std::string& newVal) { ed->setValue(newVal); }; // ok callback (apply new value to ed)
 	row.makeAcceptInputHandler([this, label, ed, updateVal] {
-		mWindow->pushGui(new GuiTextEditPopup(mWindow, label, ed->getValue(), updateVal, false));
+		mWindow->pushGui(new GuiTextEditPopup(
+			mWindow,
+			label,
+			ed->getValue(),
+			updateVal,
+			false,
+			"OK",
+			ViewController::get()->getState().getSystem()->getTheme()
+		));
 	});
 	assert(ed);
 	addRow(row);

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -5,6 +5,8 @@
 #include "GuiComponent.h"
 #include "Log.h"
 #include "Window.h"
+#include "SystemData.h"
+#include "views/ViewController.h"
 
 //Used to display a list of options.
 //Can select one or multiple options.
@@ -123,6 +125,14 @@ private:
 			}
 
 			return GuiComponent::input(config, input);
+		}
+
+		HelpStyle getHelpStyle() override
+		{
+			HelpStyle style = HelpStyle();
+			style.applyTheme(ViewController::get()->getState().getSystem()->getTheme(), "system");
+
+			return style;
 		}
 
 		std::vector<HelpPrompt> getHelpPrompts() override
@@ -314,6 +324,14 @@ private:
 				}
 			}
 		}
+	}
+
+	HelpStyle getHelpStyle() override
+	{
+		HelpStyle style = HelpStyle();
+		style.applyTheme(ViewController::get()->getState().getSystem()->getTheme(), "system");
+
+		return style;
 	}
 
 	std::vector<HelpPrompt> getHelpPrompts() override

--- a/es-core/src/guis/GuiMsgBox.cpp
+++ b/es-core/src/guis/GuiMsgBox.cpp
@@ -5,11 +5,15 @@
 
 #define HORIZONTAL_PADDING_PX 20
 
-GuiMsgBox::GuiMsgBox(Window* window, const std::string& text,
-	const std::string& name1, const std::function<void()>& func1,
-	const std::string& name2, const std::function<void()>& func2,
-	const std::string& name3, const std::function<void()>& func3) : GuiComponent(window),
-	mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 2))
+GuiMsgBox::GuiMsgBox(Window *window, const std::string &text,
+	const std::string &name1, const std::function<void()> &func1,
+	const std::string &name2, const std::function<void()> &func2,
+	const std::string &name3, const std::function<void()> &func3,
+	const std::shared_ptr<ThemeData> &theme):
+		GuiComponent(window),
+		mBackground(window, ":/frame.png"),
+		mGrid(window, Vector2i(1, 2)),
+		mTheme(theme)
 {
 	float width = Renderer::getScreenWidth() * 0.6f; // max width
 	float minWidth = Renderer::getScreenWidth() * 0.3f; // minimum width
@@ -102,6 +106,18 @@ void GuiMsgBox::deleteMeAndCall(const std::function<void()>& func)
 	if(funcCopy)
 		funcCopy();
 
+}
+
+HelpStyle GuiMsgBox::getHelpStyle()
+{
+	if (mTheme)
+	{
+		HelpStyle style = HelpStyle();
+		style.applyTheme(mTheme, "system");
+		return style;
+	}
+
+	return GuiComponent::getHelpStyle();
 }
 
 std::vector<HelpPrompt> GuiMsgBox::getHelpPrompts()

--- a/es-core/src/guis/GuiMsgBox.h
+++ b/es-core/src/guis/GuiMsgBox.h
@@ -13,13 +13,15 @@ class GuiMsgBox : public GuiComponent
 {
 public:
 	GuiMsgBox(Window* window, const std::string& text,
-		const std::string& name1 = "OK", const std::function<void()>& func1 = nullptr,
-		const std::string& name2 = "", const std::function<void()>& func2 = nullptr,
-		const std::string& name3 = "", const std::function<void()>& func3 = nullptr);
+		const std::string &name1 = "OK", const std::function<void()> &func1 = nullptr,
+		const std::string &name2 = "", const std::function<void()> &func2 = nullptr,
+		const std::string &name3 = "", const std::function<void()> &func3 = nullptr,
+		const std::shared_ptr<ThemeData> &theme = NULL);
 
 	bool input(InputConfig* config, Input input) override;
 	void onSizeChanged() override;
 	std::vector<HelpPrompt> getHelpPrompts() override;
+	HelpStyle getHelpStyle() override;
 
 private:
 	void deleteMeAndCall(const std::function<void()>& func);
@@ -32,6 +34,7 @@ private:
 	std::vector< std::shared_ptr<ButtonComponent> > mButtons;
 	std::shared_ptr<ComponentGrid> mButtonGrid;
 	std::function<void()> mAcceleratorFunc;
+	std::shared_ptr<ThemeData> mTheme;
 };
 
 #endif // ES_CORE_GUIS_GUI_MSG_BOX_H

--- a/es-core/src/guis/GuiTextEditPopup.cpp
+++ b/es-core/src/guis/GuiTextEditPopup.cpp
@@ -4,9 +4,9 @@
 #include "components/MenuComponent.h"
 #include "components/TextEditComponent.h"
 
-GuiTextEditPopup::GuiTextEditPopup(Window* window, const std::string& title, const std::string& initValue,
-	const std::function<void(const std::string&)>& okCallback, bool multiLine, const char* acceptBtnText)
-	: GuiComponent(window), mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 3)), mMultiLine(multiLine)
+GuiTextEditPopup::GuiTextEditPopup(Window *window, const std::string &title, const std::string &initValue,
+								   const std::function<void(const std::string &)> &okCallback, bool multiLine, const char *acceptBtnText, const std::shared_ptr<ThemeData> &theme)
+	: GuiComponent(window), mBackground(window, ":/frame.png"), mGrid(window, Vector2i(1, 3)), mMultiLine(multiLine), mTheme(theme)
 {
 	addChild(&mBackground);
 	addChild(&mGrid);
@@ -63,6 +63,17 @@ bool GuiTextEditPopup::input(InputConfig* config, Input input)
 	}
 
 	return false;
+}
+
+HelpStyle GuiTextEditPopup::getHelpStyle()
+{
+	if (mTheme) {
+		HelpStyle style = HelpStyle();
+		style.applyTheme(mTheme, "system");
+		return style;
+	}
+
+	return GuiComponent::getHelpStyle();
 }
 
 std::vector<HelpPrompt> GuiTextEditPopup::getHelpPrompts()

--- a/es-core/src/guis/GuiTextEditPopup.h
+++ b/es-core/src/guis/GuiTextEditPopup.h
@@ -12,12 +12,15 @@ class TextEditComponent;
 class GuiTextEditPopup : public GuiComponent
 {
 public:
-	GuiTextEditPopup(Window* window, const std::string& title, const std::string& initValue,
-		const std::function<void(const std::string&)>& okCallback, bool multiLine, const char* acceptBtnText = "OK");
+	GuiTextEditPopup(Window *window, const std::string &title, const std::string &initValue,
+					 const std::function<void(const std::string &)> &okCallback, bool multiLine,
+					 const char *acceptBtnText = "OK", const std::shared_ptr<ThemeData> &theme = NULL);
 
 	bool input(InputConfig* config, Input input) override;
 	void onSizeChanged() override;
+
 	std::vector<HelpPrompt> getHelpPrompts() override;
+	HelpStyle getHelpStyle() override;
 
 private:
 	NinePatchComponent mBackground;
@@ -26,6 +29,7 @@ private:
 	std::shared_ptr<TextComponent> mTitle;
 	std::shared_ptr<TextEditComponent> mText;
 	std::shared_ptr<ComponentGrid> mButtonGrid;
+	std::shared_ptr<ThemeData> mTheme;
 
 	bool mMultiLine;
 };


### PR DESCRIPTION
This builds on #146.

Fixes various Help hints in the Main Menu dialog not inheriting the current theme's styling.

Sample:
I'm using the same theme for both screenshot.

Before (help hint is supposed to be centered):
![image](https://github.com/RetroPie/EmulationStation/assets/15792724/d5965871-b0e5-412c-ab70-ed4d05b14244)

After the fix:
![image](https://github.com/RetroPie/EmulationStation/assets/15792724/13d16615-f646-416f-a2a4-5899c27d3756)


Before (Comic-Book theme, help hints are unstyled):
![image](https://github.com/RetroPie/EmulationStation/assets/15792724/512ea728-050e-42d9-9cd6-55434f97c1cf)

After:
![image](https://github.com/RetroPie/EmulationStation/assets/15792724/6739e7d5-4d35-4463-b1ba-ab6e643eff47)

There are other screens with the same issues: scraper menu, deeper down the custom collection submenus, the TextEdit dialogs, etc.

Hopefully this fixes all of them.

Note: I am not really a C++ developer, so you might see some poor choices I made in code.