### PR TITLE
Add new option --monitor

### DIFF
--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -52,7 +52,18 @@ bool parseArgs(int argc, char* argv[])
 
 	for(int i = 1; i < argc; i++)
 	{
-		if(strcmp(argv[i], "--resolution") == 0)
+		if(strcmp(argv[i], "--monitor") == 0)
+		{
+			if (i >= argc - 1)
+			{
+				std::cerr << "Invalid monitor supplied.";
+				return false;
+			}
+
+			int monitor = atoi(argv[i + 1]);
+			i++; // skip the argument value
+			Settings::getInstance()->setInt("MonitorID", monitor);
+		}else if(strcmp(argv[i], "--resolution") == 0)
 		{
 			if(i >= argc - 2)
 			{
@@ -182,6 +193,7 @@ bool parseArgs(int argc, char* argv[])
 				"--screenoffset X Y             move the canvas by x,y pixels\n"
 				"--fullscreen-borderless        borderless fullscreen window\n"
 				"--windowed                     not fullscreen, should be used with --resolution\n"
+				"--monitor N                    monitor index (0-)\n"
 				"\nGame and settings visibility in ES and behaviour of ES:\n"
 				"--force-disable-filters        force the UI to ignore applied filters on\n"
 				"                               gamelist (p)\n"

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -13,27 +13,28 @@ Settings* Settings::sInstance = NULL;
 // these values are NOT saved to es_settings.xml
 // since they're set through command-line arguments, and not the in-program settings menu
 std::vector<const char*> settings_dont_save {
-	 "Debug" ,
-	 "DebugGrid" ,
-	 "DebugText" ,
-	 "DebugImage" ,
-	 "ForceKid" ,
-	 "ForceKiosk" ,
-	 "IgnoreGamelist" ,
-	 "HideConsole" ,
-	 "ShowExit" ,
-	 "ConfirmQuit" ,
-	 "SplashScreen" ,
-	 "VSync" ,
-	 "FullscreenBorderless" ,
-	 "Windowed" ,
-	 "WindowWidth" ,
-	 "WindowHeight" ,
-	 "ScreenWidth" ,
-	 "ScreenHeight" ,
-	 "ScreenOffsetX" ,
-	 "ScreenOffsetY" ,
-	 "ScreenRotate"
+	"Debug",
+	"DebugGrid",
+	"DebugText",
+	"DebugImage",
+	"ForceKid",
+	"ForceKiosk",
+	"IgnoreGamelist",
+	"HideConsole",
+	"ShowExit",
+	"ConfirmQuit",
+	"SplashScreen",
+	"VSync",
+	"FullscreenBorderless",
+	"Windowed",
+	"WindowWidth",
+	"WindowHeight",
+	"ScreenWidth",
+	"ScreenHeight",
+	"ScreenOffsetX",
+	"ScreenOffsetY",
+	"ScreenRotate",
+	"MonitorID"
 };
 
 Settings::Settings()
@@ -178,6 +179,7 @@ void Settings::setDefaults()
 	mIntMap["ScreenOffsetX"] = 0;
 	mIntMap["ScreenOffsetY"] = 0;
 	mIntMap["ScreenRotate"]  = 0;
+	mIntMap["MonitorID"] = 0;
 
 	mBoolMap["UseFullscreenPaging"] = false;
 

--- a/es-core/src/renderers/Renderer.cpp
+++ b/es-core/src/renderers/Renderer.cpp
@@ -75,8 +75,14 @@ namespace Renderer
 
 		initialCursorState = (SDL_ShowCursor(0) != 0);
 
+		int displayIndex = Settings::getInstance()->getInt("MonitorID");
+
+		if(displayIndex < 0 || displayIndex >= SDL_GetNumVideoDisplays()){
+			displayIndex = 0;
+		}
+
 		SDL_DisplayMode dispMode;
-		SDL_GetDesktopDisplayMode(0, &dispMode);
+		SDL_GetDesktopDisplayMode(displayIndex, &dispMode);
 		windowWidth   = Settings::getInstance()->getInt("WindowWidth")   ? Settings::getInstance()->getInt("WindowWidth")   : dispMode.w;
 		windowHeight  = Settings::getInstance()->getInt("WindowHeight")  ? Settings::getInstance()->getInt("WindowHeight")  : dispMode.h;
 		screenWidth   = Settings::getInstance()->getInt("ScreenWidth")   ? Settings::getInstance()->getInt("ScreenWidth")   : windowWidth;
@@ -89,7 +95,7 @@ namespace Renderer
 
 		const unsigned int windowFlags = (Settings::getInstance()->getBool("Windowed") ? 0 : (Settings::getInstance()->getBool("FullscreenBorderless") ? SDL_WINDOW_BORDERLESS : SDL_WINDOW_FULLSCREEN)) | getWindowFlags();
 
-		if((sdlWindow = SDL_CreateWindow("EmulationStation", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, windowWidth, windowHeight, windowFlags)) == nullptr)
+		if((sdlWindow = SDL_CreateWindow("EmulationStation", SDL_WINDOWPOS_UNDEFINED_DISPLAY(displayIndex), SDL_WINDOWPOS_UNDEFINED_DISPLAY(displayIndex), windowWidth, windowHeight, windowFlags)) == nullptr)
 		{
 			LOG(LogError) << "Error creating SDL window!\n\t" << SDL_GetError();
 			return false;


### PR DESCRIPTION
Raspberry Pi 4 and later models are equipped dual HDMI out, so some people may be able to connect multiple displays and play games.
While there may be a minority using EmulationStation on Windows, there are many more who have multiple displays.
Therefore, I suggest adding the command line option `--monitor N`.
`N` is an integer specifying the display index. It defaults to 0, which is the current behavior. (The 0 origin is to match the SDL API.)
In addition, the option names and setting identifiers were based on Batocera.
