### PR TITLE
Directory interpreted as file

### DIFF
--- a/GAMELISTS.md
+++ b/GAMELISTS.md
@@ -75,7 +75,8 @@ Things to be Aware Of
 
 * If a value matches the default for a particular piece of metadata, ES will not write it to the gamelist.xml (for example, if `genre` isn't specified, ES won't write an empty genre tag; if `players` is 1, ES won't write a `players` tag).
 
-* A `game` can actually point to a folder/directory if the the folder has a matching extension.
+* A `game` can actually point to a folder/directory if the the folder has a matching extension. It shows up as a game in ES.
+When launch this, if there is a file with the same name as the folder in that folder, that file will be passed to the command as `%ROM%`. Otherwise, just the directory path is passed.
 
 * `folder` metadata will only be used if a game is found inside of that folder.
 

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -287,9 +287,17 @@ void FileData::launchGame(Window* window)
 
 	std::string command = mEnvData->mLaunchCommand;
 
-	const std::string rom      = Utils::FileSystem::getEscapedPath(getPath());
-	const std::string basename = Utils::FileSystem::getStem(getPath());
-	const std::string rom_raw  = Utils::FileSystem::getPreferredPath(getPath());
+	std::string path = getPath();
+	if(Utils::FileSystem::isDirectory(path))
+	{
+		const std::string path2 = Utils::FileSystem::resolveRelativePath(Utils::FileSystem::getFileName(path), path, false, true);
+		if(Utils::FileSystem::isRegularFile(path2))
+			path = path2;
+	}
+
+	const std::string rom      = Utils::FileSystem::getEscapedPath(path);
+	const std::string basename = Utils::FileSystem::getStem(path);
+	const std::string rom_raw  = Utils::FileSystem::getPreferredPath(path);
 	const std::string name     = getName();
 
 	command = Utils::String::replace(command, "%ROM%", rom);


### PR DESCRIPTION
Adds behavior like es-de's "Directories interpreted as files"

---
(Background)
How do you handle games that consist of multiple media (disc/disk) in ES?

Commonly known method is to make ES recognize `.m3u`/`.cmd`/etc. and, since it would be inconvenient if individual media were displayed in the game list, to give them extensions that ES does not recognize, such as `.cd1` `.cd2`.

However, this method requires the media file extension to be uncommon, which can cause problems with programs such as `lr-np2kai`, which determine the media file type by the extension.
(For example, `lr-np2kai` has each own processing for file extensions such as `.d88`, `.fdd`, `.nfd`, etc., and if you change these to `.fd1` `.fd2`, it will not work correctly)

Other methods that have been devised include making media files you don't want to display hidden files beginning with ".", or storing them in a directory other than the one ES searches for, but I think both of these methods make management complicated and unintuitive.

---
(Suggestion)
es-de (not sure if it's the original) have a simple solution.

Create a directory and store the media files and launch files such as `.m3u` or `.cmd` in it.
There is no need to change the extension or make the file hidden, and you can store any other file you like in it.
Then name the directory to the same name (including extension) as the file in the folder you want to launch.
This folder will then appear as a game in ES, and when you launch the game, the file to be launched inside it will be passed to the command as `%ROM%`.

All other behavior are the same as before.

I set up a directory around this concept and tested it on a Raspberry Pi and Windows build, and it managed PC-98 and X68000 games as expected.

I hope this will help you manage your treasured library.
