### PR TITLE
Fix #641: Main menu and game list options menu now loop. 

### DIFF
--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -13,7 +13,7 @@
 #include "components/TextListComponent.h"
 
 GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : GuiComponent(window),
-	mSystem(system), mMenu(window, "OPTIONS"), mFromPlaceholder(false), mFiltersChanged(false),
+	mSystem(system), mMenu(window, "OPTIONS", Font::get(FONT_SIZE_LARGE), LIST_ALWAYS_LOOP), mFromPlaceholder(false), mFiltersChanged(false),
 	mJumpToSelected(false), mMetadataChanged(false)
 {
 	addChild(&mMenu);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -23,7 +23,7 @@
 #include "views/gamelist/IGameListView.h"
 #include "guis/GuiInfoPopup.h"
 
-GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MENU"), mVersion(window)
+GuiMenu::GuiMenu(Window* window) : GuiComponent(window), mMenu(window, "MAIN MENU", Font::get(FONT_SIZE_LARGE), LIST_ALWAYS_LOOP), mVersion(window)
 {
 	bool isFullUI = UIModeController::getInstance()->isUIModeFull();
 

--- a/es-core/src/components/ComponentList.cpp
+++ b/es-core/src/components/ComponentList.cpp
@@ -2,7 +2,7 @@
 
 #define TOTAL_HORIZONTAL_PADDING_PX 20
 
-ComponentList::ComponentList(Window* window) : IList<ComponentListRow, void*>(window, LIST_SCROLL_STYLE_SLOW, LIST_NEVER_LOOP)
+ComponentList::ComponentList(Window* window, ListLoopType loop_type) : IList<ComponentListRow, void*>(window, LIST_SCROLL_STYLE_SLOW, loop_type)
 {
 	mSelectorBarOffset = 0;
 	mCameraOffset = 0;

--- a/es-core/src/components/ComponentList.h
+++ b/es-core/src/components/ComponentList.h
@@ -46,7 +46,7 @@ struct ComponentListRow
 class ComponentList : public IList<ComponentListRow, void*>
 {
 public:
-	ComponentList(Window* window);
+	ComponentList(Window* window, ListLoopType loop_type = LIST_NEVER_LOOP);
 
 	void addRow(const ComponentListRow& row, bool setCursorHere = false);
 

--- a/es-core/src/components/MenuComponent.cpp
+++ b/es-core/src/components/MenuComponent.cpp
@@ -7,7 +7,7 @@
 
 #define TITLE_HEIGHT (mTitle->getFont()->getLetterHeight() + TITLE_VERT_PADDING)
 
-MenuComponent::MenuComponent(Window* window, const char* title, const std::shared_ptr<Font>& titleFont) : GuiComponent(window),
+MenuComponent::MenuComponent(Window* window, const char* title, const std::shared_ptr<Font>& titleFont, ListLoopType loop_type) : GuiComponent(window),
 	mBackground(window), mGrid(window, Vector2i(1, 3))
 {
 	addChild(&mBackground);
@@ -23,7 +23,7 @@ MenuComponent::MenuComponent(Window* window, const char* title, const std::share
 	mGrid.setEntry(mTitle, Vector2i(0, 0), false);
 
 	// set up list which will never change (externally, anyway)
-	mList = std::make_shared<ComponentList>(mWindow);
+	mList = std::make_shared<ComponentList>(mWindow, loop_type);
 	mGrid.setEntry(mList, Vector2i(0, 1), true);
 
 	updateGrid();

--- a/es-core/src/components/MenuComponent.h
+++ b/es-core/src/components/MenuComponent.h
@@ -19,7 +19,7 @@ std::shared_ptr<ImageComponent> makeArrow(Window* window);
 class MenuComponent : public GuiComponent
 {
 public:
-	MenuComponent(Window* window, const char* title, const std::shared_ptr<Font>& titleFont = Font::get(FONT_SIZE_LARGE));
+	MenuComponent(Window* window, const char* title, const std::shared_ptr<Font>& titleFont = Font::get(FONT_SIZE_LARGE), ListLoopType loop_type = LIST_NEVER_LOOP);
 
 	void onSizeChanged() override;
 


### PR DESCRIPTION
Main menu and game list options menu now loop, so when you are on top menu item and push "up" button you go to last menu item, and from last you go to the first item.

Added new default parameter `ListLoopType loop_type = LIST_NEVER_LOOP` to ComponentList and MenuComponent constructors, and use it in GuiGamelistOptions and GuiMenu.