### PR TITLE
Fix Font (texture) handling

### DIFF
--- a/es-core/src/resources/Font.cpp
+++ b/es-core/src/resources/Font.cpp
@@ -76,6 +76,7 @@ Font::Font(int size, const std::string& path) : mSize(size), mPath(path)
 {
 	assert(mSize > 0);
 
+	mTextures.reserve(10);
 	mLoaded = true;
 	mMaxGlyphHeight = 0;
 
@@ -209,6 +210,13 @@ void Font::getTextureForNewGlyph(const Vector2i& glyphSize, FontTexture*& tex_ou
 		// will this one work?
 		if(tex_out->findEmpty(glyphSize, cursor_out))
 			return; // yes
+	}
+
+	if(mTextures.size() >= mTextures.capacity())
+	{
+		LOG(LogError) << "Glyph too many to create a new texture!";
+		tex_out = NULL;
+		return;
 	}
 
 	// current textures are full,
@@ -684,7 +692,7 @@ TextCache* Font::buildTextCache(const std::string& text, Vector2f offset, unsign
 	unsigned int i = 0;
 	for(auto it = vertMap.cbegin(); it != vertMap.cend(); it++)
 	{
-		TextCache::VertexList& vertList = cache->vertexLists.at(i);
+		TextCache::VertexList& vertList = cache->vertexLists.at(i++);
 
 		vertList.textureIdPtr = &it->first->textureId;
 		vertList.verts = it->second;


### PR DESCRIPTION
When ES renders characters on the screen, it first uploads the glyphs to a texture and caches them.
The size of each texture is 2048x512, and when one is used up, allocate another texture and used.
If you are an alphabetic region, you probably won't need multiple textures.
For example users East Asian countries who use Chinese characters, one texture is often not enough.
(This is even more noticeable on high-resolution displays, where one character has more pixels.)
When this happens, ES will not work properly. This PR will fix this.

---

In `TextComponent`, the *text* to be drawn is stored in the `TextCache`.
If the glyphs used in the *text* span multiple textures for the reasons mentioned above, there will be more than one `VertexList` holding the *vertices* and *textureId*.
This is constructed by `Font::buildTextCache()`, and the result of the calculation is set to *cache->vertexLists* at the end of the function, but the increment of `i` is forgotten and it is only stored in the *first* element.
As a result, ES will abort. I will correct this by incrementing `i` appropriately.

However, this alone will not result in correct drawing.

Because, when (reasons mentioned above) a new texture is pushed back into `mTextures`, reallocation occurs when the `std::vector` is resized elements, and the texture is destroyed even if it is in use.
`FontTexture` has a default copy ctor and dtor, so they are called when reallocate.
The ctor simply copies the members, and the dtor destroys the associated texture.
...Oh, I just wanted to reallocate it, but it destroyed the texture!

I considered defining an appropriate copy constructor to fix this, but unfortunately `mTextures[].textureId` is referenced by pointer from the `TextCache`'s `vertexLists`, so even if I did that, it would be necessary to update the `TextCache`'s pointer every time `mTextures` is reallocated.

It's a bit of a hasty job, but I reserved 10 elements when generating the `Font` to prevent rearrangement. I think 10 is a sufficient number even in kanji-using countries.
I also set up a guard to prevent any attempt to exceed 10.
