### PR TITLE
async metadata images reading

### DIFF
--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -1,6 +1,11 @@
 #include "Gamelist.h"
 
+#include <algorithm>
 #include <chrono>
+#include <fstream>
+#include <future>
+#include <mutex>
+#include <sstream>
 
 #include "utils/FileSystemUtil.h"
 #include "FileData.h"
@@ -9,6 +14,11 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include <pugixml.hpp>
+#include <unordered_map>
+
+// Async gamelist write infrastructure
+static std::mutex sGamelistWriteMutex;
+static std::vector<std::future<void>> sGamelistPendingWrites;
 
 FileData* findOrCreateFile(SystemData* system, const std::string& path, FileType type)
 {
@@ -292,6 +302,7 @@ void updateGamelist(SystemData* system)
 					if(!pathNode)
 					{
 						LOG(LogError) << "<" << tag << "> node contains no <path> child!";
+						fileNode = nextNode;
 						continue;
 					}
 
@@ -325,22 +336,59 @@ void updateGamelist(SystemData* system)
 		// now write the file
 
 		if (numUpdated > 0) {
-			const auto startTs = std::chrono::system_clock::now();
-
 			//make sure the folders leading up to this path exist (or the write will fail)
 			std::string xmlWritePath(system->getGamelistPath(true));
 			Utils::FileSystem::createDirectory(Utils::FileSystem::getParent(xmlWritePath));
 
 			LOG(LogInfo) << "Added/Updated " << numUpdated << " entities in '" << xmlReadPath << "'";
 
-			if (!doc.save_file(xmlWritePath.c_str())) {
-				LOG(LogError) << "Error saving gamelist.xml to \"" << xmlWritePath << "\" (for system " << system->getName() << ")!";
-			}
+			// Serialize the XML document to a string on the main thread,
+			// then write the string to file on a background thread to
+			// avoid blocking the UI on slow NAS I/O.
+			std::stringstream ss;
+			doc.save(ss);
+			std::string xmlContent = ss.str();
+			std::string sysName = system->getName();
 
-			const auto endTs = std::chrono::system_clock::now();
-			LOG(LogInfo) << "Saved gamelist.xml for system \"" << system->getName() << "\" in " << std::chrono::duration_cast<std::chrono::milliseconds>(endTs - startTs).count() << " ms";
+			{
+				// Clean up finished futures
+				std::lock_guard<std::mutex> lock(sGamelistWriteMutex);
+				sGamelistPendingWrites.erase(
+					std::remove_if(sGamelistPendingWrites.begin(), sGamelistPendingWrites.end(),
+						[](std::future<void>& f) {
+							return f.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+						}),
+					sGamelistPendingWrites.end());
+
+				sGamelistPendingWrites.push_back(std::async(std::launch::async,
+					[xmlContent, xmlWritePath, sysName]() {
+						const auto startTs = std::chrono::system_clock::now();
+
+						std::ofstream outFile(xmlWritePath, std::ios::out | std::ios::trunc);
+						if (outFile.is_open()) {
+							outFile << xmlContent;
+							outFile.close();
+						} else {
+							LOG(LogError) << "Error saving gamelist.xml to \"" << xmlWritePath << "\" (for system " << sysName << ")!";
+						}
+
+						const auto endTs = std::chrono::system_clock::now();
+						LOG(LogInfo) << "Saved gamelist.xml for system \"" << sysName << "\" in " << std::chrono::duration_cast<std::chrono::milliseconds>(endTs - startTs).count() << " ms";
+					}));
+			}
 		}
 	}else{
 		LOG(LogError) << "Found no root folder for system \"" << system->getName() << "\"!";
 	}
+}
+
+void waitForGamelistWrites()
+{
+	std::lock_guard<std::mutex> lock(sGamelistWriteMutex);
+	for (auto& f : sGamelistPendingWrites)
+	{
+		if (f.valid())
+			f.wait();
+	}
+	sGamelistPendingWrites.clear();
 }

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -342,39 +342,50 @@ void updateGamelist(SystemData* system)
 
 			LOG(LogInfo) << "Added/Updated " << numUpdated << " entities in '" << xmlReadPath << "'";
 
-			// Serialize the XML document to a string on the main thread,
-			// then write the string to file on a background thread to
-			// avoid blocking the UI on slow NAS I/O.
-			std::stringstream ss;
-			doc.save(ss);
-			std::string xmlContent = ss.str();
-			std::string sysName = system->getName();
-
+			if (!Settings::getInstance()->getBool("AsyncFileIO"))
 			{
-				// Clean up finished futures
-				std::lock_guard<std::mutex> lock(sGamelistWriteMutex);
-				sGamelistPendingWrites.erase(
-					std::remove_if(sGamelistPendingWrites.begin(), sGamelistPendingWrites.end(),
-						[](std::future<void>& f) {
-							return f.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
-						}),
-					sGamelistPendingWrites.end());
+				const auto startTs = std::chrono::system_clock::now();
+				if (!doc.save_file(xmlWritePath.c_str()))
+					LOG(LogError) << "Error saving gamelist.xml to \"" << xmlWritePath << "\" (for system " << system->getName() << ")!";
+				const auto endTs = std::chrono::system_clock::now();
+				LOG(LogInfo) << "Saved gamelist.xml for system \"" << system->getName() << "\" in " << std::chrono::duration_cast<std::chrono::milliseconds>(endTs - startTs).count() << " ms";
+			}
+			else
+			{
+				// Serialize the XML document to a string on the main thread,
+				// then write the string to file on a background thread to
+				// avoid blocking the UI on slow NAS I/O.
+				std::stringstream ss;
+				doc.save(ss);
+				std::string xmlContent = ss.str();
+				std::string sysName = system->getName();
 
-				sGamelistPendingWrites.push_back(std::async(std::launch::async,
-					[xmlContent, xmlWritePath, sysName]() {
-						const auto startTs = std::chrono::system_clock::now();
+				{
+					// Clean up finished futures
+					std::lock_guard<std::mutex> lock(sGamelistWriteMutex);
+					sGamelistPendingWrites.erase(
+						std::remove_if(sGamelistPendingWrites.begin(), sGamelistPendingWrites.end(),
+							[](std::future<void>& f) {
+								return f.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+							}),
+						sGamelistPendingWrites.end());
 
-						std::ofstream outFile(xmlWritePath, std::ios::out | std::ios::trunc);
-						if (outFile.is_open()) {
-							outFile << xmlContent;
-							outFile.close();
-						} else {
-							LOG(LogError) << "Error saving gamelist.xml to \"" << xmlWritePath << "\" (for system " << sysName << ")!";
-						}
+					sGamelistPendingWrites.push_back(std::async(std::launch::async,
+						[xmlContent, xmlWritePath, sysName]() {
+							const auto startTs = std::chrono::system_clock::now();
 
-						const auto endTs = std::chrono::system_clock::now();
-						LOG(LogInfo) << "Saved gamelist.xml for system \"" << sysName << "\" in " << std::chrono::duration_cast<std::chrono::milliseconds>(endTs - startTs).count() << " ms";
-					}));
+							std::ofstream outFile(xmlWritePath, std::ios::out | std::ios::trunc);
+							if (outFile.is_open()) {
+								outFile << xmlContent;
+								outFile.close();
+							} else {
+								LOG(LogError) << "Error saving gamelist.xml to \"" << xmlWritePath << "\" (for system " << sysName << ")!";
+							}
+
+							const auto endTs = std::chrono::system_clock::now();
+							LOG(LogInfo) << "Saved gamelist.xml for system \"" << sysName << "\" in " << std::chrono::duration_cast<std::chrono::milliseconds>(endTs - startTs).count() << " ms";
+						}));
+				}
 			}
 		}
 	}else{

--- a/es-app/src/Gamelist.h
+++ b/es-app/src/Gamelist.h
@@ -10,4 +10,8 @@ void parseGamelist(SystemData* system);
 // Writes currently loaded metadata for a SystemData to gamelist.xml.
 void updateGamelist(SystemData* system);
 
+// Blocks until all pending async gamelist writes have completed.
+// Must be called before process exit to avoid data loss.
+void waitForGamelistWrites();
+
 #endif // ES_APP_GAME_LIST_H

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -451,6 +451,11 @@ void GuiMenu::openOtherSettings()
 	s->addWithLabel("PARSE GAMESLISTS ONLY", parse_gamelists);
 	s->addSaveFunc([parse_gamelists] { Settings::getInstance()->setBool("ParseGamelistOnly", parse_gamelists->getState()); });
 
+	auto async_file_io = std::make_shared<SwitchComponent>(mWindow);
+	async_file_io->setState(Settings::getInstance()->getBool("AsyncFileIO"));
+	s->addWithLabel("ASYNC FILE IO", async_file_io);
+	s->addSaveFunc([async_file_io] { Settings::getInstance()->setBool("AsyncFileIO", async_file_io->getState()); });
+
 	auto local_art = std::make_shared<SwitchComponent>(mWindow);
 	local_art->setState(Settings::getInstance()->getBool("LocalArt"));
 	s->addWithLabel("SEARCH FOR LOCAL ART", local_art);

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -18,6 +18,7 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include "SystemScreenSaver.h"
+#include "components/VideoVlcComponent.h"
 #include <SDL_events.h>
 #include <SDL_main.h>
 #include <SDL_timer.h>
@@ -482,6 +483,11 @@ int main(int argc, char* argv[])
 
 	InputManager::getInstance()->deinit();
 	window.deinit();
+
+	// Join the VLC cleanup worker and release the VLC instance. Must happen after
+	// window.deinit() so all VideoVlcComponents are destroyed and their final
+	// stopVideo() cleanup tasks are already posted to the queue.
+	VideoVlcComponent::deinit();
 
 	MameNames::deinit();
 	CollectionSystemManager::deinit();

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -8,6 +8,7 @@
 #include "views/ViewController.h"
 #include "CollectionSystemManager.h"
 #include "EmulationStation.h"
+#include "Gamelist.h"
 #include "InputManager.h"
 #include "Log.h"
 #include "MameNames.h"
@@ -484,6 +485,7 @@ int main(int argc, char* argv[])
 
 	MameNames::deinit();
 	CollectionSystemManager::deinit();
+	waitForGamelistWrites();
 	SystemData::deleteSystems();
 
 	// call this ONLY when linking with FreeImage as a static library

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -221,9 +221,9 @@ void DetailedGameListView::updateInfoPanel()
 		//mDescription.setText("");
 		fadingOut = true;
 	}else{
-		mThumbnail.setImage(file->getThumbnailPath());
-		mMarquee.setImage(file->getMarqueePath());
-		mImage.setImage(file->getImagePath());
+		mThumbnail.setImageAsync(file->getThumbnailPath());
+		mImage.setImageAsync(file->getImagePath());
+		mMarquee.setImageAsync(file->getMarqueePath());
 		mDescription.setText(file->metadata.get("desc"));
 		mDescContainer.reset();
 

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -323,9 +323,9 @@ void GridGameListView::updateInfoPanel()
 		}
 		mVideoPlaying = true;
 
