### PR TITLE
Fix audio stuttering when first playing a sound

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -311,6 +311,7 @@ void FileData::launchGame(Window* window)
 	window->init();
 	InputManager::getInstance()->init();
 	VolumeControl::getInstance()->init();
+	AudioManager::getInstance()->init();
 	window->normalizeNextUpdate();
 
 	//update number of times the game has been launched

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -17,6 +17,7 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include "SystemScreenSaver.h"
+#include "AudioManager.h"
 #include <SDL_events.h>
 #include <SDL_main.h>
 #include <SDL_timer.h>
@@ -395,6 +396,7 @@ int main(int argc, char* argv[])
 		window.renderLoadingScreen("Done.");
 
 	InputManager::getInstance()->init();
+	AudioManager::getInstance()->init();
 
 	//choose which GUI to open depending on if an input configuration already exists
 	if(errorMsg == NULL)
@@ -467,6 +469,7 @@ int main(int argc, char* argv[])
 	while(window.peekGui() != ViewController::get())
 		delete window.peekGui();
 
+	AudioManager::getInstance()->deinit();
 	InputManager::getInstance()->deinit();
 	window.deinit();
 


### PR DESCRIPTION
Have you ever had a strange first sound (such as moving the cursor) after starting up ES?
It might not be rumbling, it might sound fuzzing, etc.
I wanted to get rid of that stuttering.

---

A bit of research, I found seemed like `AudioManager` wasn't initialized until the moment just before something was played.
`AudioManager` is initialized just before the first sound is played. and I assumed this issue was caused by the first sound played in an unstable moment.
So I changed it so that initialization takes place before the first sound is played, before the ES main loop.
