### PR TITLE
Detecting DS4 and Anbernic P01 analog triggers

### DIFF
--- a/es-core/src/guis/GuiInputConfig.cpp
+++ b/es-core/src/guis/GuiInputConfig.cpp
@@ -342,27 +342,39 @@ bool GuiInputConfig::filterTrigger(Input input, InputConfig* config, int inputId
 #if defined(__linux__)
 	// on Linux, some gamepads return both an analog axis and a digital button for the trigger;
 	// we want the analog axis only, so this function removes the button press event
+	bool isPlaystation = (
+		// match PlayStation joystick with 6 axes only
+		strstr(config->getDeviceName().c_str(), "PLAYSTATION") != NULL
+		|| strstr(config->getDeviceName().c_str(), "Sony Interactive") != NULL // Official dualshock 4
+		|| strstr(config->getDeviceName().c_str(), "PS3 Ga") != NULL
+		|| strstr(config->getDeviceName().c_str(), "PS(R) Ga") != NULL
+		// BigBen kid's PS3 gamepad 146b:0902, matched on SDL GUID because its name "Bigben Interactive Bigben Game Pad" may be too generic
+		|| strcmp(config->getDeviceGUIDString().c_str(), "030000006b1400000209000011010000") == 0
+	);
+	bool isAnbernic = (
+		strcmp(config->getDeviceGUIDString().c_str(), "03004ab1020500000913000010010000") == 0 // Anbernic RG P01 has same issue
+	);
 
-	if((
-	  // match PlayStation joystick with 6 axes only
-	  strstr(config->getDeviceName().c_str(), "PLAYSTATION") != NULL
-	  || strstr(config->getDeviceName().c_str(), "PS3 Ga") != NULL
-	  || strstr(config->getDeviceName().c_str(), "PS(R) Ga") != NULL
-	  // BigBen kid's PS3 gamepad 146b:0902, matched on SDL GUID because its name "Bigben Interactive Bigben Game Pad" may be too generic
-	  || strcmp(config->getDeviceGUIDString().c_str(), "030000006b1400000209000011010000") == 0
-	  ) && InputManager::getInstance()->getAxisCountByDevice(config->getDeviceId()) == 6)
+	if((isPlaystation || isAnbernic) 
+		&& InputManager::getInstance()->getAxisCountByDevice(config->getDeviceId()) == 6)
 	{
 		// digital triggers are unwanted
-		if(input.type == TYPE_BUTTON && (input.id == 6 || input.id == 7))
+		if((
+			(isPlaystation && (input.id == 6 || input.id == 7))
+			|| (isAnbernic && (input.id == 8 || input.id == 9))
+			) && input.type == TYPE_BUTTON)
 		{
 			mHoldingInput = false;
 			return true;
 		}
 	}
 
-	// ignore negative pole for axes 2/5 only when triggers are being configured
-	if(input.type == TYPE_AXIS && (input.id == 2 || input.id == 5))
+	bool genericTrigger = !isAnbernic && (input.id == 2 || input.id == 5);
+	bool anbernicTrigger = isAnbernic && (input.id == 4 || input.id == 5);
+	// ignore negative pole for axes only when triggers are being configured
+	if(input.type == TYPE_AXIS && (genericTrigger || anbernicTrigger))
 	{
+		
 		if(strstr(GUI_INPUT_CONFIG_LIST[inputId].name, "Trigger") != NULL)
 		{
 			if(input.value == 1)


### PR DESCRIPTION
Both original Dualshock 4 and newly released Anbernic RG P01 aren't detected by the `filterTrigger` function.
With this, both triggers get registered as their respective positive axes.
Also considering that for some reason, the RG P01 has their triggers on axes 4 and 5 instead of 2 and 5.