-		mVideo->setImage(file->getThumbnailPath());
-		mMarquee.setImage(file->getMarqueePath());
-		mImage.setImage(file->getImagePath());
+		mVideo->setImageAsync(file->getThumbnailPath());
+		mMarquee.setImageAsync(file->getMarqueePath());
+		mImage.setImageAsync(file->getImagePath());
 
 		mDescription.setText(file->metadata.get("desc"));
 		mDescContainer.reset();

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -265,10 +265,10 @@ void VideoGameListView::updateInfoPanel()
 		}
 		mVideoPlaying = true;
 
-		mVideo->setImage(file->getThumbnailPath());
-		mThumbnail.setImage(file->getThumbnailPath());
-		mMarquee.setImage(file->getMarqueePath());
-		mImage.setImage(file->getImagePath());
+		mVideo->setImageAsync(file->getThumbnailPath());
+		mThumbnail.setImageAsync(file->getThumbnailPath());
+		mMarquee.setImageAsync(file->getMarqueePath());
+		mImage.setImageAsync(file->getImagePath());
 
 		mDescription.setText(file->metadata.get("desc"));
 		mDescContainer.reset();

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -58,6 +58,7 @@ void Settings::setDefaults()
 
 	mBoolMap["BackgroundJoystickInput"] = false;
 	mBoolMap["ParseGamelistOnly"] = false;
+	mBoolMap["AsyncFileIO"] = false;
 	mBoolMap["ShowHiddenFiles"] = false;
 	mBoolMap["DrawFramerate"] = false;
 	mBoolMap["ShowExit"] = true;

--- a/es-core/src/Window.cpp
+++ b/es-core/src/Window.cpp
@@ -254,6 +254,10 @@ void Window::render()
 			onSleep();
 		}
 	}
+
+	// Mark the end of a frame for the texture cache so its eviction logic can
+	// distinguish textures that were just rendered from older entries.
+	TextureResource::nextBindGeneration();
 }
 
 void Window::normalizeNextUpdate()

--- a/es-core/src/components/IList.h
+++ b/es-core/src/components/IList.h
@@ -240,8 +240,13 @@ protected:
 		if(mScrollVelocity == 0 || size() < 2)
 			return;
 
-		mScrollCursorAccumulator += deltaTime;
-		mScrollTierAccumulator += deltaTime;
+		// Cap the delta time used for scrolling to prevent multiple scroll jumps
+		// after a long-blocking frame (e.g., slow NAS I/O)
+		const int maxScrollDelta = mTierList.tiers[mScrollTier].scrollDelay;
+		int scrollDelta = (deltaTime > maxScrollDelta) ? maxScrollDelta : deltaTime;
+
+		mScrollCursorAccumulator += scrollDelta;
+		mScrollTierAccumulator += scrollDelta;
 
 		// we delay scrolling until after scroll tier has updated so isScrolling() returns accurately during onCursorChanged callbacks
 		// we don't just do scroll tier first because it would not catch the scrollDelay == tier length case

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -135,9 +135,11 @@ void ImageComponent::setImage(std::string path, bool tile)
 {
 	mAsyncPending = false;
 
-	if(path.empty() || !ResourceManager::getInstance()->fileExists(path))
+	// Skip fileExists() — it calls stat64 which blocks on NAS paths.
+	// TextureData::load() handles missing files gracefully (returns empty texture).
+	if(path.empty())
 	{
-		if(mDefaultPath.empty() || !ResourceManager::getInstance()->fileExists(mDefaultPath))
+		if(mDefaultPath.empty())
 			mTexture.reset();
 		else
 			mTexture = TextureResource::get(mDefaultPath, tile, mForceLoad, mDynamic);

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -21,7 +21,8 @@ Vector2f ImageComponent::getSize() const
 ImageComponent::ImageComponent(Window* window, bool forceLoad, bool dynamic) : GuiComponent(window),
 	mTargetIsMax(false), mTargetIsMin(false), mFlipX(false), mFlipY(false), mTargetSize(0, 0), mColorShift(0xFFFFFFFF),
 	mColorShiftEnd(0xFFFFFFFF), mColorGradientHorizontal(true), mForceLoad(forceLoad), mDynamic(dynamic),
-	mFadeOpacity(0), mFading(false), mRotateByTargetSize(false), mTopLeftCrop(0.0f, 0.0f), mBottomRightCrop(1.0f, 1.0f)
+	mFadeOpacity(0), mFading(false), mRotateByTargetSize(false), mTopLeftCrop(0.0f, 0.0f), mBottomRightCrop(1.0f, 1.0f),
+	mAsyncPending(false)
 {
 	updateColors();
 }
@@ -132,6 +133,8 @@ void ImageComponent::setDefaultImage(std::string path)
 
 void ImageComponent::setImage(std::string path, bool tile)
 {
+	mAsyncPending = false;
+
 	if(path.empty() || !ResourceManager::getInstance()->fileExists(path))
 	{
 		if(mDefaultPath.empty() || !ResourceManager::getInstance()->fileExists(mDefaultPath))
@@ -158,7 +161,61 @@ void ImageComponent::setImage(const char* path, size_t length, bool tile)
 void ImageComponent::setImage(const std::shared_ptr<TextureResource>& texture)
 {
 	mTexture = texture;
+	mAsyncPending = false;
 	resize();
+}
+
+void ImageComponent::setImageAsync(std::string path, bool tile)
+{
+	mAsyncPending = false;
+
+	// Skip the fileExists() check used by setImage() — it calls stat64 which blocks
+	// on NAS. Instead, just hand the path to TextureResource and let the background
+	// thread's load() handle missing files gracefully.
+	if(path.empty())
+	{
+		if(mDefaultPath.empty())
+			mTexture.reset();
+		else
+			mTexture = TextureResource::get(mDefaultPath, tile, mForceLoad, mDynamic, false);
+	} else {
+		mTexture = TextureResource::get(path, tile, mForceLoad, mDynamic, false);
+	}
+
+	if(mTexture)
+	{
+		// Check if the texture is already loaded (e.g. cache hit)
+		if(mTexture->updateTextureSize())
+		{
+			LOG(LogDebug) << "setImageAsync: immediate load for " << path;
+			resize();
+		}
+		else
+		{
+			// Texture is loading in background - resize() will be called from update() when ready
+			LOG(LogDebug) << "setImageAsync: queued async for " << path;
+			mAsyncPending = true;
+		}
+	}
+	else
+	{
+		LOG(LogDebug) << "setImageAsync: no texture for " << path;
+	}
+}
+
+void ImageComponent::update(int deltaTime)
+{
+	GuiComponent::update(deltaTime);
+
+	if(mAsyncPending && mTexture)
+	{
+		if(mTexture->updateTextureSize())
+		{
+			LOG(LogDebug) << "ImageComponent::update: async load complete, calling resize. size=" << mTexture->getSize().x() << "x" << mTexture->getSize().y();
+			mAsyncPending = false;
+			resize();
+		}
+	}
 }
 
 void ImageComponent::setResize(float width, float height)
@@ -325,7 +382,7 @@ void ImageComponent::render(const Transform4x4f& parentTrans)
 	Transform4x4f trans = parentTrans * getTransform();
 	Renderer::setMatrix(trans);
 
-	if(mTexture && mOpacity > 0)
+	if(mTexture && mOpacity > 0 && !mAsyncPending)
 	{
 		if(Settings::getInstance()->getBool("DebugImage")) {
 			Vector2f targetSizePos = (mTargetSize - mSize) * mOrigin * -1;
@@ -345,6 +402,13 @@ void ImageComponent::render(const Transform4x4f& parentTrans)
 			LOG(LogError) << "Image texture is not initialized!";
 			mTexture.reset();
 		}
+	}
+	else if(mTexture && mAsyncPending)
+	{
+		// Debug: log when we're skipping render due to async pending
+		static int skipCount = 0;
+		if(++skipCount % 60 == 1) // log every ~1 second at 60fps
+			LOG(LogDebug) << "render: skipping due to mAsyncPending, mSize=" << mSize.x() << "x" << mSize.y() << " opacity=" << (int)mOpacity;
 	}
 
 	GuiComponent::renderChildren(trans);

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -414,9 +414,9 @@ void ImageComponent::render(const Transform4x4f& parentTrans)
 	}
 	else if(mTexture && mAsyncPending)
 	{
-		// Clear mAsyncPending for failed loads even when update() isn't being called
+		// Resolve mAsyncPending for failed loads even when update() isn't being called
 		// (e.g. game list rendered in background during system carousel transition).
-		if(mTexture->hasLoadFailed())
+		if(mTexture->updateTextureSize())
 		{
 			mAsyncPending = false;
 		}

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -417,7 +417,7 @@ void ImageComponent::render(const Transform4x4f& parentTrans)
 		// Debug: log when we're skipping render due to async pending
 		static int skipCount = 0;
 		if(++skipCount % 60 == 1) // log every ~1 second at 60fps
-			LOG(LogDebug) << "render: skipping due to mAsyncPending, mSize=" << mSize.x() << "x" << mSize.y() << " opacity=" << (int)mOpacity;
+			LOG(LogDebug) << "render: skipping due to mAsyncPending for " << mTexturePath << " mSize=" << mSize.x() << "x" << mSize.y() << " opacity=" << (int)mOpacity;
 	}
 
 	GuiComponent::renderChildren(trans);

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -414,10 +414,18 @@ void ImageComponent::render(const Transform4x4f& parentTrans)
 	}
 	else if(mTexture && mAsyncPending)
 	{
-		// Debug: log when we're skipping render due to async pending
-		static int skipCount = 0;
-		if(++skipCount % 60 == 1) // log every ~1 second at 60fps
-			LOG(LogDebug) << "render: skipping due to mAsyncPending for " << mTexturePath << " mSize=" << mSize.x() << "x" << mSize.y() << " opacity=" << (int)mOpacity;
+		// Clear mAsyncPending for failed loads even when update() isn't being called
+		// (e.g. game list rendered in background during system carousel transition).
+		if(mTexture->hasLoadFailed())
+		{
+			mAsyncPending = false;
+		}
+		else
+		{
+			static int skipCount = 0;
+			if(++skipCount % 60 == 1) // log every ~1 second at 60fps
+				LOG(LogDebug) << "render: skipping due to mAsyncPending for " << mTexturePath << " mSize=" << mSize.x() << "x" << mSize.y() << " opacity=" << (int)mOpacity;
+		}
 	}
 
 	GuiComponent::renderChildren(trans);

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -176,6 +176,7 @@ void ImageComponent::setImageAsync(std::string path, bool tile)
 	}
 
 	mAsyncPending = false;
+	mTexturePath = path;
 
 	// Skip the fileExists() check used by setImage() — it calls stat64 which blocks
 	// on NAS. Instead, just hand the path to TextureResource and let the background
@@ -219,7 +220,7 @@ void ImageComponent::update(int deltaTime)
 	{
 		if(mTexture->updateTextureSize())
 		{
-			LOG(LogDebug) << "ImageComponent::update: async load complete, calling resize. size=" << mTexture->getSize().x() << "x" << mTexture->getSize().y();
+			LOG(LogDebug) << "ImageComponent::update: async load complete for " << mTexturePath << " size=" << mTexture->getSize().x() << "x" << mTexture->getSize().y();
 			mAsyncPending = false;
 			resize();
 		}

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -167,6 +167,12 @@ void ImageComponent::setImage(const std::shared_ptr<TextureResource>& texture)
 
 void ImageComponent::setImageAsync(std::string path, bool tile)
 {
+	if (!Settings::getInstance()->getBool("AsyncFileIO"))
+	{
+		setImage(path, tile);
+		return;
+	}
+
 	mAsyncPending = false;
 
 	// Skip the fileExists() check used by setImage() — it calls stat64 which blocks

--- a/es-core/src/components/ImageComponent.cpp
+++ b/es-core/src/components/ImageComponent.cpp
@@ -4,6 +4,7 @@
 #include "Log.h"
 #include "Settings.h"
 #include "ThemeData.h"
+#include <SDL_timer.h>
 
 Vector2i ImageComponent::getTextureSize() const
 {
@@ -204,6 +205,7 @@ void ImageComponent::setImageAsync(std::string path, bool tile)
 			// Texture is loading in background - resize() will be called from update() when ready
 			LOG(LogDebug) << "setImageAsync: queued async for " << path;
 			mAsyncPending = true;
+			mAsyncStartTime = SDL_GetTicks();
 		}
 	}
 	else
@@ -220,7 +222,7 @@ void ImageComponent::update(int deltaTime)
 	{
 		if(mTexture->updateTextureSize())
 		{
-			LOG(LogDebug) << "ImageComponent::update: async load complete for " << mTexturePath << " size=" << mTexture->getSize().x() << "x" << mTexture->getSize().y();
+			LOG(LogDebug) << "ImageComponent::update: async load complete for " << mTexturePath << " size=" << mTexture->getSize().x() << "x" << mTexture->getSize().y() << " time=" << (SDL_GetTicks() - mAsyncStartTime) << "ms";
 			mAsyncPending = false;
 			resize();
 		}

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -82,6 +82,7 @@ public:
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 
 	std::shared_ptr<TextureResource> getTexture() { return mTexture; };
+	bool isAsyncPending() const { return mAsyncPending; };
 private:
 	Vector2f mTargetSize;
 

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -23,8 +23,13 @@ public:
 	//Use an already existing texture.
 	void setImage(const std::shared_ptr<TextureResource>& texture);
 
+	//Loads the image asynchronously in a background thread. The image will fade in when ready.
+	void setImageAsync(std::string path, bool tile = false);
+
 	void onSizeChanged() override;
 	void setOpacity(unsigned char opacity) override;
+
+	void update(int deltaTime) override;
 
 	// Resize the image to fit this size. If one axis is zero, scale that axis to maintain aspect ratio.
 	// If both are non-zero, potentially break the aspect ratio.  If both are zero, no resizing.
@@ -104,6 +109,7 @@ private:
 	bool					mForceLoad;
 	bool					mDynamic;
 	bool					mRotateByTargetSize;
+	bool					mAsyncPending;
 
 	Vector2f mTopLeftCrop;
 	Vector2f mBottomRightCrop;

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -112,6 +112,7 @@ private:
 	bool					mDynamic;
 	bool					mRotateByTargetSize;
 	bool					mAsyncPending;
+	int						mAsyncStartTime;
 
 	Vector2f mTopLeftCrop;
 	Vector2f mBottomRightCrop;

--- a/es-core/src/components/ImageComponent.h
+++ b/es-core/src/components/ImageComponent.h
@@ -102,6 +102,7 @@ private:
 	bool mColorGradientHorizontal;
 
 	std::string mDefaultPath;
+	std::string mTexturePath;
 
 	std::shared_ptr<TextureResource> mTexture;
 	unsigned char			mFadeOpacity;

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -135,6 +135,17 @@ void VideoComponent::setImage(std::string path)
 	mStaticImagePath = path;
 }
 
+void VideoComponent::setImageAsync(std::string path)
+{
+	// Check that the image has changed
+	if (path == mStaticImagePath)
+		return;
+
+	mStaticImage.setImageAsync(path);
+	mFadeIn = 0.0f;
+	mStaticImagePath = path;
+}
+
 void VideoComponent::setDefaultVideo()
 {
 	setVideo(mConfig.defaultVideoPath);
@@ -266,6 +277,10 @@ void VideoComponent::startVideoWithDelay()
 void VideoComponent::update(int deltaTime)
 {
 	manageState();
+
+	// mStaticImage is not a child, so we must pump its update manually
+	// to let its async-load polling (mAsyncPending) resolve.
+	mStaticImage.update(deltaTime);
 
 	// If the video start is delayed and there is less than the fade time then set the image fade
 	// accordingly

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -1,6 +1,7 @@
 #include "components/VideoComponent.h"
 
 #include "resources/ResourceManager.h"
+#include "Settings.h"
 #include "utils/FileSystemUtil.h"
 #include "PowerSaver.h"
 #include "ThemeData.h"
@@ -141,7 +142,11 @@ void VideoComponent::setImageAsync(std::string path)
 	if (path == mStaticImagePath)
 		return;
 
-	mStaticImage.setImageAsync(path);
+	if (!Settings::getInstance()->getBool("AsyncFileIO"))
+		mStaticImage.setImage(path);
+	else
+		mStaticImage.setImageAsync(path);
+
 	mFadeIn = 0.0f;
 	mStaticImagePath = path;
 }

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -239,8 +239,6 @@ void VideoComponent::handleStartDelay()
 		}
 		// Completed
 		mStartDelayed = false;
-		// Clear the playing flag so startVideo works
-		mIsPlaying = false;
 		startVideo();
 	}
 }
