### PR TITLE
Add %ROM_DIR%, %ES_CFG% tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ The following "tags" are replaced by ES in launch commands:
 
 `%ROM_RAW%`	- Replaced with the unescaped, absolute path to the selected ROM.  If your emulator is picky about paths, you might want to use this instead of %ROM%, but enclosed in quotes.
 
+`%ROM_DIR%`	- Replaced with the dirname (except "/base.ext") of the selected ROM. Use this when you need to chdir to the directory where the ROM.
+
+`%ES_CFG%`	- Replaced with the directory path of the EmulationStation configuration file contains (i.e. your .emulationstation directory). If .emulationstation is symlink, the link will resolved.
+
 See [SYSTEMS.md](SYSTEMS.md) for some live examples in EmulationStation.
 
 gamelist.xml

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -291,10 +291,14 @@ void FileData::launchGame(Window* window)
 	const std::string basename = Utils::FileSystem::getStem(getPath());
 	const std::string rom_raw  = Utils::FileSystem::getPreferredPath(getPath());
 	const std::string name     = getName();
+	const std::string rom_dir  = Utils::FileSystem::getPreferredPath(Utils::FileSystem::getParent(getPath()));
+	const std::string es_cfg   = Utils::FileSystem::getPreferredPath(Utils::FileSystem::getCanonicalPath(Utils::FileSystem::getHomePath() + "/.emulationstation"));
 
 	command = Utils::String::replace(command, "%ROM%", rom);
 	command = Utils::String::replace(command, "%BASENAME%", basename);
 	command = Utils::String::replace(command, "%ROM_RAW%", rom_raw);
+	command = Utils::String::replace(command, "%ROM_DIR%", rom_dir);
+	command = Utils::String::replace(command, "%ES_CFG%", es_cfg);
 
 	Scripting::fireEvent("game-start", rom, basename, name);
 


### PR DESCRIPTION
Add %ROM_DIR%, %ES_CFG% tags in launch commands.

`%ROM_DIR%`	- Replaced with the dirname (except "/base.ext") of the selected ROM. Use this when you need to chdir to the directory where the ROM.

`%ES_CFG%`	- Replaced with the directory path of the EmulationStation configuration file contains (i.e. your .emulationstation directory). If .emulationstation is symlink, the link will resolved.
