### PR TITLE
Some WIN32 updates

### DIFF
--- a/.github/workflows/win32.yml
+++ b/.github/workflows/win32.yml
@@ -27,14 +27,14 @@ jobs:
       # Check-out repository under $GITHUB_WORKSPACE
       # https://github.com/actions/checkout
       - name: Check-out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
       # Discover location of MSBuild tool and to PATH environment variables
       # https://github.com/microsoft/setup-msbuild
       - name: Locate MSBuild
-        uses: microsoft/setup-msbuild@v1.3.1
+        uses: microsoft/setup-msbuild@v2
 
       # Use NuGet to download the latest libVLC.
       - name: Download libVLC
@@ -130,7 +130,7 @@ jobs:
       # Uploads artifacts from workflow
       # https://github.com/actions/upload-artifact
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: EmulationStation
           path: |

--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -120,6 +120,7 @@ set(ES_SOURCES
 if(MSVC)
     LIST(APPEND ES_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/EmulationStation.rc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/EmulationStation.manifest
     )
 endif()
 

--- a/es-app/src/EmulationStation.manifest
+++ b/es-app/src/EmulationStation.manifest
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<assembly manifestVersion='1.0' xmlns='urn:schemas-microsoft-com:asm.v1'>
+	<application>
+		<windowsSettings>
+			<dpiAwareness xmlns='http://schemas.microsoft.com/SMI/2016/WindowsSettings'>PerMonitorV2</dpiAwareness>
+			<activeCodePage xmlns='http://schemas.microsoft.com/SMI/2019/WindowsSettings'>UTF-8</activeCodePage>
+		</windowsSettings>
+	</application>
+</assembly>

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -280,10 +280,12 @@ void FileData::launchGame(Window* window)
 {
 	LOG(LogInfo) << "Attempting to launch game...";
 
+#ifndef _WIN32
 	AudioManager::getInstance()->deinit();
 	VolumeControl::getInstance()->deinit();
 	InputManager::getInstance()->deinit();
 	window->deinit();
+#endif
 
 	std::string command = mEnvData->mLaunchCommand;
 
@@ -299,7 +301,7 @@ void FileData::launchGame(Window* window)
 	Scripting::fireEvent("game-start", rom, basename, name);
 
 	LOG(LogInfo) << "	" << command;
-	int exitCode = runSystemCommand(command);
+	int exitCode = launchGameCommand(command);
 
 	if(exitCode != 0)
 	{
@@ -308,10 +310,12 @@ void FileData::launchGame(Window* window)
 
 	Scripting::fireEvent("game-end");
 
+#ifndef _WIN32
 	window->init();
 	InputManager::getInstance()->init();
 	VolumeControl::getInstance()->init();
 	window->normalizeNextUpdate();
+#endif
 
 	//update number of times the game has been launched
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -522,6 +522,7 @@ void GuiMenu::openQuitMenu()
 	ComponentListRow row;
 	if (UIModeController::getInstance()->isUIModeFull())
 	{
+#ifndef _WIN32
 		auto static restart_es_fx = []() {
 			Scripting::fireEvent("quit");
 			if (quitES(QuitMode::RESTART)) {
@@ -538,6 +539,7 @@ void GuiMenu::openQuitMenu()
 		}
 		row.addElement(std::make_shared<TextComponent>(window, "RESTART EMULATIONSTATION", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
 		s->addRow(row);
+#endif
 
 		if(Settings::getInstance()->getBool("ShowExit"))
 		{

--- a/es-core/src/Scripting.cpp
+++ b/es-core/src/Scripting.cpp
@@ -30,12 +30,10 @@ namespace Scripting
         for(std::list<std::string>::const_iterator dirIt = scriptDirList.cbegin(); dirIt != scriptDirList.cend(); ++dirIt) {
             std::list<std::string> scripts = Utils::FileSystem::getDirContent(*dirIt);
             for (std::list<std::string>::const_iterator it = scripts.cbegin(); it != scripts.cend(); ++it) {
-#ifndef WIN32 // osx / linux
                 if (!Utils::FileSystem::isExecutable(*it)) {
                     LOG(LogWarning) << *it << " is not executable. Review file permissions.";
                     continue;
                 }
-#endif
                 std::string script = *it;
                 if (arg1.length() > 0) {
                     script += " \"" + arg1 + "\"";

--- a/es-core/src/platform.h
+++ b/es-core/src/platform.h
@@ -17,7 +17,8 @@ enum QuitMode
 	REBOOT = 3
 };
 
-int runSystemCommand(const std::string& cmd_utf8); // run a utf-8 encoded in the shell (requires wstring conversion on Windows)
+int runSystemCommand(const std::string& cmd_utf8); // run a utf-8 encoded in the shell
+int launchGameCommand(const std::string& cmd_utf8);
 int quitES(QuitMode mode = QuitMode::QUIT);
 void processQuitMode();
 

--- a/es-core/src/utils/FileSystemUtil.h
+++ b/es-core/src/utils/FileSystemUtil.h
@@ -39,9 +39,7 @@ namespace Utils
 		bool        isDirectory        (const std::string& _path);
 		bool        isSymlink          (const std::string& _path);
 		bool        isHidden           (const std::string& _path);
-#if !defined(_WIN32)
 		bool        isExecutable       (const std::string& _path);
-#endif // !_WIN32
 
 	} // FileSystem::
 


### PR DESCRIPTION
I would like to suggest some improvements for Windows.
* Version bump of workflow actions
* Add manifest file
  * Set activeCodePage to UTF-8 (This allows to remove the wstring conversion in the source)
  * High DPI support
* Improve window processing when starting the game (so that the emulator screen comes to the foreground, and ES comes to the foreground when the emulator is closed)
* "Restart ES" in the exit menu was removed because it does not work on Windows that is not started from script
* Utils::FileSystem::isExecutable() determined by the file *extension* on Windows
I mind affect as little as possible with mainstream Raspberry Pi builds.
