### PR TITLE
cmake: update supported versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5...4.0)
 # Note: Visual Studio 2022 generator requires CMake 3.21 or greater.
 
 option(GLES "Set to ON if targeting Embedded OpenGL" ${GLES})


### PR DESCRIPTION
Enable a version range to support both older and the new (4) versions of CMake. This mirrors the `pugixml` supported versions modified by the recent update.

CMake 3.5 is the minimum version, which seems quite reasonable given that:

 - Debian Buster included version 3.14 (the Raspbian version includes `cmake` 3.16.3, which is what's included in our current image).
 - Ubuntu 18.04 (now out of mainstream support) has `cmake` 3.10 included.
 - RHEL 8 (and downstream Rocky/AlmaLinux/Centos) comes with `cmake` 3.11

Version 3.5 was released 9 years ago.

Closes #892 