@@ -251,8 +249,8 @@ void VideoComponent::handleLooping()
 
 void VideoComponent::startVideoWithDelay()
 {
-	// If not playing then either start the video or initiate the delay
-	if (!mIsPlaying)
+	// If not playing and not already preparing to play, start the process
+	if (!mIsPlaying && mPlayingVideoPath.empty())
 	{
 		// Set the video that we are going to be playing so we don't attempt to restart it
 		mPlayingVideoPath = mVideoPath;
@@ -270,7 +268,6 @@ void VideoComponent::startVideoWithDelay()
 			mFadeIn = 0.0f;
 			mStartTime = SDL_GetTicks() + mConfig.startDelay;
 		}
-		mIsPlaying = true;
 	}
 }
 
@@ -313,8 +310,8 @@ void VideoComponent::manageState()
 	// is not active and the component is visible
 	bool show = mShowing && !mScreensaverActive && !mDisable && mVisible;
 
-	// See if we're already playing
-	if (mIsPlaying)
+	// See if we're already playing (or mid-parse preparing to play)
+	if (mIsPlaying || mPlayingVideoPath.length() > 0)
 	{
 		// If we are not on display then stop the video from playing
 		if (!show)
@@ -332,7 +329,7 @@ void VideoComponent::manageState()
 		}
 	}
 	// Need to recheck variable rather than 'else' because it may be modified above
-	if (!mIsPlaying)
+	if (!mIsPlaying && mPlayingVideoPath.empty())
 	{
 		// If we are on display then see if we should start the video
 		if (show && !mVideoPath.empty())

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -115,14 +115,9 @@ bool VideoComponent::setVideo(std::string path)
 	// Store the path
 	mVideoPath = fullPath;
 
-	// If the file exists then set the new video
-	if (!fullPath.empty() && ResourceManager::getInstance()->fileExists(fullPath))
-	{
-		// Return true to show that we are going to attempt to play a video
-		return true;
-	}
-	// Return false to show that no video will be displayed
-	return false;
+	// Return true if there's a path to attempt; missing files are handled
+	// gracefully by VLC, avoiding a blocking stat() call on NAS paths.
+	return !fullPath.empty();
 }
 
 void VideoComponent::setImage(std::string path)

