### PR TITLE
Fix persistence of new collections, either from theme or custom name

### DIFF
--- a/es-app/src/CollectionSystemManager.h
+++ b/es-app/src/CollectionSystemManager.h
@@ -30,6 +30,24 @@ enum CollectionSystemType
 	CUSTOM_COLLECTION
 };
 
+// Flags when loading or creating a collection
+enum class CollectionFlags : uint8_t
+{
+	NONE,        // create only
+	HOLD_IN_MAP, // create and keep in mAutoCollectionSystemsData or mCustomCollectionSystemsData
+	NEEDS_SAVE   // force save of newly added collection
+};
+
+constexpr CollectionFlags operator|(CollectionFlags a,CollectionFlags b)
+{
+    return static_cast<CollectionFlags>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
+}
+
+constexpr CollectionFlags operator&(CollectionFlags a, CollectionFlags b)
+{
+    return static_cast<CollectionFlags>(static_cast<uint8_t>(a) & static_cast<uint8_t>(b));
+}
+
 struct CollectionSystemDecl
 {
 	CollectionSystemType type; // type of system
@@ -58,7 +76,7 @@ public:
 	static CollectionSystemManager* get();
 	static void init(Window* window);
 	static void deinit();
-	void saveCustomCollection(SystemData* sys);
+	bool saveCustomCollection(SystemData* sys);
 
 	void loadCollectionSystems(bool async=false);
 	void loadEnabledListFromSettings();
@@ -74,7 +92,7 @@ public:
 	inline SystemData* getCustomCollectionsBundle() { return mCustomCollectionsBundle; };
 	inline SystemData* getRandomCollection() { return mRandomCollection; };
 	std::vector<std::string> getUnusedSystemsFromTheme();
-	SystemData* addNewCustomCollection(std::string name);
+	SystemData* addNewCustomCollection(std::string name, bool needsSave = false);
 
 	bool isThemeGenericCollectionCompatible(bool genericCustomCollections);
 	bool isThemeCustomCollectionCompatible(std::vector<std::string> stringVector);
@@ -107,7 +125,7 @@ private:
 
 	void initAutoCollectionSystems();
 	void initCustomCollectionSystems();
-	SystemData* createNewCollectionEntry(std::string name, CollectionSystemDecl sysDecl, bool index = true);
+	SystemData* createNewCollectionEntry(std::string name, CollectionSystemDecl sysDecl, const CollectionFlags flags);
 	void populateAutoCollection(CollectionSystemData* sysData);
 	void populateCustomCollection(CollectionSystemData* sysData);
 	void addRandomGames(SystemData* newSys, SystemData* sourceSystem, FileData* rootFolder, FileFilterIndex* index,


### PR DESCRIPTION
Fixes the bug in this scenario:

1. Select in _Main Menu_ -> _Game Collection Settings_ -> _Create New Custom Collection from Theme_ or _Create New Custom Collection_
2. Notice the toast which states that you are editing the custom collection now
3. Add at least one game with _Y_-Button to the collection
4. Select in _Main Menu_ -> _Game Collection Settings_ -> _Finish Editing 'xyz' Collection_
2. Notice the toast which states editing has ended
5. Quit EmulationStation via the _Main Menu_ (do not use _F4_) 
6. Restart EmulationStation

**Result**

The custom 'xyz' collection is not created, or if it was a theme based custom collection it is no longer present on the carousel.

**Expected result**

After restart/reboot, the new collection is still available/present in ES and contains the games added before.

**Additional Notes**

- The collection is persisted as soon as _end editing_ is selected and not only in the destructor of the CustomCollectionManager class. 
- It fixes also a cornercase when the filename index on collection name collisions has two digits (index 10 or above)  (the added infix " (n)" is then longer than 4 characters.
- It inhibits also the editing of second, third, ... custom collection before the first one is closed (end editing):
The _end editing_ is now shown instead of the new custom collection entries to emphasise this.

Hope you can reconstruct the issue.
Any Qs, please let me know.