--- a/es-core/src/components/VideoComponent.cpp
+++ b/es-core/src/components/VideoComponent.cpp
@@ -232,6 +232,13 @@ void VideoComponent::handleStartDelay()
 	// Only play if any delay has timed out
 	if (mStartDelayed)
 	{
+		// If the snapshot image is still loading, keep pushing the deadline forward
+		// so the delay doesn't expire before the user has had a chance to see it.
+		if (mConfig.showSnapshotDelay && mStaticImage.isAsyncPending())
+		{
+			mStartTime = SDL_GetTicks() + mConfig.startDelay;
+			return;
+		}
 		if (mStartTime > SDL_GetTicks())
 		{
 			// Timeout not yet completed

--- a/es-core/src/components/VideoComponent.h
+++ b/es-core/src/components/VideoComponent.h
@@ -31,6 +31,8 @@ public:
 	bool setVideo(std::string path);
 	// Loads a static image that is displayed if the video cannot be played
 	void setImage(std::string path);
+	// Loads a static image asynchronously in a background thread
+	void setImageAsync(std::string path);
 
 	// Configures the component to show the default video
 	void setDefaultVideo();

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -17,6 +17,44 @@ typedef SSIZE_T ssize_t;
 
 libvlc_instance_t* VideoVlcComponent::mVLC = NULL;
 
+// Persistent worker thread statics for non-blocking VLC cleanup
+std::thread              VideoVlcComponent::sCleanupThread;
+std::mutex               VideoVlcComponent::sCleanupMutex;
+std::condition_variable  VideoVlcComponent::sCleanupCond;
+std::deque<std::function<void()>> VideoVlcComponent::sCleanupQueue;
+bool                     VideoVlcComponent::sCleanupRunning = false;
+
+void VideoVlcComponent::cleanupWorker()
+{
+	while (true)
+	{
+		std::function<void()> task;
+		{
+			std::unique_lock<std::mutex> lock(sCleanupMutex);
+			sCleanupCond.wait(lock, [] { return !sCleanupQueue.empty(); });
+			task = std::move(sCleanupQueue.front());
+			sCleanupQueue.pop_front();
+		}
+		task();
+	}
+}
+
+void VideoVlcComponent::postCleanupTask(std::function<void()> task)
+{
+	{
+		std::lock_guard<std::mutex> lock(sCleanupMutex);
+		// Lazily start the persistent worker thread on first use
+		if (!sCleanupRunning)
+		{
+			sCleanupRunning = true;
+			sCleanupThread = std::thread(cleanupWorker);
+			sCleanupThread.detach();
+		}
+		sCleanupQueue.push_back(std::move(task));
+	}
+	sCleanupCond.notify_one();
+}
+
 // VLC prepares to render a video frame.
 static void *lock(void *data, void **p_pixels) {
 	struct VideoContext *c = (struct VideoContext *)data;
@@ -43,7 +81,7 @@ VideoVlcComponent::VideoVlcComponent(Window* window, std::string subtitles) :
 	mMediaPlayer(nullptr),
 	mMediaParsing(false)
 {
-	memset(&mContext, 0, sizeof(mContext));
+	mContext = nullptr;
 
 	// Get an empty texture for rendering the video
 	mTexture = TextureResource::get("");
@@ -146,7 +184,7 @@ void VideoVlcComponent::render(const Transform4x4f& parentTrans)
 	GuiComponent::renderChildren(trans);
 	Renderer::setMatrix(trans);
 
-	if (mIsPlaying && mContext.valid)
+	if (mIsPlaying && mContext && mContext->valid)
 	{
 		const unsigned int fadeIn = (unsigned int)(Math::clamp(0.0f, mFadeIn, 1.0f) * 255.0f);
 		const unsigned int color  = Renderer::convertColor((fadeIn << 24) | (fadeIn << 16) | (fadeIn << 8) | 255);
@@ -162,7 +200,7 @@ void VideoVlcComponent::render(const Transform4x4f& parentTrans)
 			vertices[i].pos.round();
 
 		// Build a texture for the video frame
-		mTexture->initFromPixels((unsigned char*)mContext.surface->pixels, mContext.surface->w, mContext.surface->h);
+		mTexture->initFromPixels((unsigned char*)mContext->surface->pixels, mContext->surface->w, mContext->surface->h);
 		mTexture->bind();
 
 		// Render it
@@ -176,23 +214,25 @@ void VideoVlcComponent::render(const Transform4x4f& parentTrans)
 
 void VideoVlcComponent::setupContext()
 {
-	if (!mContext.valid)
+	if (!mContext)
 	{
 		// Create an RGBA surface to render the video into
-		mContext.surface = SDL_CreateRGBSurface(SDL_SWSURFACE, (int)mVideoWidth, (int)mVideoHeight, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
-		mContext.mutex = SDL_CreateMutex();
-		mContext.valid = true;
+		mContext = new VideoContext();
+		mContext->surface = SDL_CreateRGBSurface(SDL_SWSURFACE, (int)mVideoWidth, (int)mVideoHeight, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
+		mContext->mutex = SDL_CreateMutex();
+		mContext->valid = true;
 		resize();
 	}
 }
 
 void VideoVlcComponent::freeContext()
 {
-	if (mContext.valid)
+	if (mContext)
 	{
-		SDL_FreeSurface(mContext.surface);
-		SDL_DestroyMutex(mContext.mutex);
-		mContext.valid = false;
+		SDL_FreeSurface(mContext->surface);
+		SDL_DestroyMutex(mContext->mutex);
+		delete mContext;
+		mContext = nullptr;
 	}
 }
 
@@ -336,7 +376,7 @@ void VideoVlcComponent::onMediaParsed()
 		setMuteMode();
 
 		libvlc_media_player_play(mMediaPlayer);
-		libvlc_video_set_callbacks(mMediaPlayer, lock, unlock, display, (void*)&mContext);
+		libvlc_video_set_callbacks(mMediaPlayer, lock, unlock, display, (void*)mContext);
 		libvlc_video_set_format(mMediaPlayer, "RGBA", (int)mVideoWidth, (int)mVideoHeight, (int)mVideoWidth * 4);
 
 		// Update the playing state
@@ -350,23 +390,44 @@ void VideoVlcComponent::stopVideo()
 	mIsPlaying = false;
 	mStartDelayed = false;
 	mPlayingVideoPath = "";
-	// If we were mid-parse with no player yet, cancel the parse and release the media
+	// If we were mid-parse with no player yet, cancel the parse on a background
+	// thread so the blocking libvlc_media_parse_stop call doesn't stall the UI.
 	if (mMediaParsing && mMedia)
 	{
-		libvlc_media_parse_stop(mMedia);
-		libvlc_media_release(mMedia);
+		libvlc_media_t* media = mMedia;
 		mMedia = nullptr;
+		mMediaParsing = false;
+
+		postCleanupTask([media]() {
+			libvlc_media_parse_stop(media);
+			libvlc_media_release(media);
+		});
+		return;
 	}
 	mMediaParsing = false;
-	// Release the media player so it stops calling back to us
+	// Release the media player on a background thread so the blocking
+	// libvlc_media_player_stop call doesn't freeze the UI.
 	if (mMediaPlayer)
 	{
-		libvlc_media_player_stop(mMediaPlayer);
-		libvlc_media_player_release(mMediaPlayer);
-		libvlc_media_release(mMedia);
-		mMediaPlayer = NULL;
-		freeContext();
-		PowerSaver::resume();
+		libvlc_media_player_t* player = mMediaPlayer;
+		libvlc_media_t* media = mMedia;
+		VideoContext* context = mContext;
+
+		mMediaPlayer = nullptr;
+		mMedia = nullptr;
+		mContext = nullptr;
+
+		postCleanupTask([player, media, context]() {
+			libvlc_media_player_stop(player);
+			libvlc_media_player_release(player);
+			libvlc_media_release(media);
+			if (context) {
+				SDL_FreeSurface(context->surface);
+				SDL_DestroyMutex(context->mutex);
+				delete context;
+			}
+			PowerSaver::resume();
+		});
 	}
 }
 

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -23,6 +23,7 @@ std::mutex               VideoVlcComponent::sCleanupMutex;
 std::condition_variable  VideoVlcComponent::sCleanupCond;
 std::deque<std::function<void()>> VideoVlcComponent::sCleanupQueue;
 bool                     VideoVlcComponent::sCleanupRunning = false;
+bool                     VideoVlcComponent::sCleanupExit = false;
 
 void VideoVlcComponent::cleanupWorker()
 {
@@ -31,7 +32,9 @@ void VideoVlcComponent::cleanupWorker()
 		std::function<void()> task;
 		{
 			std::unique_lock<std::mutex> lock(sCleanupMutex);
-			sCleanupCond.wait(lock, [] { return !sCleanupQueue.empty(); });
+			sCleanupCond.wait(lock, [] { return !sCleanupQueue.empty() || sCleanupExit; });
+			if (sCleanupQueue.empty())
+				break; // exit flag set and no remaining work
 			task = std::move(sCleanupQueue.front());
 			sCleanupQueue.pop_front();
 		}
@@ -48,11 +51,30 @@ void VideoVlcComponent::postCleanupTask(std::function<void()> task)
 		{
 			sCleanupRunning = true;
 			sCleanupThread = std::thread(cleanupWorker);
-			sCleanupThread.detach();
+			// Thread is kept joinable — deinit() will join it on shutdown.
 		}
 		sCleanupQueue.push_back(std::move(task));
 	}
 	sCleanupCond.notify_one();
+}
+
+void VideoVlcComponent::deinit()
+{
+	// Signal the worker thread to exit once the queue is drained
+	{
+		std::lock_guard<std::mutex> lock(sCleanupMutex);
+		sCleanupExit = true;
+	}
+	sCleanupCond.notify_one();
+
+	if (sCleanupRunning && sCleanupThread.joinable())
+		sCleanupThread.join();
+
+	if (mVLC)
+	{
+		libvlc_release(mVLC);
+		mVLC = nullptr;
+	}
 }
 
 // VLC prepares to render a video frame.

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -40,7 +40,8 @@ static void display(void* /*data*/, void* /*id*/) {
 
 VideoVlcComponent::VideoVlcComponent(Window* window, std::string subtitles) :
 	VideoComponent(window),
-	mMediaPlayer(nullptr)
+	mMediaPlayer(nullptr),
+	mMediaParsing(false)
 {
 	memset(&mContext, 0, sizeof(mContext));
 
@@ -136,6 +137,9 @@ void VideoVlcComponent::render(const Transform4x4f& parentTrans)
 {
 	if (!isVisible())
 		return;
+
+	// Poll for async media parsing completion each frame
+	handleParsing();
 
 	VideoComponent::render(parentTrans);
 	Transform4x4f trans = parentTrans * getTransform();
@@ -233,7 +237,7 @@ void VideoVlcComponent::handleLooping()
 
 void VideoVlcComponent::startVideo()
 {
-	if (!mIsPlaying) {
+	if (!mIsPlaying && !mMediaParsing) {
 		mVideoWidth = 0;
 		mVideoHeight = 0;
 
@@ -252,76 +256,92 @@ void VideoVlcComponent::startVideo()
 			mMedia = libvlc_media_new_path(mVLC, path.c_str());
 			if (mMedia)
 			{
-				unsigned track_count;
-				// Get the media metadata so we can find the aspect ratio
+				// Start async parse — we will poll for completion in handleParsing()
 				libvlc_media_parse_with_options(mMedia, libvlc_media_fetch_local, -1);
-				while (libvlc_media_get_parsed_status(mMedia) == 0)
-					;
-				libvlc_media_track_t** tracks;
-				track_count = libvlc_media_tracks_get(mMedia, &tracks);
-				for (unsigned track = 0; track < track_count; ++track)
+				mMediaParsing = true;
+			}
+		}
+	}
+}
+
+void VideoVlcComponent::handleParsing()
+{
+	if (!mMediaParsing || !mMedia)
+		return;
+
+	// Poll — not yet parsed, come back next frame
+	if (libvlc_media_get_parsed_status(mMedia) == 0)
+		return;
+
+	mMediaParsing = false;
+	onMediaParsed();
+}
+
+void VideoVlcComponent::onMediaParsed()
+{
+	unsigned track_count;
+	libvlc_media_track_t** tracks;
+	track_count = libvlc_media_tracks_get(mMedia, &tracks);
+	for (unsigned track = 0; track < track_count; ++track)
+	{
+		if (tracks[track]->i_type == libvlc_track_video)
+		{
+			mVideoWidth = tracks[track]->video->i_width;
+			mVideoHeight = tracks[track]->video->i_height;
+			break;
+		}
+	}
+	libvlc_media_tracks_release(tracks, track_count);
+
+	// Make sure we found a valid video track
+	if ((mVideoWidth > 0) && (mVideoHeight > 0))
+	{
+		if (mScreensaverMode)
+		{
+			std::string resolution = Settings::getInstance()->getString("VlcScreenSaverResolution");
+			if(resolution != "original") {
+				float scale = 1;
+				if (resolution == "low")
+					// 25% of screen resolution
+					scale = 0.25;
+				if (resolution == "medium")
+					// 50% of screen resolution
+					scale = 0.5;
+				if (resolution == "high")
+					// 75% of screen resolution
+					scale = 0.75;
+
+				Vector2f resizeScale((Renderer::getScreenWidth() / (float)mVideoWidth) * scale, (Renderer::getScreenHeight() / (float)mVideoHeight) * scale);
+
+				if(resizeScale.x() < resizeScale.y())
 				{
-					if (tracks[track]->i_type == libvlc_track_video)
-					{
-						mVideoWidth = tracks[track]->video->i_width;
-						mVideoHeight = tracks[track]->video->i_height;
-						break;
-					}
-				}
-				libvlc_media_tracks_release(tracks, track_count);
-
-				// Make sure we found a valid video track
-				if ((mVideoWidth > 0) && (mVideoHeight > 0))
-				{
-					if (mScreensaverMode)
-					{
-						std::string resolution = Settings::getInstance()->getString("VlcScreenSaverResolution");
-						if(resolution != "original") {
-							float scale = 1;
-							if (resolution == "low")
-								// 25% of screen resolution
-								scale = 0.25;
-							if (resolution == "medium")
-								// 50% of screen resolution
-								scale = 0.5;
-							if (resolution == "high")
-								// 75% of screen resolution
-								scale = 0.75;
-
-							Vector2f resizeScale((Renderer::getScreenWidth() / (float)mVideoWidth) * scale, (Renderer::getScreenHeight() / (float)mVideoHeight) * scale);
-
-							if(resizeScale.x() < resizeScale.y())
-							{
-								mVideoWidth = (unsigned int) (mVideoWidth * resizeScale.x());
-								mVideoHeight = (unsigned int) (mVideoHeight * resizeScale.x());
-							}else{
-								mVideoWidth = (unsigned int) (mVideoWidth * resizeScale.y());
-								mVideoHeight = (unsigned int) (mVideoHeight * resizeScale.y());
-							}
-						}
-					}
-					else
-					{
-						remove(getTitlePath().c_str());
-					}
-					PowerSaver::pause();
-					setupContext();
-
-					// Setup the media player
-					mMediaPlayer = libvlc_media_player_new_from_media(mMedia);
-
-					setMuteMode();
-
-					libvlc_media_player_play(mMediaPlayer);
-					libvlc_video_set_callbacks(mMediaPlayer, lock, unlock, display, (void*)&mContext);
-					libvlc_video_set_format(mMediaPlayer, "RGBA", (int)mVideoWidth, (int)mVideoHeight, (int)mVideoWidth * 4);
-
-					// Update the playing state
-					mIsPlaying = true;
-					mFadeIn = 0.0f;
+					mVideoWidth = (unsigned int) (mVideoWidth * resizeScale.x());
+					mVideoHeight = (unsigned int) (mVideoHeight * resizeScale.x());
+				}else{
+					mVideoWidth = (unsigned int) (mVideoWidth * resizeScale.y());
+					mVideoHeight = (unsigned int) (mVideoHeight * resizeScale.y());
 				}
 			}
 		}
+		else
+		{
+			remove(getTitlePath().c_str());
+		}
+		PowerSaver::pause();
+		setupContext();
+
+		// Setup the media player
+		mMediaPlayer = libvlc_media_player_new_from_media(mMedia);
+
+		setMuteMode();
+
+		libvlc_media_player_play(mMediaPlayer);
+		libvlc_video_set_callbacks(mMediaPlayer, lock, unlock, display, (void*)&mContext);
+		libvlc_video_set_format(mMediaPlayer, "RGBA", (int)mVideoWidth, (int)mVideoHeight, (int)mVideoWidth * 4);
+
+		// Update the playing state
+		mIsPlaying = true;
+		mFadeIn = 0.0f;
 	}
 }
 
@@ -329,6 +349,15 @@ void VideoVlcComponent::stopVideo()
 {
 	mIsPlaying = false;
 	mStartDelayed = false;
+	mPlayingVideoPath = "";
+	// If we were mid-parse with no player yet, cancel the parse and release the media
+	if (mMediaParsing && mMedia)
+	{
+		libvlc_media_parse_stop(mMedia);
+		libvlc_media_release(mMedia);
+		mMedia = nullptr;
+	}
+	mMediaParsing = false;
 	// Release the media player so it stops calling back to us
 	if (mMediaPlayer)
 	{

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -52,6 +52,10 @@ public:
 	// Never breaks the aspect ratio. setMaxSize() and setResize() are mutually exclusive.
 	void setMaxSize(float width, float height) override;
 
+	// Signal the cleanup worker to exit and wait for it to finish.
+	// Must be called after all VideoVlcComponent instances are destroyed.
+	static void deinit();
+
 private:
 	// Calculates the correct mSize from our resizing information (set by setResize/setMaxSize).
 	// Used internally whenever the resizing parameters or texture change.
@@ -85,6 +89,7 @@ private:
 	static std::condition_variable	sCleanupCond;
 	static std::deque<std::function<void()>> sCleanupQueue;
 	static bool						sCleanupRunning;
+	static bool						sCleanupExit;
 	libvlc_media_t*					mMedia;
 	libvlc_media_player_t*			mMediaPlayer;
 	VideoContext*				mContext;

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -62,12 +62,19 @@ private:
 	void setupContext();
 	void freeContext();
 
+	// Called each frame to check if async media parsing has completed;
+	// once done, extracts track info and starts playback.
+	void handleParsing();
+	// Second half of startVideo — runs after parsing finishes.
+	void onMediaParsed();
+
 private:
 	static libvlc_instance_t*		mVLC;
 	libvlc_media_t*					mMedia;
 	libvlc_media_player_t*			mMediaPlayer;
 	VideoContext					mContext;
 	std::shared_ptr<TextureResource> mTexture;
+	bool							mMediaParsing;
 };
 
 #endif // ES_CORE_COMPONENTS_VIDEO_VLC_COMPONENT_H

--- a/es-core/src/components/VideoVlcComponent.h
+++ b/es-core/src/components/VideoVlcComponent.h
@@ -3,6 +3,11 @@
 #define ES_CORE_COMPONENTS_VIDEO_VLC_COMPONENT_H
 
 #include "VideoComponent.h"
+#include <functional>
+#include <mutex>
+#include <condition_variable>
+#include <deque>
+#include <thread>
 
 struct SDL_mutex;
 struct SDL_Surface;
@@ -68,11 +73,21 @@ private:
 	// Second half of startVideo — runs after parsing finishes.
 	void onMediaParsed();
 
+	// Post a cleanup task to the shared background worker thread.
+	static void postCleanupTask(std::function<void()> task);
+
+	static void cleanupWorker();
+
 private:
 	static libvlc_instance_t*		mVLC;
+	static std::thread				sCleanupThread;
+	static std::mutex				sCleanupMutex;
+	static std::condition_variable	sCleanupCond;
+	static std::deque<std::function<void()>> sCleanupQueue;
+	static bool						sCleanupRunning;
 	libvlc_media_t*					mMedia;
 	libvlc_media_player_t*			mMediaPlayer;
-	VideoContext					mContext;
+	VideoContext*				mContext;
 	std::shared_ptr<TextureResource> mTexture;
 	bool							mMediaParsing;
 };

--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -144,24 +144,14 @@ bool TextureData::load()
 	return retval;
 }
 
-bool TextureData::isLoaded()
+TextureData::LoadStatus TextureData::loadStatus()
 {
 	std::unique_lock<std::mutex> lock(mMutex);
 	if (mDataRGBA || (mTextureID != 0))
-		return true;
-	return false;
-}
-
-bool TextureData::hasLoadFailed()
-{
-	std::unique_lock<std::mutex> lock(mMutex);
-	return mLoadFailed;
-}
-
-bool TextureData::isLoadedOrFailed()
-{
-	std::unique_lock<std::mutex> lock(mMutex);
-	return mDataRGBA || (mTextureID != 0) || mLoadFailed;
+		return LoadStatus::LOADED;
+	if (mLoadFailed)
+		return LoadStatus::FAILED;
+	return LoadStatus::LOADING;
 }
 
 bool TextureData::uploadAndBind()

--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -13,7 +13,7 @@
 #define DPI 96
 
 TextureData::TextureData(bool tile) : mTile(tile), mTextureID(0), mDataRGBA(nullptr), mScalable(false),
-									  mWidth(0), mHeight(0), mSourceWidth(0.0f), mSourceHeight(0.0f)
+									  mWidth(0), mHeight(0), mSourceWidth(0.0f), mSourceHeight(0.0f), mLoadFailed(false)
 {
 }
 
@@ -136,6 +136,11 @@ bool TextureData::load()
 		else
 			retval = initImageFromMemory((const unsigned char*)data.ptr.get(), data.length);
 	}
+	if (!retval)
+	{
+		std::unique_lock<std::mutex> lock(mMutex);
+		mLoadFailed = true;
+	}
 	return retval;
 }
 
@@ -145,6 +150,18 @@ bool TextureData::isLoaded()
 	if (mDataRGBA || (mTextureID != 0))
 		return true;
 	return false;
+}
+
+bool TextureData::hasLoadFailed()
+{
+	std::unique_lock<std::mutex> lock(mMutex);
+	return mLoadFailed;
+}
+
+bool TextureData::isLoadedOrFailed()
+{
+	std::unique_lock<std::mutex> lock(mMutex);
+	return mDataRGBA || (mTextureID != 0) || mLoadFailed;
 }
 
 bool TextureData::uploadAndBind()

--- a/es-core/src/resources/TextureData.cpp
+++ b/es-core/src/resources/TextureData.cpp
@@ -13,7 +13,8 @@
 #define DPI 96
 
 TextureData::TextureData(bool tile) : mTile(tile), mTextureID(0), mDataRGBA(nullptr), mScalable(false),
-									  mWidth(0), mHeight(0), mSourceWidth(0.0f), mSourceHeight(0.0f), mLoadFailed(false)
+									  mWidth(0), mHeight(0), mSourceWidth(0.0f), mSourceHeight(0.0f), mLoadFailed(false),
+									  mBindGeneration(0)
 {
 }
 

--- a/es-core/src/resources/TextureData.h
+++ b/es-core/src/resources/TextureData.h
@@ -21,17 +21,18 @@ public:
 	bool initImageFromMemory(const unsigned char* fileData, size_t length);
 	bool initFromRGBA(const unsigned char* dataRGBA, size_t width, size_t height);
 
+	enum class LoadStatus
+	{
+		LOADING,  // not yet loaded or in progress
+		LOADED,   // pixel data is in RAM or VRAM
+		FAILED    // load() was attempted and permanently failed (e.g. file not found)
+	};
+
 	// Read the data into memory if necessary
 	bool load();
 
-	bool isLoaded();
-	// Returns true if a previous load() attempt failed (e.g. file not found).
-	// The texture will not be re-queued for loading while this is set.
-	bool hasLoadFailed();
-	// Returns true if loading is complete — either successfully loaded or
-	// permanently failed. Single mutex acquisition; use in preference to
-	// !isLoaded() && !hasLoadFailed() or isLoaded() || hasLoadFailed().
-	bool isLoadedOrFailed();
+	// Returns the current load state under a single mutex acquisition.
+	LoadStatus loadStatus();
 
 	// Upload the texture to VRAM if necessary and bind. Returns true if bound ok or
 	// false if either not loaded

--- a/es-core/src/resources/TextureData.h
+++ b/es-core/src/resources/TextureData.h
@@ -25,6 +25,13 @@ public:
 	bool load();
 
 	bool isLoaded();
+	// Returns true if a previous load() attempt failed (e.g. file not found).
+	// The texture will not be re-queued for loading while this is set.
+	bool hasLoadFailed();
+	// Returns true if loading is complete — either successfully loaded or
+	// permanently failed. Single mutex acquisition; use in preference to
+	// !isLoaded() && !hasLoadFailed() or isLoaded() || hasLoadFailed().
+	bool isLoadedOrFailed();
 
 	// Upload the texture to VRAM if necessary and bind. Returns true if bound ok or
 	// false if either not loaded
@@ -59,6 +66,7 @@ private:
 	float			mSourceHeight;
 	bool			mScalable;
 	bool			mReloadable;
+	bool			mLoadFailed;
 };
 
 #endif // ES_CORE_RESOURCES_TEXTURE_DATA_H

--- a/es-core/src/resources/TextureData.h
+++ b/es-core/src/resources/TextureData.h
@@ -2,6 +2,7 @@
 #ifndef ES_CORE_RESOURCES_TEXTURE_DATA_H
 #define ES_CORE_RESOURCES_TEXTURE_DATA_H
 
+#include <cstdint>
 #include <mutex>
 #include <string>
 
@@ -55,6 +56,12 @@ public:
 
 	bool tiled() { return mTile; }
 
+	// Bind generation when this texture was last successfully bound. Compared
+	// against the manager's current generation by the eviction loop, so that
+	// textures rendered in recent frames are protected from being evicted.
+	uint64_t bindGeneration() const { return mBindGeneration; }
+	void setBindGeneration(uint64_t gen) { mBindGeneration = gen; }
+
 private:
 	std::mutex		mMutex;
 	bool			mTile;
@@ -68,6 +75,7 @@ private:
 	bool			mScalable;
 	bool			mReloadable;
 	bool			mLoadFailed;
+	uint64_t		mBindGeneration;
 };
 
 #endif // ES_CORE_RESOURCES_TEXTURE_DATA_H

--- a/es-core/src/resources/TextureDataManager.cpp
+++ b/es-core/src/resources/TextureDataManager.cpp
@@ -39,6 +39,8 @@ void TextureDataManager::remove(const TextureResource* key)
 	auto it = mTextureLookup.find(key);
 	if (it != mTextureLookup.cend())
 	{
+		// Cancel any pending async load for this texture
+		mLoader->remove(*(*it).second);
 		// Remove the list entry
 		mTextures.erase((*it).second);
 		// And the lookup
@@ -84,7 +86,12 @@ size_t TextureDataManager::getTotalSize()
 {
 	size_t total = 0;
 	for (auto tex : mTextures)
-		total += tex->width() * tex->height() * 4;
+	{
+		// Only count textures whose dimensions are known — calling width()/height()
+		// on an unloaded texture triggers a synchronous load().
+		if (tex->isLoaded())
+			total += tex->width() * tex->height() * 4;
+	}
 	return total;
 }
 
@@ -220,12 +227,15 @@ void TextureLoader::remove(std::shared_ptr<TextureData> textureData)
 size_t TextureLoader::getQueueSize()
 {
 	// Gets the amount of video memory that will be used once all textures in
-	// the queue are loaded
+	// the queue are loaded.  Only count textures whose dimensions are already
+	// known — calling width()/height() on an unloaded texture triggers a
+	// synchronous load() which blocks the main thread on NAS I/O.
 	size_t mem = 0;
 	std::unique_lock<std::mutex> lock(mMutex);
 	for (auto tex : mTextureDataQ)
 	{
-		mem += tex->width() * tex->height() * 4;
+		if (tex->isLoaded())
+			mem += tex->width() * tex->height() * 4;
 	}
 	return mem;
 }

--- a/es-core/src/resources/TextureDataManager.cpp
+++ b/es-core/src/resources/TextureDataManager.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<TextureData> TextureDataManager::get(const TextureResource* key,
 		// Make sure it's loaded or queued for loading.
 		// Skip textures whose load previously failed (e.g. file not found) so
 		// we don't keep re-queuing them every frame they are rendered.
-		if (enableLoading && !tex->isLoadedOrFailed())
+		if (enableLoading && tex->loadStatus() == TextureData::LoadStatus::LOADING)
 			load(tex);
 	}
 	return tex;
@@ -91,7 +91,7 @@ size_t TextureDataManager::getTotalSize()
 	{
 		// Only count textures whose dimensions are known — calling width()/height()
 		// on an unloaded texture triggers a synchronous load().
-		if (tex->isLoaded())
+		if (tex->loadStatus() == TextureData::LoadStatus::LOADED)
 			total += tex->width() * tex->height() * 4;
 	}
 	return total;
@@ -113,7 +113,7 @@ size_t TextureDataManager::getQueueSize()
 void TextureDataManager::load(std::shared_ptr<TextureData> tex, bool block)
 {
 	// See if it's already loaded or has permanently failed
-	if (tex->isLoadedOrFailed())
+	if (tex->loadStatus() != TextureData::LoadStatus::LOADING)
 		return;
 	// Not loaded. Make sure there is room
 	size_t max_texture = (size_t)Settings::getInstance()->getInt("MaxVRAM") * 1024 * 1024;
@@ -199,7 +199,7 @@ void TextureLoader::threadProc()
 void TextureLoader::load(std::shared_ptr<TextureData> textureData)
 {
 	// Make sure it's not already loaded and hasn't permanently failed
-	if (!textureData->isLoadedOrFailed())
+	if (textureData->loadStatus() == TextureData::LoadStatus::LOADING)
 	{
 		std::unique_lock<std::mutex> lock(mMutex);
 		// Remove it from the queue if it is already there
@@ -239,7 +239,7 @@ size_t TextureLoader::getQueueSize()
 	std::unique_lock<std::mutex> lock(mMutex);
 	for (auto tex : mTextureDataQ)
 	{
-		if (tex->isLoaded())
+		if (tex->loadStatus() == TextureData::LoadStatus::LOADED)
 			mem += tex->width() * tex->height() * 4;
 	}
 	return mem;

--- a/es-core/src/resources/TextureDataManager.cpp
+++ b/es-core/src/resources/TextureDataManager.cpp
@@ -64,8 +64,10 @@ std::shared_ptr<TextureData> TextureDataManager::get(const TextureResource* key,
 		// Store it back in the lookup
 		mTextureLookup[key] = mTextures.cbegin();
 
-		// Make sure it's loaded or queued for loading
-		if (enableLoading && !tex->isLoaded())
+		// Make sure it's loaded or queued for loading.
+		// Skip textures whose load previously failed (e.g. file not found) so
+		// we don't keep re-queuing them every frame they are rendered.
+		if (enableLoading && !tex->isLoadedOrFailed())
 			load(tex);
 	}
 	return tex;
@@ -110,8 +112,8 @@ size_t TextureDataManager::getQueueSize()
 
 void TextureDataManager::load(std::shared_ptr<TextureData> tex, bool block)
 {
-	// See if it's already loaded
-	if (tex->isLoaded())
+	// See if it's already loaded or has permanently failed
+	if (tex->isLoadedOrFailed())
 		return;
 	// Not loaded. Make sure there is room
 	size_t max_texture = (size_t)Settings::getInstance()->getInt("MaxVRAM") * 1024 * 1024;
@@ -146,12 +148,15 @@ TextureLoader::TextureLoader() : mExit(false)
 
 TextureLoader::~TextureLoader()
 {
-	// Just abort any waiting texture
-	mTextureDataQ.clear();
-	mTextureDataLookup.clear();
-
-	// Exit the thread
-	mExit = true;
+	// Clear the queue and signal exit atomically under the mutex so there is no
+	// race with the background thread's condition_variable wait (which holds the
+	// mutex while sleeping).
+	{
+		std::unique_lock<std::mutex> lock(mMutex);
+		mTextureDataQ.clear();
+		mTextureDataLookup.clear();
+		mExit = true;
+	}
 	mEvent.notify_one();
 	mThread->join();
 	delete mThread;
@@ -193,8 +198,8 @@ void TextureLoader::threadProc()
 
 void TextureLoader::load(std::shared_ptr<TextureData> textureData)
 {
-	// Make sure it's not already loaded
-	if (!textureData->isLoaded())
+	// Make sure it's not already loaded and hasn't permanently failed
+	if (!textureData->isLoadedOrFailed())
 	{
 		std::unique_lock<std::mutex> lock(mMutex);
 		// Remove it from the queue if it is already there

--- a/es-core/src/resources/TextureDataManager.cpp
+++ b/es-core/src/resources/TextureDataManager.cpp
@@ -126,12 +126,15 @@ void TextureDataManager::load(std::shared_ptr<TextureData> tex, bool block)
 		{
 			if (size < max_texture)
 				break;
-			//size -= (*it)->getVRAMUsage();
+			// Only evict textures that actually have data in RAM or VRAM.
+			// Evicting a LOADING texture frees no memory (getVRAMUsage()==0) and cancels
+			// its pending background load — which then gets immediately re-queued on the
+			// next bind(), triggering another eviction cycle. Skipping these breaks the
+			// evict→cancel→re-queue→evict cascade that causes non-stop texture flickering.
+			if ((*it)->loadStatus() != TextureData::LoadStatus::LOADED)
+				continue;
 			(*it)->releaseVRAM();
 			(*it)->releaseRAM();
-			// It may be already in the loader queue. In this case it wouldn't have been using
-			// any VRAM yet but it will be. Remove it from the loader queue
-			mLoader->remove(*it);
 			size = TextureResource::getTotalMemUsage();
 		}
 	}

--- a/es-core/src/resources/TextureDataManager.cpp
+++ b/es-core/src/resources/TextureDataManager.cpp
@@ -81,6 +81,10 @@ bool TextureDataManager::bind(const TextureResource* key)
 		bound = tex->uploadAndBind();
 	if (!bound)
 		mBlank->uploadAndBind();
+	else
+		// Stamp this texture as bound this generation so the eviction loop in
+		// load() won't kick it out and cause it to flicker on the next frame.
+		tex->setBindGeneration(mBindGeneration);
 	return bound;
 }
 
@@ -121,6 +125,13 @@ void TextureDataManager::load(std::shared_ptr<TextureData> tex, bool block)
 	// if max_texture is 0, then texture memory should be considered unlimited
 	if (max_texture > 0)
 	{
+		// Two-pass eviction. Pass 1 protects textures that were rendered in the
+		// current or previous bind generation — evicting them would cause flickering
+		// since they will be re-bound (and immediately re-loaded) on the very next
+		// frame.  Pass 2 is a fallback that ignores the protection if we still don't
+		// have enough budget after pass 1, so we never deadlock if the on-screen
+		// working set genuinely exceeds MaxVRAM.
+		const uint64_t protectGen = mBindGeneration > 0 ? mBindGeneration - 1 : 0;
 		size_t size = TextureResource::getTotalMemUsage();
 		for (auto it = mTextures.crbegin(); it != mTextures.crend(); ++it)
 		{
@@ -133,9 +144,27 @@ void TextureDataManager::load(std::shared_ptr<TextureData> tex, bool block)
 			// evict→cancel→re-queue→evict cascade that causes non-stop texture flickering.
 			if ((*it)->loadStatus() != TextureData::LoadStatus::LOADED)
 				continue;
+			if ((*it)->bindGeneration() >= protectGen)
+				continue;
 			(*it)->releaseVRAM();
 			(*it)->releaseRAM();
 			size = TextureResource::getTotalMemUsage();
+		}
+		// Pass 2: if still over budget, evict on-screen textures too. Rare (only
+		// when the working set itself is bigger than MaxVRAM), but necessary to
+		// avoid runaway memory growth.
+		if (size >= max_texture)
+		{
+			for (auto it = mTextures.crbegin(); it != mTextures.crend(); ++it)
+			{
+				if (size < max_texture)
+					break;
+				if ((*it)->loadStatus() != TextureData::LoadStatus::LOADED)
+					continue;
+				(*it)->releaseVRAM();
+				(*it)->releaseRAM();
+				size = TextureResource::getTotalMemUsage();
+			}
 		}
 	}
 	if (!block)

--- a/es-core/src/resources/TextureDataManager.h
+++ b/es-core/src/resources/TextureDataManager.h
@@ -3,6 +3,7 @@
 #define ES_CORE_RESOURCES_TEXTURE_DATA_MANAGER_H
 
 #include <condition_variable>
+#include <cstdint>
 #include <list>
 #include <map>
 #include <memory>
@@ -76,12 +77,20 @@ public:
 	// Load a texture, freeing resources as necessary to make space
 	void load(std::shared_ptr<TextureData> tex, bool block = false);
 
+	// Advance the bind-generation counter. Called once per rendered frame so the
+	// eviction logic in load() can tell which textures were drawn recently and
+	// avoid evicting them — otherwise the just-evicted texture is immediately
+	// re-requested next frame, causing a cascade of evictions and visible flicker.
+	void nextBindGeneration() { ++mBindGeneration; }
+	uint64_t currentBindGeneration() const { return mBindGeneration; }
+
 private:
 
 	std::list<std::shared_ptr<TextureData> >												mTextures;
 	std::map<const TextureResource*, std::list<std::shared_ptr<TextureData> >::const_iterator > 	mTextureLookup;
 	std::shared_ptr<TextureData>															mBlank;
 	TextureLoader*																			mLoader;
+	uint64_t																				mBindGeneration = 1;
 };
 
 #endif // ES_CORE_RESOURCES_TEXTURE_DATA_MANAGER_H

--- a/es-core/src/resources/TextureResource.cpp
+++ b/es-core/src/resources/TextureResource.cpp
@@ -7,7 +7,7 @@ TextureDataManager		TextureResource::sTextureDataManager;
 std::map< TextureResource::TextureKeyType, std::weak_ptr<TextureResource> > TextureResource::sTextureMap;
 std::set<TextureResource*> 	TextureResource::sAllTextures;
 
-TextureResource::TextureResource(const std::string& path, bool tile, bool dynamic) : mTextureData(nullptr), mSize(0.0f, 0.0f), mSourceSize(0.0f, 0.0f), mForceLoad(false)
+TextureResource::TextureResource(const std::string& path, bool tile, bool dynamic, bool block) : mTextureData(nullptr), mSize(0.0f, 0.0f), mSourceSize(0.0f, 0.0f), mForceLoad(false)
 {
 	// Create a texture data object for this texture
 	if (!path.empty())
@@ -19,20 +19,24 @@ TextureResource::TextureResource(const std::string& path, bool tile, bool dynami
 		{
 			data = sTextureDataManager.add(this, tile);
 			data->initFromPath(path);
-			// Force the texture manager to load it using a blocking load
-			sTextureDataManager.load(data, true);
+			// Load the texture - either blocking or async via the background thread
+			sTextureDataManager.load(data, block);
 		}
 		else
 		{
 			mTextureData = std::shared_ptr<TextureData>(new TextureData(tile));
 			data = mTextureData;
 			data->initFromPath(path);
-			// Load it so we can read the width/height
+			// Non-dynamic textures are always loaded immediately (blocking)
 			data->load();
 		}
 
-		mSize = Vector2i((int)data->width(), (int)data->height());
-		mSourceSize = Vector2f(data->sourceWidth(), data->sourceHeight());
+		if (block || !dynamic)
+		{
+			mSize = Vector2i((int)data->width(), (int)data->height());
+			mSourceSize = Vector2f(data->sourceWidth(), data->sourceHeight());
+		}
+		// When block=false && dynamic, sizes stay at (0,0) until updateTextureSize() is called
 	}
 	else
 	{
@@ -100,11 +104,16 @@ bool TextureResource::bind()
 	}
 }
 
-std::shared_ptr<TextureResource> TextureResource::get(const std::string& path, bool tile, bool forceLoad, bool dynamic)
+std::shared_ptr<TextureResource> TextureResource::get(const std::string& path, bool tile, bool forceLoad, bool dynamic, bool block)
 {
 	std::shared_ptr<ResourceManager>& rm = ResourceManager::getInstance();
 
-	const std::string canonicalPath = Utils::FileSystem::getCanonicalPath(path);
+	// Avoid getCanonicalPath here — it calls stat64/lstat64 on every path component
+	// to resolve symlinks, which blocks the main thread for tens of ms per call on NAS.
+	// Use getGenericPath (pure string normalization) instead. Built-in resource paths
+	// starting with ":/" are passed through as-is (matching getCanonicalPath behavior).
+	const std::string canonicalPath = (path.size() >= 2 && path[0] == ':' && path[1] == '/')
+		? path : Utils::FileSystem::getGenericPath(path);
 	if(canonicalPath.empty())
 	{
 		std::shared_ptr<TextureResource> tex(new TextureResource("", tile, false));
@@ -122,8 +131,10 @@ std::shared_ptr<TextureResource> TextureResource::get(const std::string& path, b
 
 	// need to create it
 	std::shared_ptr<TextureResource> tex;
-	tex = std::shared_ptr<TextureResource>(new TextureResource(key.first, tile, dynamic));
-	std::shared_ptr<TextureData> data = sTextureDataManager.get(tex.get());
+	tex = std::shared_ptr<TextureResource>(new TextureResource(key.first, tile, dynamic, block));
+	// When block=false, pass enableLoading=false to avoid re-triggering a synchronous
+	// load — the constructor already queued it for async loading via TextureLoader.
+	std::shared_ptr<TextureData> data = sTextureDataManager.get(tex.get(), block);
 
 	// is it an SVG?
 	if(key.first.substr(key.first.size() - 4, std::string::npos) != ".svg")
@@ -162,6 +173,31 @@ void TextureResource::rasterizeAt(size_t width, size_t height)
 Vector2f TextureResource::getSourceImageSize() const
 {
 	return mSourceSize;
+}
+
+bool TextureResource::updateTextureSize()
+{
+	// If sizes are already known, nothing to do
+	if (mSize != Vector2i(0, 0))
+		return true;
+
+	// Get the texture data without triggering a load
+	std::shared_ptr<TextureData> data;
+	if (mTextureData != nullptr)
+		data = mTextureData;
+	else
+		data = sTextureDataManager.get(this, false);
+
+	if (data && data->isLoaded())
+	{
+		// The background thread has finished loading - read dimensions now
+		// (safe because isLoaded() guarantees data is available via mutex ordering)
+		mSize = Vector2i((int)data->width(), (int)data->height());
+		mSourceSize = Vector2f(data->sourceWidth(), data->sourceHeight());
+		return true;
+	}
+
+	return false;
 }
 
 bool TextureResource::isInitialized() const

--- a/es-core/src/resources/TextureResource.cpp
+++ b/es-core/src/resources/TextureResource.cpp
@@ -175,6 +175,16 @@ Vector2f TextureResource::getSourceImageSize() const
 	return mSourceSize;
 }
 
+bool TextureResource::hasLoadFailed() const
+{
+	std::shared_ptr<TextureData> data;
+	if (mTextureData != nullptr)
+		data = mTextureData;
+	else
+		data = sTextureDataManager.get(this, false);
+	return data && data->hasLoadFailed();
+}
+
 bool TextureResource::updateTextureSize()
 {
 	// If sizes are already known, nothing to do

--- a/es-core/src/resources/TextureResource.cpp
+++ b/es-core/src/resources/TextureResource.cpp
@@ -197,6 +197,12 @@ bool TextureResource::updateTextureSize()
 		return true;
 	}
 
+	// Load permanently failed (e.g. file not found). Treat as "done" so callers
+	// (e.g. ImageComponent) don't keep polling every frame waiting for a result
+	// that will never come. mSize stays (0,0) — the image simply won't display.
+	if (data && data->hasLoadFailed())
+		return true;
+
 	return false;
 }
 
@@ -259,7 +265,7 @@ void TextureResource::reload()
 {
 	// For dynamically loaded textures the texture manager will load them on demand.
 	// For manually loaded textures we have to reload them here
-	if (mTextureData && !mTextureData->isLoaded())
+	if (mTextureData && !mTextureData->isLoadedOrFailed())
 		mTextureData->load();
 
 	// Uncomment this 2 lines in future release in order to reload texture VRAM exactly as it was before

--- a/es-core/src/resources/TextureResource.cpp
+++ b/es-core/src/resources/TextureResource.cpp
@@ -175,16 +175,6 @@ Vector2f TextureResource::getSourceImageSize() const
 	return mSourceSize;
 }
 
-bool TextureResource::hasLoadFailed() const
-{
-	std::shared_ptr<TextureData> data;
-	if (mTextureData != nullptr)
-		data = mTextureData;
-	else
-		data = sTextureDataManager.get(this, false);
-	return data && data->loadStatus() == TextureData::LoadStatus::FAILED;
-}
-
 bool TextureResource::updateTextureSize()
 {
 	// If sizes are already known, nothing to do

--- a/es-core/src/resources/TextureResource.cpp
+++ b/es-core/src/resources/TextureResource.cpp
@@ -182,7 +182,7 @@ bool TextureResource::hasLoadFailed() const
 		data = mTextureData;
 	else
 		data = sTextureDataManager.get(this, false);
-	return data && data->hasLoadFailed();
+	return data && data->loadStatus() == TextureData::LoadStatus::FAILED;
 }
 
 bool TextureResource::updateTextureSize()
@@ -198,22 +198,27 @@ bool TextureResource::updateTextureSize()
 	else
 		data = sTextureDataManager.get(this, false);
 
-	if (data && data->isLoaded())
+	if (!data)
+		return false;
+
+	switch (data->loadStatus())
 	{
-		// The background thread has finished loading - read dimensions now
-		// (safe because isLoaded() guarantees data is available via mutex ordering)
-		mSize = Vector2i((int)data->width(), (int)data->height());
-		mSourceSize = Vector2f(data->sourceWidth(), data->sourceHeight());
-		return true;
+		case TextureData::LoadStatus::LOADED:
+			// The background thread has finished — read dimensions now
+			// (safe because LOADED guarantees data is available via mutex ordering)
+			mSize = Vector2i((int)data->width(), (int)data->height());
+			mSourceSize = Vector2f(data->sourceWidth(), data->sourceHeight());
+			return true;
+
+		case TextureData::LoadStatus::FAILED:
+			// Permanently failed (e.g. file not found). Treat as done so callers
+			// don't keep polling. mSize stays (0,0) — image simply won't display.
+			return true;
+
+		case TextureData::LoadStatus::LOADING:
+		default:
+			return false;
 	}
-
-	// Load permanently failed (e.g. file not found). Treat as "done" so callers
-	// (e.g. ImageComponent) don't keep polling every frame waiting for a result
-	// that will never come. mSize stays (0,0) — the image simply won't display.
-	if (data && data->hasLoadFailed())
-		return true;
-
-	return false;
 }
 
 bool TextureResource::isInitialized() const
@@ -260,7 +265,7 @@ bool TextureResource::unload()
 	else
 		data = mTextureData;
 
-	if (data != nullptr && data->isLoaded())
+	if (data != nullptr && data->loadStatus() == TextureData::LoadStatus::LOADED)
 	{
 		data->releaseVRAM();
 		data->releaseRAM();
@@ -275,7 +280,7 @@ void TextureResource::reload()
 {
 	// For dynamically loaded textures the texture manager will load them on demand.
 	// For manually loaded textures we have to reload them here
-	if (mTextureData && !mTextureData->isLoadedOrFailed())
+	if (mTextureData && mTextureData->loadStatus() == TextureData::LoadStatus::LOADING)
 		mTextureData->load();
 
 	// Uncomment this 2 lines in future release in order to reload texture VRAM exactly as it was before

--- a/es-core/src/resources/TextureResource.h
+++ b/es-core/src/resources/TextureResource.h
@@ -28,9 +28,6 @@ public:
 	// Returns true if sizes are available (texture loaded), false if still pending.
 	bool updateTextureSize();
 
-	// Returns true if a previous load attempt permanently failed (e.g. file not found).
-	bool hasLoadFailed() const;
-
 	virtual ~TextureResource();
 
 	bool isInitialized() const;

--- a/es-core/src/resources/TextureResource.h
+++ b/es-core/src/resources/TextureResource.h
@@ -16,13 +16,17 @@ class TextureData;
 class TextureResource : public IReloadable
 {
 public:
-	static std::shared_ptr<TextureResource> get(const std::string& path, bool tile = false, bool forceLoad = false, bool dynamic = true);
+	static std::shared_ptr<TextureResource> get(const std::string& path, bool tile = false, bool forceLoad = false, bool dynamic = true, bool block = true);
 	void initFromPixels(const unsigned char* dataRGBA, size_t width, size_t height);
 	virtual void initFromMemory(const char* file, size_t length);
 
 	// For scalable source images in textures we want to set the resolution to rasterize at
 	void rasterizeAt(size_t width, size_t height);
 	Vector2f getSourceImageSize() const;
+
+	// Check if asynchronously-loaded texture data is ready and update cached sizes.
+	// Returns true if sizes are available (texture loaded), false if still pending.
+	bool updateTextureSize();
 
 	virtual ~TextureResource();
 
@@ -36,7 +40,7 @@ public:
 	static size_t getTotalTextureSize(); // returns the number of bytes that would be used if all textures were in memory
 
 protected:
-	TextureResource(const std::string& path, bool tile, bool dynamic);
+	TextureResource(const std::string& path, bool tile, bool dynamic, bool block = true);
 	virtual bool unload();
 	virtual void reload();
 

--- a/es-core/src/resources/TextureResource.h
+++ b/es-core/src/resources/TextureResource.h
@@ -28,6 +28,9 @@ public:
 	// Returns true if sizes are available (texture loaded), false if still pending.
 	bool updateTextureSize();
 
+	// Returns true if a previous load attempt permanently failed (e.g. file not found).
+	bool hasLoadFailed() const;
+
 	virtual ~TextureResource();
 
 	bool isInitialized() const;

--- a/es-core/src/resources/TextureResource.h
+++ b/es-core/src/resources/TextureResource.h
@@ -39,6 +39,10 @@ public:
 	static size_t getTotalMemUsage(); // returns an approximation of total VRAM used by textures (in bytes)
 	static size_t getTotalTextureSize(); // returns the number of bytes that would be used if all textures were in memory
 
+	// Advance the per-frame counter the texture cache uses to protect
+	// recently-rendered textures from eviction. Called by Window::render().
+	static void nextBindGeneration() { sTextureDataManager.nextBindGeneration(); }
+
 protected:
 	TextureResource(const std::string& path, bool tile, bool dynamic, bool block = true);
 	virtual bool unload();

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -605,13 +605,13 @@ namespace Utils
 			if(!exists(path))
 				return true;
 
-			bool removed = (unlink(path.c_str()) == 0);
-			
-			// if removed, let's remove it from the index
-			if (removed)
-				pathExistsIndex[_path] = false;
-
 			// try to remove file
+			bool removed = (unlink(path.c_str()) == 0);
+			if (removed)
+			{
+				const std::unique_lock<std::recursive_mutex> lock(mutex);
+				pathExistsIndex[_path] = false;
+			}
 			return removed;
 
 		} // removeFile
@@ -629,6 +629,7 @@ namespace Utils
 			// try to create directory
 			if(mkdir(path.c_str(), 0755) == 0)
 			{
+				const std::unique_lock<std::recursive_mutex> lock(mutex);
 				pathExistsIndex[_path] = true;
 				return true;
 			}
@@ -642,9 +643,11 @@ namespace Utils
 
 			// try to create directory again now that the parent should exist
 			bool created = (mkdir(path.c_str(), 0755) == 0);
-			if(created)
+			if (created)
+			{
+				const std::unique_lock<std::recursive_mutex> lock(mutex);
 				pathExistsIndex[_path] = true;
-
+			}
 			return created;
 
 		} // createDirectory
@@ -653,17 +656,27 @@ namespace Utils
 
 		bool exists(const std::string& _path)
 		{
-			const std::unique_lock<std::recursive_mutex> lock(mutex);
-
-			if(pathExistsIndex.find(_path) == pathExistsIndex.cend())
+			// Fast path: return cached result without doing any I/O.
 			{
-				const std::string path = getGenericPath(_path);
-				struct stat64 info;
-				// check if stat64 succeeded
-				pathExistsIndex[_path] = (stat64(path.c_str(), &info) == 0);
+				const std::unique_lock<std::recursive_mutex> lock(mutex);
+				auto it = pathExistsIndex.find(_path);
+				if (it != pathExistsIndex.cend())
+					return it->second;
 			}
 
-			return pathExistsIndex.at(_path);
+			// Slow path: stat outside the lock so a blocking NAS call on the
+			// background texture-loader thread doesn't stall the main thread
+			// when it tries to acquire the same mutex (e.g. Scripting::fireEvent).
+			const std::string path = getGenericPath(_path);
+			struct stat64 info;
+			bool result = (stat64(path.c_str(), &info) == 0);
+
+			{
+				const std::unique_lock<std::recursive_mutex> lock(mutex);
+				pathExistsIndex[_path] = result;
+			}
+
+			return result;
 
 		} // exists
 


### PR DESCRIPTION
Some use cases can put metadata images on a NAS. This can introduce some extreme latencies when reading a file. This is rather not gonna make emulation station so happy as the File IO happens  on the same thread as the UI. If the file IO takes a while, the UI is FROZEN.
Move it to a more async way of reading file where it rather polls until it is done reading the file and pop the image in

BEFORE

https://github.com/user-attachments/assets/5f311b2f-473a-4321-ba54-2e0ccc9b973b


AFTER


https://github.com/user-attachments/assets/4e197f90-8d28-48a2-8d3f-64a518035a8d




This was mostly done with Claude