### PR TITLE
Allow for a Game to have multiple 'rom' files attached with it

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -37,6 +37,7 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiCollectionSystemsOptions.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRandomCollectionOptions.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiInfoPopup.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRomSelectionMenu.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRomSelector.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRomMetaDataEd.h
 
@@ -98,6 +99,7 @@ set(ES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiCollectionSystemsOptions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRandomCollectionOptions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiInfoPopup.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRomSelectionMenu.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRomSelector.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRomMetaDataEd.cpp
 

--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -37,6 +37,8 @@ set(ES_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiCollectionSystemsOptions.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRandomCollectionOptions.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiInfoPopup.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRomSelector.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRomMetaDataEd.h
 
     # Scrapers
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/Scraper.h
@@ -96,6 +98,8 @@ set(ES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiCollectionSystemsOptions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRandomCollectionOptions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiInfoPopup.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRomSelector.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/guis/GuiRomMetaDataEd.cpp
 
     # Scrapers
     ${CMAKE_CURRENT_SOURCE_DIR}/src/scrapers/Scraper.cpp

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -357,7 +357,7 @@ void FileData::sort(const SortType& type)
 	mSortDesc = type.description;
 }
 
-void FileData::launchGame(Window* window)
+void FileData::launchGame(Window* window, const std::string& romPathOverride)
 {
 	LOG(LogInfo) << "Attempting to launch game...";
 
@@ -368,7 +368,7 @@ void FileData::launchGame(Window* window)
 
 	std::string command = mEnvData->mLaunchCommand;
 
-	const std::string launchPath = getLaunchRomPath();
+	const std::string launchPath = romPathOverride.empty() ? getLaunchRomPath() : romPathOverride;
 	const std::string rom      = Utils::FileSystem::getEscapedPath(launchPath);
 	const std::string basename = Utils::FileSystem::getStem(launchPath);
 	const std::string rom_raw  = Utils::FileSystem::getPreferredPath(launchPath);

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -24,6 +24,13 @@ FileData::FileData(FileType type, const std::string& path, SystemEnvironmentData
 	if(metadata.get("name").empty())
 		metadata.set("name", getDisplayName());
 	mSystemName = system->getName();
+	if(mType == GAME)
+	{
+		RomData rom;
+		rom.path = path;
+		rom.preferred = true;
+		mRoms.push_back(rom);
+	}
 	metadata.resetChangedFlag();
 }
 
@@ -54,12 +61,22 @@ std::string FileData::getCleanName() const
 
 const std::string FileData::getThumbnailPath() const
 {
-	std::string thumbnail = metadata.get("thumbnail");
+	return getEffectiveThumbnailPath(getPreferredRom());
+}
+
+const std::string FileData::getEffectiveThumbnailPath(const RomData* rom) const
+{
+	std::string thumbnail;
+	if(rom)
+		thumbnail = rom->thumbnail;
+
+	if(thumbnail.empty())
+		thumbnail = metadata.get("thumbnail");
 
 	// no thumbnail, try image
 	if(thumbnail.empty())
 	{
-		thumbnail = metadata.get("image");
+		thumbnail = getEffectiveImagePath(rom);
 
 		// no image, try to use local image
 		if(thumbnail.empty() && Settings::getInstance()->getBool("LocalArt"))
@@ -115,7 +132,17 @@ const std::vector<FileData*>& FileData::getChildrenListToDisplay() {
 
 const std::string FileData::getVideoPath() const
 {
-	std::string video = metadata.get("video");
+	return getEffectiveVideoPath(getPreferredRom());
+}
+
+const std::string FileData::getEffectiveVideoPath(const RomData* rom) const
+{
+	std::string video;
+	if(rom)
+		video = rom->video;
+
+	if(video.empty())
+		video = metadata.get("video");
 
 	// no video, try to use local video
 	if(video.empty() && Settings::getInstance()->getBool("LocalArt"))
@@ -130,7 +157,17 @@ const std::string FileData::getVideoPath() const
 
 const std::string FileData::getMarqueePath() const
 {
-	std::string marquee = metadata.get("marquee");
+	return getEffectiveMarqueePath(getPreferredRom());
+}
+
+const std::string FileData::getEffectiveMarqueePath(const RomData* rom) const
+{
+	std::string marquee;
+	if(rom)
+		marquee = rom->marquee;
+
+	if(marquee.empty())
+		marquee = metadata.get("marquee");
 
 	// no marquee, try to use local marquee
 	if(marquee.empty() && Settings::getInstance()->getBool("LocalArt"))
@@ -152,7 +189,17 @@ const std::string FileData::getMarqueePath() const
 
 const std::string FileData::getImagePath() const
 {
-	std::string image = metadata.get("image");
+	return getEffectiveImagePath(getPreferredRom());
+}
+
+const std::string FileData::getEffectiveImagePath(const RomData* rom) const
+{
+	std::string image;
+	if(rom)
+		image = rom->image;
+
+	if(image.empty())
+		image = metadata.get("image");
 
 	// no image, try to use local image
 	if(image.empty())
@@ -170,6 +217,40 @@ const std::string FileData::getImagePath() const
 	}
 
 	return image;
+}
+
+const RomData* FileData::getPreferredRom() const
+{
+	if(mRoms.empty())
+		return NULL;
+
+	for(auto it = mRoms.cbegin(); it != mRoms.cend(); ++it)
+	{
+		if(it->preferred)
+			return &(*it);
+	}
+
+	return &mRoms.front();
+}
+
+const RomData* FileData::getRomByPath(const std::string& path) const
+{
+	for(auto it = mRoms.cbegin(); it != mRoms.cend(); ++it)
+	{
+		if(it->path == path)
+			return &(*it);
+	}
+
+	return NULL;
+}
+
+const std::string FileData::getLaunchRomPath() const
+{
+	const RomData* preferred = getPreferredRom();
+	if(preferred != NULL && !preferred->path.empty())
+		return preferred->path;
+
+	return getPath();
 }
 
 std::vector<FileData*> FileData::getFilesRecursive(unsigned int typeMask, bool displayedOnly) const
@@ -287,9 +368,10 @@ void FileData::launchGame(Window* window)
 
 	std::string command = mEnvData->mLaunchCommand;
 
-	const std::string rom      = Utils::FileSystem::getEscapedPath(getPath());
-	const std::string basename = Utils::FileSystem::getStem(getPath());
-	const std::string rom_raw  = Utils::FileSystem::getPreferredPath(getPath());
+	const std::string launchPath = getLaunchRomPath();
+	const std::string rom      = Utils::FileSystem::getEscapedPath(launchPath);
+	const std::string basename = Utils::FileSystem::getStem(launchPath);
+	const std::string rom_raw  = Utils::FileSystem::getPreferredPath(launchPath);
 	const std::string name     = getName();
 
 	command = Utils::String::replace(command, "%ROM%", rom);
@@ -335,6 +417,7 @@ CollectionFileData::CollectionFileData(FileData* file, SystemData* system)
 	refreshMetadata();
 	mParent = NULL;
 	metadata = mSourceFileData->metadata;
+	getRomsMutable() = mSourceFileData->getRoms();
 	mSystemName = mSourceFileData->getSystem()->getName();
 }
 
@@ -358,6 +441,7 @@ FileData* CollectionFileData::getSourceFileData()
 void CollectionFileData::refreshMetadata()
 {
 	metadata = mSourceFileData->metadata;
+	getRomsMutable() = mSourceFileData->getRoms();
 	mDirty = true;
 }
 

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -105,7 +105,7 @@ public:
 	// As above, but also remove parenthesis
 	std::string getCleanName() const;
 
-	void launchGame(Window* window);
+	void launchGame(Window* window, const std::string& romPathOverride = "");
 
 	typedef bool ComparisonFunction(const FileData* a, const FileData* b);
 	struct SortType

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -10,9 +10,30 @@ class SystemData;
 class Window;
 struct SystemEnvironmentData;
 
+struct RomData
+{
+	std::string path;
+	std::string romName;
+
+	std::vector<std::string> regions;
+	std::vector<std::string> languages;
+
+	std::string releaseDate;
+	std::string revision;
+
+	std::string image;
+	std::string video;
+	std::string thumbnail;
+	std::string marquee;
+
+	bool preferred;
+
+	RomData() : preferred(false) {}
+};
+
 enum FileType
 {
-	GAME = 1,   // Cannot have children.
+	GAME = 1,   // Cannot have FileData children (ROM variants are stored in mRoms, not as FileData nodes).
 	FOLDER = 2,
 	PLACEHOLDER = 3
 };
@@ -49,6 +70,17 @@ public:
 	virtual const std::string getVideoPath() const;
 	virtual const std::string getMarqueePath() const;
 	virtual const std::string getImagePath() const;
+	const std::string getEffectiveImagePath(const RomData* rom) const;
+	const std::string getEffectiveVideoPath(const RomData* rom) const;
+	const std::string getEffectiveThumbnailPath(const RomData* rom) const;
+	const std::string getEffectiveMarqueePath(const RomData* rom) const;
+
+	inline const std::vector<RomData>& getRoms() const { return mRoms; }
+	// Mutable access for parser/migration code that needs to rebuild ROM variants in-place.
+	inline std::vector<RomData>& getRomsMutable() { return mRoms; }
+	const RomData* getPreferredRom() const;
+	const RomData* getRomByPath(const std::string& path) const;
+	const std::string getLaunchRomPath() const;
 
 	const std::vector<FileData*>& getChildrenListToDisplay();
 	std::vector<FileData*> getFilesRecursive(unsigned int typeMask, bool displayedOnly = false) const;
@@ -104,6 +136,7 @@ private:
 	std::unordered_map<std::string,FileData*> mChildrenByFilename;
 	std::vector<FileData*> mChildren;
 	std::vector<FileData*> mFilteredChildren;
+	std::vector<RomData> mRoms;
 	std::string mSortDesc;
 };
 

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -19,7 +19,6 @@ struct RomData
 	std::vector<std::string> languages;
 
 	std::string releaseDate;
-	std::string revision;
 
 	std::string image;
 	std::string video;

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -94,6 +94,15 @@ namespace
 			parent.append_child(tag).text().set(value.c_str());
 	}
 
+	void appendOptionalPathNode(pugi::xml_node& parent, const char* tag, const std::string& value, const std::string& relativeTo)
+	{
+		if(value.empty())
+			return;
+
+		std::string relValue = Utils::FileSystem::createRelativePath(value, relativeTo, true, true);
+		parent.append_child(tag).text().set(relValue.c_str());
+	}
+
 	std::string getGamePathForNode(const pugi::xml_node& gameNode, const std::string& relativeTo)
 	{
 		// New format can omit top-level <path>. In that case we choose the preferred
@@ -433,10 +442,10 @@ void addFileDataNode(pugi::xml_node& parent, const FileData* file, const char* t
 			appendMultiValueNode(romNode, "languages", "language", it->languages);
 			appendOptionalTextNode(romNode, "releasedate", it->releaseDate);
 			appendOptionalTextNode(romNode, "revision", it->revision);
-			appendOptionalTextNode(romNode, "image", it->image);
-			appendOptionalTextNode(romNode, "video", it->video);
-			appendOptionalTextNode(romNode, "thumbnail", it->thumbnail);
-			appendOptionalTextNode(romNode, "marquee", it->marquee);
+			appendOptionalPathNode(romNode, "image", it->image, system->getStartPath());
+			appendOptionalPathNode(romNode, "video", it->video, system->getStartPath());
+			appendOptionalPathNode(romNode, "thumbnail", it->thumbnail, system->getStartPath());
+			appendOptionalPathNode(romNode, "marquee", it->marquee, system->getStartPath());
 		}
 		return;
 	}

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -70,10 +70,10 @@ namespace
 		rom.languages = parseRomMultiValue(romNode, "language", "languages");
 		rom.releaseDate = romNode.child("releasedate").text().get();
 		rom.revision = romNode.child("revision").text().get();
-		rom.image = romNode.child("image").text().get();
-		rom.video = romNode.child("video").text().get();
-		rom.thumbnail = romNode.child("thumbnail").text().get();
-		rom.marquee = romNode.child("marquee").text().get();
+		rom.image = Utils::FileSystem::resolveRelativePath(romNode.child("image").text().get(), relativeTo, true, true);
+		rom.video = Utils::FileSystem::resolveRelativePath(romNode.child("video").text().get(), relativeTo, true, true);
+		rom.thumbnail = Utils::FileSystem::resolveRelativePath(romNode.child("thumbnail").text().get(), relativeTo, true, true);
+		rom.marquee = Utils::FileSystem::resolveRelativePath(romNode.child("marquee").text().get(), relativeTo, true, true);
 		rom.preferred = parsePreferredRomAttribute(romNode);
 		return rom;
 	}
@@ -342,10 +342,10 @@ void parseGamelist(SystemData* system)
 						rom.languages = parseRomMultiValue(fileNode, "language", "languages");
 						rom.releaseDate = fileNode.child("releasedate").text().get();
 						rom.revision = fileNode.child("revision").text().get();
-						rom.image = fileNode.child("image").text().get();
-						rom.video = fileNode.child("video").text().get();
-						rom.thumbnail = fileNode.child("thumbnail").text().get();
-						rom.marquee = fileNode.child("marquee").text().get();
+						rom.image = Utils::FileSystem::resolveRelativePath(fileNode.child("image").text().get(), relativeTo, true, true);
+						rom.video = Utils::FileSystem::resolveRelativePath(fileNode.child("video").text().get(), relativeTo, true, true);
+						rom.thumbnail = Utils::FileSystem::resolveRelativePath(fileNode.child("thumbnail").text().get(), relativeTo, true, true);
+						rom.marquee = Utils::FileSystem::resolveRelativePath(fileNode.child("marquee").text().get(), relativeTo, true, true);
 						rom.preferred = true;
 						roms.push_back(rom);
 						romVariantCount++;

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -10,7 +10,7 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include <pugixml.hpp>
-#include <unordered_set>
+#include <unordered_map>
 
 namespace
 {
@@ -214,36 +214,24 @@ FileData* findOrCreateFile(SystemData* system, const std::string& path, FileType
 	return NULL;
 }
 
-FileData* findFile(SystemData* system, const std::string& path)
+std::unordered_map<std::string, FileData*> buildGamePathIndex(SystemData* system)
 {
-	FileData* root = system->getRootFolder();
-	bool contains = false;
-	const std::string systemPath = root->getPath();
+	std::unordered_map<std::string, FileData*> index;
+	FileData* rootFolder = system->getRootFolder();
+	if(rootFolder == NULL)
+		return index;
 
-	std::string relative = Utils::FileSystem::removeCommonPath(path, systemPath, contains, true);
-	if(!contains)
-		return NULL;
+	const std::vector<FileData*> games = rootFolder->getFilesRecursive(GAME);
+	for(auto it = games.cbegin(); it != games.cend(); ++it)
+		index[(*it)->getPath()] = *it;
 
-	Utils::FileSystem::stringList pathList = Utils::FileSystem::getPathList(relative);
-	if(pathList.empty())
-		return NULL;
-
-	FileData* treeNode = root;
-	for(auto path_it = pathList.cbegin(); path_it != pathList.cend(); ++path_it)
-	{
-		const std::unordered_map<std::string, FileData*>& children = treeNode->getChildrenByFilename();
-		auto candidate = children.find(*path_it);
-		if(candidate == children.cend())
-			return NULL;
-
-		treeNode = candidate->second;
-	}
-
-	return treeNode;
+	return index;
 }
 
 void parseGamelist(SystemData* system)
 {
+	const auto parseStartTs = std::chrono::steady_clock::now();
+
 	bool trustGamelist = Settings::getInstance()->getBool("ParseGamelistOnly");
 	std::string xmlpath = system->getGamelistPath(false);
 	const std::vector<std::string> allowedExtensions = system->getExtensions();
@@ -270,9 +258,14 @@ void parseGamelist(SystemData* system)
 	}
 
 	std::string relativeTo = system->getStartPath();
+	const auto indexStartTs = std::chrono::steady_clock::now();
+	std::unordered_map<std::string, FileData*> gamePathIndex = buildGamePathIndex(system);
+	const auto indexEndTs = std::chrono::steady_clock::now();
 
-	std::unordered_set<std::string> canonicalGamePaths;
-	std::unordered_set<std::string> romVariantPaths;
+	size_t hierarchicalGameCount = 0;
+	size_t romVariantCount = 0;
+	size_t duplicateRemovedCount = 0;
+	const auto parseLoopStartTs = std::chrono::steady_clock::now();
 
 	const char* tagList[2] = { "game", "folder" };
 	FileType typeList[2] = { GAME, FOLDER };
@@ -312,7 +305,7 @@ void parseGamelist(SystemData* system)
 			else if(!file->isArcadeAsset())
 			{
 				if(type == GAME)
-					canonicalGamePaths.insert(path);
+					gamePathIndex[file->getPath()] = file;
 
 				std::string defaultName = file->metadata.get("name");
 				file->metadata = MetaDataList::createFromXML(file->getType() == GAME ? GAME_METADATA : FOLDER_METADATA, fileNode, relativeTo);
@@ -326,14 +319,16 @@ void parseGamelist(SystemData* system)
 					pugi::xml_node romsNode = fileNode.child("roms");
 					if(romsNode)
 					{
+						hierarchicalGameCount++;
 						for(pugi::xml_node romNode = romsNode.child("rom"); romNode; romNode = romNode.next_sibling("rom"))
 						{
 							RomData rom = parseRomNode(romNode, relativeTo);
 							if(!rom.path.empty())
 							{
 								roms.push_back(rom);
-								romVariantPaths.insert(rom.path);
+								romVariantCount++;
 							}
+							
 						}
 					}
 
@@ -353,7 +348,7 @@ void parseGamelist(SystemData* system)
 						rom.marquee = fileNode.child("marquee").text().get();
 						rom.preferred = true;
 						roms.push_back(rom);
-						romVariantPaths.insert(rom.path);
+						romVariantCount++;
 					}
 
 					bool hasPreferred = false;
@@ -372,6 +367,24 @@ void parseGamelist(SystemData* system)
 					// Preserve legacy behavior where releasedate was expected on game-level metadata.
 					if((file->metadata.get("releasedate").empty() || file->metadata.get("releasedate") == "not-a-date-time") && !roms.front().releaseDate.empty())
 						file->metadata.set("releasedate", roms.front().releaseDate);
+
+					// Keep one canonical FileData entry per hierarchical game. Any other
+					// ROM paths in this same game node are variants and should not remain
+					// as standalone top-level entries discovered from filesystem scanning.
+					for(auto rit = roms.cbegin(); rit != roms.cend(); ++rit)
+					{
+						if(rit->path.empty() || rit->path == file->getPath())
+							continue;
+
+						auto duplicateIt = gamePathIndex.find(rit->path);
+						FileData* duplicate = (duplicateIt != gamePathIndex.cend()) ? duplicateIt->second : NULL;
+						if(duplicate != NULL && duplicate->getType() == GAME)
+						{
+							gamePathIndex.erase(rit->path);
+							delete duplicate;
+							duplicateRemovedCount++;
+						}
+					}
 				}
 
 				//make sure name gets set if one didn't exist
@@ -383,17 +396,15 @@ void parseGamelist(SystemData* system)
 		}
 	}
 
-	// Hierarchical entries keep one canonical FileData; remove sibling FileData nodes
-	// created from filesystem scanning for non-canonical ROM variants.
-	for(auto it = romVariantPaths.cbegin(); it != romVariantPaths.cend(); ++it)
-	{
-		if(canonicalGamePaths.find(*it) != canonicalGamePaths.cend())
-			continue;
-
-		FileData* duplicate = findFile(system, *it);
-		if(duplicate != NULL && duplicate->getType() == GAME)
-			delete duplicate;
-	}
+	const auto parseLoopEndTs = std::chrono::steady_clock::now();
+	const auto parseEndTs = std::chrono::steady_clock::now();
+	LOG(LogInfo) << "Parsed gamelist performance for system '" << system->getName() << "': "
+		<< "index=" << std::chrono::duration_cast<std::chrono::milliseconds>(indexEndTs - indexStartTs).count() << "ms, "
+		<< "parse-loop=" << std::chrono::duration_cast<std::chrono::milliseconds>(parseLoopEndTs - parseLoopStartTs).count() << "ms, "
+		<< "total=" << std::chrono::duration_cast<std::chrono::milliseconds>(parseEndTs - parseStartTs).count() << "ms, "
+		<< "hierarchical-games=" << hierarchicalGameCount << ", "
+		<< "rom-variants=" << romVariantCount << ", "
+		<< "duplicates-removed=" << duplicateRemovedCount;
 }
 
 void addFileDataNode(pugi::xml_node& parent, const FileData* file, const char* tag, SystemData* system)

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -10,6 +10,7 @@
 #include "Settings.h"
 #include "SystemData.h"
 #include <pugixml.hpp>
+#include <unordered_set>
 
 namespace
 {
@@ -213,6 +214,34 @@ FileData* findOrCreateFile(SystemData* system, const std::string& path, FileType
 	return NULL;
 }
 
+FileData* findFile(SystemData* system, const std::string& path)
+{
+	FileData* root = system->getRootFolder();
+	bool contains = false;
+	const std::string systemPath = root->getPath();
+
+	std::string relative = Utils::FileSystem::removeCommonPath(path, systemPath, contains, true);
+	if(!contains)
+		return NULL;
+
+	Utils::FileSystem::stringList pathList = Utils::FileSystem::getPathList(relative);
+	if(pathList.empty())
+		return NULL;
+
+	FileData* treeNode = root;
+	for(auto path_it = pathList.cbegin(); path_it != pathList.cend(); ++path_it)
+	{
+		const std::unordered_map<std::string, FileData*>& children = treeNode->getChildrenByFilename();
+		auto candidate = children.find(*path_it);
+		if(candidate == children.cend())
+			return NULL;
+
+		treeNode = candidate->second;
+	}
+
+	return treeNode;
+}
+
 void parseGamelist(SystemData* system)
 {
 	bool trustGamelist = Settings::getInstance()->getBool("ParseGamelistOnly");
@@ -241,6 +270,9 @@ void parseGamelist(SystemData* system)
 	}
 
 	std::string relativeTo = system->getStartPath();
+
+	std::unordered_set<std::string> canonicalGamePaths;
+	std::unordered_set<std::string> romVariantPaths;
 
 	const char* tagList[2] = { "game", "folder" };
 	FileType typeList[2] = { GAME, FOLDER };
@@ -279,6 +311,9 @@ void parseGamelist(SystemData* system)
 			}
 			else if(!file->isArcadeAsset())
 			{
+				if(type == GAME)
+					canonicalGamePaths.insert(path);
+
 				std::string defaultName = file->metadata.get("name");
 				file->metadata = MetaDataList::createFromXML(file->getType() == GAME ? GAME_METADATA : FOLDER_METADATA, fileNode, relativeTo);
 				if(type == GAME)
@@ -295,7 +330,10 @@ void parseGamelist(SystemData* system)
 						{
 							RomData rom = parseRomNode(romNode, relativeTo);
 							if(!rom.path.empty())
+							{
 								roms.push_back(rom);
+								romVariantPaths.insert(rom.path);
+							}
 						}
 					}
 
@@ -315,6 +353,7 @@ void parseGamelist(SystemData* system)
 						rom.marquee = fileNode.child("marquee").text().get();
 						rom.preferred = true;
 						roms.push_back(rom);
+						romVariantPaths.insert(rom.path);
 					}
 
 					bool hasPreferred = false;
@@ -342,6 +381,18 @@ void parseGamelist(SystemData* system)
 				file->metadata.resetChangedFlag();
 			}
 		}
+	}
+
+	// Hierarchical entries keep one canonical FileData; remove sibling FileData nodes
+	// created from filesystem scanning for non-canonical ROM variants.
+	for(auto it = romVariantPaths.cbegin(); it != romVariantPaths.cend(); ++it)
+	{
+		if(canonicalGamePaths.find(*it) != canonicalGamePaths.cend())
+			continue;
+
+		FileData* duplicate = findFile(system, *it);
+		if(duplicate != NULL && duplicate->getType() == GAME)
+			delete duplicate;
 	}
 }
 

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -69,7 +69,6 @@ namespace
 		rom.regions = parseRomMultiValue(romNode, "region", "regions");
 		rom.languages = parseRomMultiValue(romNode, "language", "languages");
 		rom.releaseDate = romNode.child("releasedate").text().get();
-		rom.revision = romNode.child("revision").text().get();
 		rom.image = Utils::FileSystem::resolveRelativePath(romNode.child("image").text().get(), relativeTo, true, true);
 		rom.video = Utils::FileSystem::resolveRelativePath(romNode.child("video").text().get(), relativeTo, true, true);
 		rom.thumbnail = Utils::FileSystem::resolveRelativePath(romNode.child("thumbnail").text().get(), relativeTo, true, true);
@@ -350,7 +349,6 @@ void parseGamelist(SystemData* system)
 						rom.regions = parseRomMultiValue(fileNode, "region", "regions");
 						rom.languages = parseRomMultiValue(fileNode, "language", "languages");
 						rom.releaseDate = fileNode.child("releasedate").text().get();
-						rom.revision = fileNode.child("revision").text().get();
 						rom.image = Utils::FileSystem::resolveRelativePath(fileNode.child("image").text().get(), relativeTo, true, true);
 						rom.video = Utils::FileSystem::resolveRelativePath(fileNode.child("video").text().get(), relativeTo, true, true);
 						rom.thumbnail = Utils::FileSystem::resolveRelativePath(fileNode.child("thumbnail").text().get(), relativeTo, true, true);
@@ -441,7 +439,6 @@ void addFileDataNode(pugi::xml_node& parent, const FileData* file, const char* t
 			appendMultiValueNode(romNode, "regions", "region", it->regions);
 			appendMultiValueNode(romNode, "languages", "language", it->languages);
 			appendOptionalTextNode(romNode, "releasedate", it->releaseDate);
-			appendOptionalTextNode(romNode, "revision", it->revision);
 			appendOptionalPathNode(romNode, "image", it->image, system->getStartPath());
 			appendOptionalPathNode(romNode, "video", it->video, system->getStartPath());
 			appendOptionalPathNode(romNode, "thumbnail", it->thumbnail, system->getStartPath());

--- a/es-app/src/Gamelist.cpp
+++ b/es-app/src/Gamelist.cpp
@@ -3,12 +3,124 @@
 #include <chrono>
 
 #include "utils/FileSystemUtil.h"
+#include "utils/StringUtil.h"
 #include "FileData.h"
 #include "FileFilterIndex.h"
 #include "Log.h"
 #include "Settings.h"
 #include "SystemData.h"
 #include <pugixml.hpp>
+
+namespace
+{
+	// Parses either nested (e.g. <languages><language>en</language></languages>)
+	// or repeated flat tags (e.g. <language>en</language><language>fr</language>)
+	// into a normalized vector.
+	std::vector<std::string> parseRomMultiValue(const pugi::xml_node& romNode, const char* singularTag, const char* containerTag)
+	{
+		std::vector<std::string> values;
+
+		pugi::xml_node container = romNode.child(containerTag);
+		if(container)
+		{
+			for(pugi::xml_node node = container.child(singularTag); node; node = node.next_sibling(singularTag))
+			{
+				const std::string value = Utils::String::trim(node.text().get());
+				if(!value.empty())
+					values.push_back(value);
+			}
+		}
+
+		if(values.empty())
+		{
+			for(pugi::xml_node node = romNode.child(singularTag); node; node = node.next_sibling(singularTag))
+			{
+				const std::string value = Utils::String::trim(node.text().get());
+				if(!value.empty())
+					values.push_back(value);
+			}
+		}
+
+		return values;
+	}
+
+	bool parsePreferredRomAttribute(const pugi::xml_node& romNode)
+	{
+		pugi::xml_attribute preferredAttr = romNode.attribute("preferred");
+		if(!preferredAttr)
+			return false;
+
+		std::string val = Utils::String::toLower(Utils::String::trim(preferredAttr.as_string()));
+		if(val == "true")
+			return true;
+		if(val == "false")
+			return false;
+
+		LOG(LogWarning) << "Invalid preferred value '" << preferredAttr.as_string() << "' on <rom>; expected 'true' or 'false'. Treating as false.";
+		return false;
+	}
+
+	RomData parseRomNode(const pugi::xml_node& romNode, const std::string& relativeTo)
+	{
+		RomData rom;
+		rom.path = Utils::FileSystem::resolveRelativePath(romNode.child("path").text().get(), relativeTo, false, true);
+		rom.romName = romNode.child("romname").text().get();
+		rom.regions = parseRomMultiValue(romNode, "region", "regions");
+		rom.languages = parseRomMultiValue(romNode, "language", "languages");
+		rom.releaseDate = romNode.child("releasedate").text().get();
+		rom.revision = romNode.child("revision").text().get();
+		rom.image = romNode.child("image").text().get();
+		rom.video = romNode.child("video").text().get();
+		rom.thumbnail = romNode.child("thumbnail").text().get();
+		rom.marquee = romNode.child("marquee").text().get();
+		rom.preferred = parsePreferredRomAttribute(romNode);
+		return rom;
+	}
+
+	void appendMultiValueNode(pugi::xml_node& parent, const char* containerTag, const char* childTag, const std::vector<std::string>& values)
+	{
+		if(values.empty())
+			return;
+
+		pugi::xml_node container = parent.append_child(containerTag);
+		for(auto it = values.cbegin(); it != values.cend(); ++it)
+			container.append_child(childTag).text().set(it->c_str());
+	}
+
+	void appendOptionalTextNode(pugi::xml_node& parent, const char* tag, const std::string& value)
+	{
+		if(!value.empty())
+			parent.append_child(tag).text().set(value.c_str());
+	}
+
+	std::string getGamePathForNode(const pugi::xml_node& gameNode, const std::string& relativeTo)
+	{
+		// New format can omit top-level <path>. In that case we choose the preferred
+		// ROM path as the canonical lookup key for findOrCreateFile.
+		std::string path = gameNode.child("path").text().get();
+		if(!path.empty())
+			return Utils::FileSystem::resolveRelativePath(path, relativeTo, false, true);
+
+		pugi::xml_node romsNode = gameNode.child("roms");
+		if(!romsNode)
+			return "";
+
+		pugi::xml_node firstRom;
+		for(pugi::xml_node romNode = romsNode.child("rom"); romNode; romNode = romNode.next_sibling("rom"))
+		{
+			if(!firstRom)
+				firstRom = romNode;
+
+			if(parsePreferredRomAttribute(romNode))
+				return Utils::FileSystem::resolveRelativePath(romNode.child("path").text().get(), relativeTo, false, true);
+		}
+
+		if(firstRom)
+			return Utils::FileSystem::resolveRelativePath(firstRom.child("path").text().get(), relativeTo, false, true);
+
+		return "";
+	}
+}
 
 FileData* findOrCreateFile(SystemData* system, const std::string& path, FileType type)
 {
@@ -138,8 +250,13 @@ void parseGamelist(SystemData* system)
 		FileType type = typeList[i];
 		for(pugi::xml_node fileNode = root.child(tag); fileNode; fileNode = fileNode.next_sibling(tag))
 		{
-			std::string path = fileNode.child("path").text().get();
-			path = Utils::FileSystem::resolveRelativePath(path, relativeTo, false, true);
+			std::string path = (type == GAME) ? getGamePathForNode(fileNode, relativeTo) : Utils::FileSystem::resolveRelativePath(fileNode.child("path").text().get(), relativeTo, false, true);
+
+			if(path.empty())
+			{
+				LOG(LogWarning) << "Missing path for <" << tag << "> entry, skipping.";
+				continue;
+			}
 
 			if(!trustGamelist && !Utils::FileSystem::exists(path))
 			{
@@ -164,6 +281,59 @@ void parseGamelist(SystemData* system)
 			{
 				std::string defaultName = file->metadata.get("name");
 				file->metadata = MetaDataList::createFromXML(file->getType() == GAME ? GAME_METADATA : FOLDER_METADATA, fileNode, relativeTo);
+				if(type == GAME)
+				{
+					// Rebuild ROM variants from XML every parse so in-memory state reflects
+					// both old flat and new hierarchical formats consistently.
+					std::vector<RomData>& roms = file->getRomsMutable();
+					roms.clear();
+
+					pugi::xml_node romsNode = fileNode.child("roms");
+					if(romsNode)
+					{
+						for(pugi::xml_node romNode = romsNode.child("rom"); romNode; romNode = romNode.next_sibling("rom"))
+						{
+							RomData rom = parseRomNode(romNode, relativeTo);
+							if(!rom.path.empty())
+								roms.push_back(rom);
+						}
+					}
+
+					if(roms.empty())
+					{
+						// Backward-compat: old flat <game> entries become one game + one rom.
+						RomData rom;
+						rom.path = path;
+						rom.romName = fileNode.child("romname").text().as_string(fileNode.child("name").text().get());
+						rom.regions = parseRomMultiValue(fileNode, "region", "regions");
+						rom.languages = parseRomMultiValue(fileNode, "language", "languages");
+						rom.releaseDate = fileNode.child("releasedate").text().get();
+						rom.revision = fileNode.child("revision").text().get();
+						rom.image = fileNode.child("image").text().get();
+						rom.video = fileNode.child("video").text().get();
+						rom.thumbnail = fileNode.child("thumbnail").text().get();
+						rom.marquee = fileNode.child("marquee").text().get();
+						rom.preferred = true;
+						roms.push_back(rom);
+					}
+
+					bool hasPreferred = false;
+					for(auto rit = roms.cbegin(); rit != roms.cend(); ++rit)
+					{
+						if(rit->preferred)
+						{
+							hasPreferred = true;
+							break;
+						}
+					}
+					if(!hasPreferred)
+						// Deterministic fallback when preferred is absent in source XML.
+						roms.front().preferred = true;
+
+					// Preserve legacy behavior where releasedate was expected on game-level metadata.
+					if((file->metadata.get("releasedate").empty() || file->metadata.get("releasedate") == "not-a-date-time") && !roms.front().releaseDate.empty())
+						file->metadata.set("releasedate", roms.front().releaseDate);
+				}
 
 				//make sure name gets set if one didn't exist
 				if(file->metadata.get("name").empty())
@@ -177,6 +347,38 @@ void parseGamelist(SystemData* system)
 
 void addFileDataNode(pugi::xml_node& parent, const FileData* file, const char* tag, SystemData* system)
 {
+	if(file->getType() == GAME)
+	{
+		pugi::xml_node newNode = parent.append_child(tag);
+
+		file->metadata.appendToXML(newNode, true, system->getStartPath());
+		// New hierarchical format stores launch paths and release dates per ROM.
+		newNode.remove_child("path");
+		newNode.remove_child("releasedate");
+
+		pugi::xml_node romsNode = newNode.append_child("roms");
+		for(auto it = file->getRoms().cbegin(); it != file->getRoms().cend(); ++it)
+		{
+			pugi::xml_node romNode = romsNode.append_child("rom");
+			if(it->preferred)
+				romNode.append_attribute("preferred") = "true";
+
+			std::string relPath = Utils::FileSystem::createRelativePath(it->path, system->getStartPath(), false, true);
+			romNode.append_child("path").text().set(relPath.c_str());
+
+			appendOptionalTextNode(romNode, "romname", it->romName);
+			appendMultiValueNode(romNode, "regions", "region", it->regions);
+			appendMultiValueNode(romNode, "languages", "language", it->languages);
+			appendOptionalTextNode(romNode, "releasedate", it->releaseDate);
+			appendOptionalTextNode(romNode, "revision", it->revision);
+			appendOptionalTextNode(romNode, "image", it->image);
+			appendOptionalTextNode(romNode, "video", it->video);
+			appendOptionalTextNode(romNode, "thumbnail", it->thumbnail);
+			appendOptionalTextNode(romNode, "marquee", it->marquee);
+		}
+		return;
+	}
+
 	//create game and add to parent node
 	pugi::xml_node newNode = parent.append_child(tag);
 
@@ -276,6 +478,7 @@ void updateGamelist(SystemData* system)
 		for(int i = 0; i < 2; i++)
 		{
 			const char* tag = tagList[i];
+			FileType nodeType = typeList[i];
 			std::vector<FileData*> changes = changedList[i];
 
 			// check for changed items of this type
@@ -284,20 +487,20 @@ void updateGamelist(SystemData* system)
 				// if it does, remove all corresponding items before adding
 				for(pugi::xml_node fileNode = root.child(tag); fileNode; )
 				{
-					pugi::xml_node pathNode = fileNode.child("path");
-
 					// we need this as we were deleting the iterator and things would become inconsistent
 					pugi::xml_node nextNode = fileNode.next_sibling(tag);
 
-					if(!pathNode)
+					std::string xmlpath;
+					if(nodeType == GAME)
+						xmlpath = getGamePathForNode(fileNode, relativeTo);
+					else
+						xmlpath = Utils::FileSystem::resolveRelativePath(fileNode.child("path").text().get(), relativeTo, false, true);
+
+					if(xmlpath.empty())
 					{
-						LOG(LogError) << "<" << tag << "> node contains no <path> child!";
+						fileNode = nextNode;
 						continue;
 					}
-
-					std::string xmlpath = pathNode.text().get();
-					// apply the same transformation as in Gamelist::parseGamelist
-					xmlpath = Utils::FileSystem::resolveRelativePath(xmlpath, relativeTo, false, true);
 
 					for(std::vector<FileData*>::const_iterator cfit = changes.cbegin(); cfit != changes.cend(); ++cfit)
 					{

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -1,6 +1,7 @@
 #include "GuiGamelistOptions.h"
 
 #include "guis/GuiGamelistFilter.h"
+#include "guis/GuiRomSelectionMenu.h"
 #include "guis/GuiRomSelector.h"
 #include "scrapers/Scraper.h"
 #include "views/gamelist/IGameListView.h"
@@ -153,6 +154,17 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 		mMenu.addRow(row);
 	}
 
+	// "SELECT PREFERRED ROM" — only for GAME entries that have ROM variants
+	if(UIModeController::getInstance()->isUIModeFull() && !mFromPlaceholder &&
+	   file->getType() == GAME && !file->getSourceFileData()->getRoms().empty())
+	{
+		row.elements.clear();
+		row.addElement(std::make_shared<TextComponent>(mWindow, "SELECT PREFERRED ROM", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+		row.addElement(makeArrow(mWindow), false);
+		row.makeAcceptInputHandler(std::bind(&GuiGamelistOptions::openPreferredRomSelector, this));
+		mMenu.addRow(row);
+	}
+
 	// "EDIT ROM METADATA" — only for GAME entries that have ROM variants
 	if(UIModeController::getInstance()->isUIModeFull() && !mFromPlaceholder &&
 	   file->getType() == GAME && !file->getSourceFileData()->getRoms().empty())
@@ -284,6 +296,12 @@ void GuiGamelistOptions::openMetaDataEd()
 	}
 
 	mWindow->pushGui(new GuiMetaDataEd(mWindow, &file->metadata, file->metadata.getMDD(), p, Utils::FileSystem::getFileName(file->getPath()), saveBtnFunc, deleteBtnFunc));
+}
+
+void GuiGamelistOptions::openPreferredRomSelector()
+{
+	FileData* file = getGamelist()->getCursor()->getSourceFileData();
+	mWindow->pushGui(new GuiRomSelectionMenu(mWindow, file));
 }
 
 void GuiGamelistOptions::openRomMetaDataEd()

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -154,9 +154,9 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 		mMenu.addRow(row);
 	}
 
-	// "SELECT PREFERRED ROM" — only for GAME entries that have ROM variants
+	// "SELECT PREFERRED ROM" — only for GAME entries that have more than one ROM variant
 	if(UIModeController::getInstance()->isUIModeFull() && !mFromPlaceholder &&
-	   file->getType() == GAME && !file->getSourceFileData()->getRoms().empty())
+	   file->getType() == GAME && file->getSourceFileData()->getRoms().size() > 1)
 	{
 		row.elements.clear();
 		row.addElement(std::make_shared<TextComponent>(mWindow, "SELECT PREFERRED ROM", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);

--- a/es-app/src/guis/GuiGamelistOptions.cpp
+++ b/es-app/src/guis/GuiGamelistOptions.cpp
@@ -1,6 +1,7 @@
 #include "GuiGamelistOptions.h"
 
 #include "guis/GuiGamelistFilter.h"
+#include "guis/GuiRomSelector.h"
 #include "scrapers/Scraper.h"
 #include "views/gamelist/IGameListView.h"
 #include "views/UIModeController.h"
@@ -152,6 +153,17 @@ GuiGamelistOptions::GuiGamelistOptions(Window* window, SystemData* system) : Gui
 		mMenu.addRow(row);
 	}
 
+	// "EDIT ROM METADATA" — only for GAME entries that have ROM variants
+	if(UIModeController::getInstance()->isUIModeFull() && !mFromPlaceholder &&
+	   file->getType() == GAME && !file->getSourceFileData()->getRoms().empty())
+	{
+		row.elements.clear();
+		row.addElement(std::make_shared<TextComponent>(mWindow, "EDIT ROM METADATA", Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+		row.addElement(makeArrow(mWindow), false);
+		row.makeAcceptInputHandler(std::bind(&GuiGamelistOptions::openRomMetaDataEd, this));
+		mMenu.addRow(row);
+	}
+
 	// center the menu
 	setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
 	mMenu.setPosition((mSize.x() - mMenu.getSize().x()) / 2, (mSize.y() - mMenu.getSize().y()) / 2);
@@ -272,6 +284,16 @@ void GuiGamelistOptions::openMetaDataEd()
 	}
 
 	mWindow->pushGui(new GuiMetaDataEd(mWindow, &file->metadata, file->metadata.getMDD(), p, Utils::FileSystem::getFileName(file->getPath()), saveBtnFunc, deleteBtnFunc));
+}
+
+void GuiGamelistOptions::openRomMetaDataEd()
+{
+	FileData* file = getGamelist()->getCursor()->getSourceFileData();
+	mWindow->pushGui(new GuiRomSelector(mWindow, file, [this, file] {
+		ViewController::get()->getGameListView(mSystem)->setCursor(file, true);
+		mMetadataChanged = true;
+		ViewController::get()->getGameListView(file->getSystem())->onFileChanged(file, FILE_METADATA_CHANGED);
+	}));
 }
 
 void GuiGamelistOptions::jumpToLetter()

--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -24,6 +24,7 @@ private:
 	void openGamelistFilter();
 	bool launchSystemScreenSaver();
 	void openMetaDataEd();
+	void openRomMetaDataEd();
 	void startEditMode();
 	void recreateCollection();
 	void exitEditMode();

--- a/es-app/src/guis/GuiGamelistOptions.h
+++ b/es-app/src/guis/GuiGamelistOptions.h
@@ -25,6 +25,7 @@ private:
 	bool launchSystemScreenSaver();
 	void openMetaDataEd();
 	void openRomMetaDataEd();
+	void openPreferredRomSelector();
 	void startEditMode();
 	void recreateCollection();
 	void exitEditMode();

--- a/es-app/src/guis/GuiRomMetaDataEd.cpp
+++ b/es-app/src/guis/GuiRomMetaDataEd.cpp
@@ -1,0 +1,276 @@
+#include "guis/GuiRomMetaDataEd.h"
+
+#include <sstream>
+#include "components/ButtonComponent.h"
+#include "components/ComponentList.h"
+#include "components/DateTimeEditComponent.h"
+#include "components/MenuComponent.h"
+#include "components/TextComponent.h"
+#include "guis/GuiMsgBox.h"
+#include "guis/GuiTextEditPopup.h"
+#include "resources/Font.h"
+#include "utils/StringUtil.h"
+#include "views/ViewController.h"
+#include "FileData.h"
+#include "SystemData.h"
+#include "Window.h"
+
+// Join a vector of strings with ", " separator
+static std::string joinStrings(const std::vector<std::string>& vec)
+{
+	std::string result;
+	for(unsigned int i = 0; i < vec.size(); ++i)
+	{
+		if(i > 0)
+			result += ", ";
+		result += vec[i];
+	}
+	return result;
+}
+
+// Split a string on "," and trim each token, skip empties
+static std::vector<std::string> splitTrimmed(const std::string& str)
+{
+	std::vector<std::string> result;
+	std::istringstream ss(str);
+	std::string token;
+	while(std::getline(ss, token, ','))
+	{
+		token = Utils::String::trim(token);
+		if(!token.empty())
+			result.push_back(token);
+	}
+	return result;
+}
+
+GuiRomMetaDataEd::GuiRomMetaDataEd(Window* window, FileData* game, unsigned int romIndex, std::function<void()> savedCallback)
+	: GuiComponent(window),
+	  mBackground(window, ":/frame.png"),
+	  mGrid(window, Vector2i(1, 3)),
+	  mGame(game),
+	  mRomIndex(romIndex),
+	  mSavedCallback(savedCallback)
+{
+	addChild(&mBackground);
+	addChild(&mGrid);
+
+	// Header
+	mHeaderGrid = std::make_shared<ComponentGrid>(mWindow, Vector2i(1, 5));
+	mTitle = std::make_shared<TextComponent>(mWindow, "EDIT ROM METADATA", Font::get(FONT_SIZE_LARGE), 0x555555FF, ALIGN_CENTER);
+
+	FileData* source = mGame->getSourceFileData();
+	const std::vector<RomData>& roms = source->getRoms();
+	std::string romLabel;
+	if(mRomIndex < roms.size())
+		romLabel = roms[mRomIndex].romName.empty() ? Utils::FileSystem::getFileName(roms[mRomIndex].path) : roms[mRomIndex].romName;
+	else
+		romLabel = Utils::FileSystem::getFileName(source->getPath());
+
+	mSubtitle = std::make_shared<TextComponent>(mWindow, "ROM: " + Utils::String::toUpper(romLabel), Font::get(FONT_SIZE_SMALL), 0x777777FF, ALIGN_CENTER);
+	mHeaderGrid->setEntry(mTitle, Vector2i(0, 1), false, true);
+	mHeaderGrid->setEntry(mSubtitle, Vector2i(0, 3), false, true);
+	mGrid.setEntry(mHeaderGrid, Vector2i(0, 0), false, true);
+
+	mList = std::make_shared<ComponentList>(mWindow);
+	mGrid.setEntry(mList, Vector2i(0, 1), true, true);
+
+	// Helper lambda to add a text+arrow row backed by GuiTextEditPopup
+	auto addTextRow = [&](const std::string& label, const std::string& initialValue, bool multiLine) {
+		ComponentListRow row;
+		auto lbl = std::make_shared<TextComponent>(mWindow, label, Font::get(FONT_SIZE_SMALL), 0x777777FF);
+		row.addElement(lbl, true);
+
+		auto ed = std::make_shared<TextComponent>(mWindow, "", Font::get(FONT_SIZE_SMALL, FONT_PATH_LIGHT), 0x777777FF, ALIGN_RIGHT);
+		const float height = lbl->getSize().y() * 0.71f;
+		ed->setSize(0, height);
+		row.addElement(ed, true);
+
+		auto spacer = std::make_shared<GuiComponent>(mWindow);
+		spacer->setSize(Renderer::getScreenWidth() * 0.005f, 0);
+		row.addElement(spacer, false);
+
+		auto bracket = std::make_shared<ImageComponent>(mWindow);
+		bracket->setImage(":/arrow.svg");
+		bracket->setResize(Vector2f(0, lbl->getFont()->getLetterHeight()));
+		row.addElement(bracket, false);
+
+		ed->setValue(initialValue);
+
+		auto updateVal = [ed](const std::string& newVal) { ed->setValue(newVal); };
+		row.makeAcceptInputHandler([this, label, ed, updateVal, multiLine] {
+			mWindow->pushGui(new GuiTextEditPopup(mWindow, label, ed->getValue(), updateVal, multiLine));
+		});
+
+		mList->addRow(row);
+		mEditors.push_back(ed);
+		mOriginalValues.push_back(initialValue);
+	};
+
+	// Helper lambda to add a date row
+	auto addDateRow = [&](const std::string& label, const std::string& initialValue) {
+		ComponentListRow row;
+		auto lbl = std::make_shared<TextComponent>(mWindow, label, Font::get(FONT_SIZE_SMALL), 0x777777FF);
+		row.addElement(lbl, true);
+
+		auto ed = std::make_shared<DateTimeEditComponent>(mWindow);
+		row.addElement(ed, false);
+
+		auto spacer = std::make_shared<GuiComponent>(mWindow);
+		spacer->setSize(Renderer::getScreenWidth() * 0.0025f, 0);
+		row.addElement(spacer, false);
+
+		// Pass input to the DateTimeEditComponent
+		row.input_handler = std::bind(&GuiComponent::input, ed.get(), std::placeholders::_1, std::placeholders::_2);
+
+		ed->setValue(initialValue);
+
+		mList->addRow(row);
+		mEditors.push_back(ed);
+		mOriginalValues.push_back(initialValue);
+	};
+
+	// Populate fields from current ROM data
+	const RomData* rom = (mRomIndex < roms.size()) ? &roms[mRomIndex] : nullptr;
+
+	std::string romName     = rom ? rom->romName     : "";
+	std::string releaseDate = rom ? rom->releaseDate : "";
+	std::string image       = rom ? rom->image       : "";
+	std::string video       = rom ? rom->video       : "";
+	std::string thumbnail   = rom ? rom->thumbnail   : "";
+	std::string marquee     = rom ? rom->marquee     : "";
+	std::string regions     = rom ? joinStrings(rom->regions)   : "";
+	std::string languages   = rom ? joinStrings(rom->languages) : "";
+
+	addTextRow("ROM NAME",     romName,     false);  // editor index 0
+	addDateRow("RELEASE DATE", releaseDate);          // editor index 1
+	addTextRow("IMAGE",        image,       false);  // editor index 2
+	addTextRow("VIDEO",        video,       false);  // editor index 3
+	addTextRow("THUMBNAIL",    thumbnail,   false);  // editor index 4
+	addTextRow("MARQUEE",      marquee,     false);  // editor index 5
+	addTextRow("REGIONS",      regions,     false);  // editor index 6
+	addTextRow("LANGUAGES",    languages,   false);  // editor index 7
+
+	// Buttons: SAVE, CANCEL
+	std::vector<std::shared_ptr<ButtonComponent>> buttons;
+	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, "SAVE",   "save",   [&] { save(); delete this; }));
+	buttons.push_back(std::make_shared<ButtonComponent>(mWindow, "CANCEL", "cancel", [&] { delete this; }));
+
+	mButtons = makeButtonGrid(mWindow, buttons);
+	mGrid.setEntry(mButtons, Vector2i(0, 2), true, false);
+
+	// Resize and center
+	float width = (float)Math::min(Renderer::getScreenHeight(), (int)(Renderer::getScreenWidth() * 0.90f));
+	setSize(width, Renderer::getScreenHeight() * 0.82f);
+	setPosition((Renderer::getScreenWidth() - mSize.x()) / 2, (Renderer::getScreenHeight() - mSize.y()) / 2);
+}
+
+void GuiRomMetaDataEd::onSizeChanged()
+{
+	mBackground.fitTo(mSize, Vector3f::Zero(), Vector2f(-32, -32));
+	mGrid.setSize(mSize);
+
+	const float titleHeight    = mTitle->getFont()->getLetterHeight();
+	const float subtitleHeight = mSubtitle->getFont()->getLetterHeight();
+	const float titleSubtitleSpacing = mSize.y() * 0.03f;
+
+	mGrid.setRowHeightPerc(0, (titleHeight + titleSubtitleSpacing + subtitleHeight + TITLE_VERT_PADDING) / mSize.y());
+	mGrid.setRowHeightPerc(2, mButtons->getSize().y() / mSize.y());
+
+	mHeaderGrid->setRowHeightPerc(1, titleHeight    / mHeaderGrid->getSize().y());
+	mHeaderGrid->setRowHeightPerc(2, titleSubtitleSpacing / mHeaderGrid->getSize().y());
+	mHeaderGrid->setRowHeightPerc(3, subtitleHeight / mHeaderGrid->getSize().y());
+}
+
+void GuiRomMetaDataEd::save()
+{
+	FileData* source = mGame->getSourceFileData();
+	std::vector<RomData>& roms = source->getRomsMutable();
+	if(mRomIndex >= roms.size())
+		return;
+
+	RomData& rom = roms[mRomIndex];
+
+	// editor indices match the order in the constructor
+	rom.romName     = mEditors[0]->getValue();
+	rom.releaseDate = mEditors[1]->getValue();
+	rom.image       = mEditors[2]->getValue();
+	rom.video       = mEditors[3]->getValue();
+	rom.thumbnail   = mEditors[4]->getValue();
+	rom.marquee     = mEditors[5]->getValue();
+	rom.regions     = splitTrimmed(mEditors[6]->getValue());
+	rom.languages   = splitTrimmed(mEditors[7]->getValue());
+
+	// Mark dirty so the gamelist writer picks up the change
+	source->metadata.set("name", source->metadata.get("name"));
+	source->getSystem()->onMetaDataSavePoint();
+
+	ViewController::get()->onFileChanged(source, FILE_METADATA_CHANGED);
+
+	if(mSavedCallback)
+		mSavedCallback();
+}
+
+void GuiRomMetaDataEd::close(bool closeAllWindows)
+{
+	bool dirty = hasChanges();
+
+	std::function<void()> closeFunc;
+	if(!closeAllWindows)
+	{
+		closeFunc = [this] { delete this; };
+	}
+	else
+	{
+		Window* window = mWindow;
+		closeFunc = [window, this] {
+			while(window->peekGui() != ViewController::get())
+				delete window->peekGui();
+		};
+	}
+
+	if(dirty)
+	{
+		mWindow->pushGui(new GuiMsgBox(mWindow,
+			"SAVE CHANGES?",
+			"YES", [this, closeFunc] { save(); closeFunc(); },
+			"NO", closeFunc
+		));
+	}
+	else
+	{
+		closeFunc();
+	}
+}
+
+bool GuiRomMetaDataEd::hasChanges()
+{
+	for(unsigned int i = 0; i < mEditors.size() && i < mOriginalValues.size(); ++i)
+	{
+		if(mEditors[i]->getValue() != mOriginalValues[i])
+			return true;
+	}
+	return false;
+}
+
+bool GuiRomMetaDataEd::input(InputConfig* config, Input input)
+{
+	if(GuiComponent::input(config, input))
+		return true;
+
+	const bool isStart = config->isMappedTo("start", input);
+	if(input.value != 0 && (config->isMappedTo("b", input) || isStart))
+	{
+		close(isStart);
+		return true;
+	}
+
+	return false;
+}
+
+std::vector<HelpPrompt> GuiRomMetaDataEd::getHelpPrompts()
+{
+	std::vector<HelpPrompt> prompts = mGrid.getHelpPrompts();
+	prompts.push_back(HelpPrompt("b", "back"));
+	prompts.push_back(HelpPrompt("start", "close"));
+	return prompts;
+}

--- a/es-app/src/guis/GuiRomMetaDataEd.h
+++ b/es-app/src/guis/GuiRomMetaDataEd.h
@@ -1,0 +1,51 @@
+#pragma once
+#ifndef ES_APP_GUIS_GUI_ROM_META_DATA_ED_H
+#define ES_APP_GUIS_GUI_ROM_META_DATA_ED_H
+
+#include "components/ComponentGrid.h"
+#include "components/NinePatchComponent.h"
+#include "GuiComponent.h"
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+class ComponentList;
+class TextComponent;
+class FileData;
+
+class GuiRomMetaDataEd : public GuiComponent
+{
+public:
+	GuiRomMetaDataEd(Window* window, FileData* game, unsigned int romIndex, std::function<void()> savedCallback);
+
+	bool input(InputConfig* config, Input input) override;
+	void onSizeChanged() override;
+	std::vector<HelpPrompt> getHelpPrompts() override;
+
+private:
+	void save();
+	void close(bool closeAllWindows);
+	bool hasChanges();
+
+	NinePatchComponent mBackground;
+	ComponentGrid mGrid;
+
+	std::shared_ptr<TextComponent> mTitle;
+	std::shared_ptr<TextComponent> mSubtitle;
+	std::shared_ptr<ComponentGrid> mHeaderGrid;
+	std::shared_ptr<ComponentList> mList;
+	std::shared_ptr<ComponentGrid> mButtons;
+
+	FileData* mGame;
+	unsigned int mRomIndex;
+	std::function<void()> mSavedCallback;
+
+	// Editors in order: romName, releaseDate, image, video, thumbnail, marquee, regions, languages
+	std::vector<std::shared_ptr<GuiComponent>> mEditors;
+
+	// Original values for change detection (same order as mEditors)
+	std::vector<std::string> mOriginalValues;
+};
+
+#endif // ES_APP_GUIS_GUI_ROM_META_DATA_ED_H

--- a/es-app/src/guis/GuiRomSelectionMenu.cpp
+++ b/es-app/src/guis/GuiRomSelectionMenu.cpp
@@ -1,0 +1,164 @@
+#include "guis/GuiRomSelectionMenu.h"
+
+#include "components/ImageComponent.h"
+#include "components/TextComponent.h"
+#include "views/gamelist/IGameListView.h"
+#include "views/ViewController.h"
+#include "FileData.h"
+#include "SystemData.h"
+#include "Window.h"
+
+// Local helper: shows "a: launch, y: preferred" in the help bar for each ROM row
+namespace
+{
+	class RomPromptTextComponent : public TextComponent
+	{
+	public:
+		RomPromptTextComponent(Window* window, const std::string& text, const std::shared_ptr<Font>& font, unsigned int color)
+			: TextComponent(window, text, font, color)
+		{
+		}
+
+		std::vector<HelpPrompt> getHelpPrompts() override
+		{
+			std::vector<HelpPrompt> prompts;
+			prompts.push_back(HelpPrompt("a", "launch"));
+			prompts.push_back(HelpPrompt("y", "preferred"));
+			return prompts;
+		}
+	};
+}
+
+GuiRomSelectionMenu::GuiRomSelectionMenu(Window* window, FileData* game)
+	: GuiSettings(window, "ROMS"), mGame(game), mPreferredChanged(false)
+{
+	buildRows();
+}
+
+GuiRomSelectionMenu::~GuiRomSelectionMenu()
+{
+	if(!mPreferredChanged || mGame == nullptr)
+		return;
+
+	// Preferred ROM changes alter effective media/launch selection, so notify both
+	// the visible entry and canonical source entry to refresh info panels immediately.
+	ViewController::get()->onFileChanged(mGame, FILE_METADATA_CHANGED);
+	FileData* source = mGame->getSourceFileData();
+	if(source != mGame)
+		ViewController::get()->onFileChanged(source, FILE_METADATA_CHANGED);
+}
+
+void GuiRomSelectionMenu::buildRows()
+{
+	if(mGame == nullptr)
+		return;
+
+	const std::vector<RomData>& roms = mGame->getRoms();
+	for(unsigned int i = 0; i < roms.size(); ++i)
+	{
+		ComponentListRow row;
+
+		auto star = std::make_shared<ImageComponent>(mWindow);
+		const float starSize = Font::get(FONT_SIZE_MEDIUM)->getLetterHeight();
+		star->setImage(":/cartridge.svg");
+		star->setResize(starSize, starSize);
+		star->setVisible(roms[i].preferred);
+
+		std::string romName = roms[i].romName.empty() ? mGame->getName() : roms[i].romName;
+		auto label = std::make_shared<RomPromptTextComponent>(mWindow, romName, Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+
+		row.addElement(star, false, false);
+		row.addElement(label, true);
+		row.input_handler = [this, i](InputConfig* config, Input input) -> bool {
+			if(input.value == 0)
+				return false;
+
+			if(config->isMappedTo("a", input))
+			{
+				launchRom(i);
+				return true;
+			}
+
+			if(config->isMappedTo("y", input))
+			{
+				setPreferredRom(i);
+				return true;
+			}
+
+			return false;
+		};
+
+		addRow(row);
+
+		RomRowWidgets widgets;
+		widgets.star = star;
+		widgets.name = label;
+		mRows.push_back(widgets);
+	}
+
+	updatePreferredIndicator();
+}
+
+void GuiRomSelectionMenu::setPreferredRom(unsigned int index)
+{
+	if(mGame == nullptr)
+		return;
+
+	FileData* source = mGame->getSourceFileData();
+	std::vector<RomData>& roms = source->getRomsMutable();
+	if(index >= roms.size())
+		return;
+
+	for(unsigned int i = 0; i < roms.size(); ++i)
+		roms[i].preferred = (i == index);
+
+	// Mark metadata dirty so onMetaDataSavePoint() persists updated ROM preference.
+	source->metadata.set("name", source->metadata.get("name"));
+	source->getSystem()->onMetaDataSavePoint();
+
+	if(mGame != source)
+		mGame->refreshMetadata();
+
+	mPreferredChanged = true;
+	updatePreferredIndicator();
+}
+
+void GuiRomSelectionMenu::launchRom(unsigned int index)
+{
+	if(mGame == nullptr)
+		return;
+
+	FileData* selectedEntry = mGame;
+	FileData* source = selectedEntry->getSourceFileData();
+	const std::vector<RomData>& roms = source->getRoms();
+	if(index >= roms.size() || roms[index].path.empty())
+		return;
+
+	const std::string launchPath = roms[index].path;
+	std::shared_ptr<IGameListView> currentGameList = ViewController::get()->getGameListView(selectedEntry->getSystem());
+	if(currentGameList)
+		currentGameList->onHide();
+
+	// Keep this popup alive so returning from gameplay lands back on the
+	// same ROM selection screen and highlighted row.
+	source->launchGame(mWindow, launchPath);
+	ViewController::get()->onFileChanged(source, FILE_METADATA_CHANGED);
+	if(selectedEntry != source)
+		ViewController::get()->onFileChanged(selectedEntry, FILE_METADATA_CHANGED);
+
+	if(currentGameList)
+	{
+		currentGameList->setCursor(selectedEntry, true);
+		currentGameList->onShow();
+	}
+}
+
+void GuiRomSelectionMenu::updatePreferredIndicator()
+{
+	if(mGame == nullptr)
+		return;
+
+	const std::vector<RomData>& roms = mGame->getRoms();
+	for(unsigned int i = 0; i < roms.size() && i < mRows.size(); ++i)
+		mRows[i].star->setVisible(roms[i].preferred);
+}

--- a/es-app/src/guis/GuiRomSelectionMenu.h
+++ b/es-app/src/guis/GuiRomSelectionMenu.h
@@ -1,0 +1,36 @@
+#pragma once
+#ifndef ES_APP_GUIS_GUI_ROM_SELECTION_MENU_H
+#define ES_APP_GUIS_GUI_ROM_SELECTION_MENU_H
+
+#include "guis/GuiSettings.h"
+#include "FileData.h"
+#include <memory>
+#include <vector>
+
+class ImageComponent;
+class TextComponent;
+
+class GuiRomSelectionMenu : public GuiSettings
+{
+public:
+	GuiRomSelectionMenu(Window* window, FileData* game);
+	~GuiRomSelectionMenu();
+
+private:
+	struct RomRowWidgets
+	{
+		std::shared_ptr<ImageComponent> star;
+		std::shared_ptr<TextComponent> name;
+	};
+
+	void buildRows();
+	void setPreferredRom(unsigned int index);
+	void launchRom(unsigned int index);
+	void updatePreferredIndicator();
+
+	FileData* mGame;
+	bool mPreferredChanged;
+	std::vector<RomRowWidgets> mRows;
+};
+
+#endif // ES_APP_GUIS_GUI_ROM_SELECTION_MENU_H

--- a/es-app/src/guis/GuiRomSelector.cpp
+++ b/es-app/src/guis/GuiRomSelector.cpp
@@ -1,0 +1,77 @@
+#include "guis/GuiRomSelector.h"
+
+#include "components/ImageComponent.h"
+#include "components/TextComponent.h"
+#include "guis/GuiRomMetaDataEd.h"
+#include "resources/Font.h"
+#include "FileData.h"
+#include "Window.h"
+
+GuiRomSelector::GuiRomSelector(Window* window, FileData* game, std::function<void()> metadataChangedCallback)
+	: GuiSettings(window, "SELECT ROM"), mGame(game), mMetadataChangedCallback(metadataChangedCallback), mAnyEdited(false)
+{
+	buildRows();
+}
+
+GuiRomSelector::~GuiRomSelector()
+{
+	if(mAnyEdited && mMetadataChangedCallback)
+		mMetadataChangedCallback();
+}
+
+void GuiRomSelector::buildRows()
+{
+	if(mGame == nullptr)
+		return;
+
+	const std::vector<RomData>& roms = mGame->getRoms();
+	for(unsigned int i = 0; i < roms.size(); ++i)
+	{
+		ComponentListRow row;
+
+		auto star = std::make_shared<ImageComponent>(mWindow);
+		const float starSize = Font::get(FONT_SIZE_MEDIUM)->getLetterHeight();
+		star->setImage(":/cartridge.svg");
+		star->setResize(starSize, starSize);
+		star->setVisible(roms[i].preferred);
+
+		std::string romName = roms[i].romName.empty() ? mGame->getName() : roms[i].romName;
+		auto label = std::make_shared<TextComponent>(mWindow, romName, Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+
+		auto bracket = std::make_shared<ImageComponent>(mWindow);
+		bracket->setImage(":/arrow.svg");
+		bracket->setResize(Vector2f(0, Font::get(FONT_SIZE_MEDIUM)->getLetterHeight()));
+
+		row.addElement(star, false, false);
+		row.addElement(label, true);
+		row.addElement(bracket, false);
+
+		row.makeAcceptInputHandler([this, i] { openMetaEd(i); });
+
+		addRow(row);
+
+		RomRowWidgets widgets;
+		widgets.star = star;
+		mRows.push_back(widgets);
+	}
+
+	updatePreferredIndicator();
+}
+
+void GuiRomSelector::openMetaEd(unsigned int romIndex)
+{
+	mWindow->pushGui(new GuiRomMetaDataEd(mWindow, mGame, romIndex, [this] {
+		mAnyEdited = true;
+		updatePreferredIndicator();
+	}));
+}
+
+void GuiRomSelector::updatePreferredIndicator()
+{
+	if(mGame == nullptr)
+		return;
+
+	const std::vector<RomData>& roms = mGame->getRoms();
+	for(unsigned int i = 0; i < roms.size() && i < mRows.size(); ++i)
+		mRows[i].star->setVisible(roms[i].preferred);
+}

--- a/es-app/src/guis/GuiRomSelector.h
+++ b/es-app/src/guis/GuiRomSelector.h
@@ -1,0 +1,35 @@
+#pragma once
+#ifndef ES_APP_GUIS_GUI_ROM_SELECTOR_H
+#define ES_APP_GUIS_GUI_ROM_SELECTOR_H
+
+#include "guis/GuiSettings.h"
+#include "FileData.h"
+#include <functional>
+#include <memory>
+#include <vector>
+
+class ImageComponent;
+
+class GuiRomSelector : public GuiSettings
+{
+public:
+	GuiRomSelector(Window* window, FileData* game, std::function<void()> metadataChangedCallback);
+	virtual ~GuiRomSelector();
+
+private:
+	struct RomRowWidgets
+	{
+		std::shared_ptr<ImageComponent> star;
+	};
+
+	void buildRows();
+	void openMetaEd(unsigned int romIndex);
+	void updatePreferredIndicator();
+
+	FileData* mGame;
+	std::function<void()> mMetadataChangedCallback;
+	bool mAnyEdited;
+	std::vector<RomRowWidgets> mRows;
+};
+
+#endif // ES_APP_GUIS_GUI_ROM_SELECTOR_H

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -31,8 +31,7 @@ void BasicGameListView::onFileChanged(FileData* file, FileChangeType change)
 {
 	if(change == FILE_METADATA_CHANGED)
 	{
-		// might switch to a detailed view
-		ViewController::get()->reloadGameListView(this);
+		ISimpleGameListView::onFileChanged(file, change);
 		return;
 	}
 

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -217,7 +217,7 @@ std::vector<HelpPrompt> BasicGameListView::getHelpPrompts()
 	if(!UIModeController::getInstance()->isUIModeKid())
 		prompts.push_back(HelpPrompt("select", "options"));
 	if(mRoot->getSystem()->isGameSystem())
-		prompts.push_back(HelpPrompt("x", "roms"));
+		prompts.push_back(HelpPrompt("x", "random"));
 	if(mRoot->getSystem()->isGameSystem() && !UIModeController::getInstance()->isUIModeKid())
 	{
 		std::string prompt = CollectionSystemManager::get()->getEditingCollection();

--- a/es-app/src/views/gamelist/BasicGameListView.cpp
+++ b/es-app/src/views/gamelist/BasicGameListView.cpp
@@ -218,7 +218,7 @@ std::vector<HelpPrompt> BasicGameListView::getHelpPrompts()
 	if(!UIModeController::getInstance()->isUIModeKid())
 		prompts.push_back(HelpPrompt("select", "options"));
 	if(mRoot->getSystem()->isGameSystem())
-		prompts.push_back(HelpPrompt("x", "random"));
+		prompts.push_back(HelpPrompt("x", "roms"));
 	if(mRoot->getSystem()->isGameSystem() && !UIModeController::getInstance()->isUIModeKid())
 	{
 		std::string prompt = CollectionSystemManager::get()->getEditingCollection();

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -1,6 +1,7 @@
 #include "views/gamelist/DetailedGameListView.h"
 
 #include "animations/LambdaAnimation.h"
+#include "utils/FileSystemUtil.h"
 #include "views/ViewController.h"
 
 DetailedGameListView::DetailedGameListView(Window* window, FileData* root) :
@@ -15,7 +16,9 @@ DetailedGameListView::DetailedGameListView(Window* window, FileData* root) :
 
 	mRating(window), mReleaseDate(window), mDeveloper(window), mPublisher(window),
 	mGenre(window), mPlayers(window), mLastPlayed(window), mPlayCount(window),
-	mName(window)
+	mName(window),
+
+	mLblRomName(window), mRomNameContainer(window), mRomNameText(window)
 {
 	//mHeaderImage.setPosition(mSize.x() * 0.25f, 0);
 
@@ -77,13 +80,22 @@ DetailedGameListView::DetailedGameListView(Window* window, FileData* root) :
 	mLblPlayCount.setText("Times played: ");
 	addChild(&mLblPlayCount);
 	addChild(&mPlayCount);
-
 	mName.setPosition(mSize.x(), mSize.y());
 	mName.setDefaultZIndex(40);
 	mName.setColor(0xAAAAAAFF);
 	mName.setFont(Font::get(FONT_SIZE_MEDIUM));
 	mName.setHorizontalAlignment(ALIGN_CENTER);
 	addChild(&mName);
+
+	mLblRomName.setText("Rom Name: ");
+	mLblRomName.setColor(0x777777FF); // default visible color; overridden by theme
+	mLblRomName.setDefaultZIndex(40);
+	addChild(&mLblRomName);
+
+	mRomNameContainer.setAutoScroll(true, true); // horizontal marquee
+	mRomNameContainer.setDefaultZIndex(40);
+	addChild(&mRomNameContainer);
+	mRomNameContainer.addChild(&mRomNameText);
 
 	mDescContainer.setPosition(mSize.x() * padding, mSize.y() * 0.65f);
 	mDescContainer.setSize(mSize.x() * (0.50f - 2*padding), mSize.y() - mDescContainer.getPosition().y());
@@ -124,6 +136,10 @@ void DetailedGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& them
 		labels[i]->applyTheme(theme, getName(), lblElements[i], ALL);
 	}
 
+	// Apply desc container position/size from theme BEFORE initMDValues() so that
+	// initMDValues() can nudge the y below the ROM name row while still inheriting
+	// the theme's x and width.
+	mDescContainer.applyTheme(theme, getName(), "md_description", POSITION | ThemeFlags::SIZE | Z_INDEX | VISIBLE);
 
 	initMDValues();
 	std::vector<GuiComponent*> values = getMDValues();
@@ -138,9 +154,16 @@ void DetailedGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& them
 		values[i]->applyTheme(theme, getName(), valElements[i], ALL ^ ThemeFlags::TEXT);
 	}
 
-	mDescContainer.applyTheme(theme, getName(), "md_description", POSITION | ThemeFlags::SIZE | Z_INDEX | VISIBLE);
+	// Apply publisher-row colors + z-index to the ROM name row so it sorts correctly.
+	mLblRomName.applyTheme(theme, getName(), "md_lbl_publisher", ThemeFlags::COLOR | ThemeFlags::Z_INDEX);
+	mRomNameText.applyTheme(theme, getName(), "md_publisher", ThemeFlags::COLOR | ThemeFlags::Z_INDEX);
+	// Container has no matching theme element; set z-index directly.
+	mRomNameContainer.setZIndex(mLblRomName.getZIndex());
+
 	mDescription.setSize(mDescContainer.getSize().x(), 0);
 	mDescription.applyTheme(theme, getName(), "md_description", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
+	mLblRomName.applyTheme(theme, getName(), "md_lbl_playcount", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | ROTATION));
+	mRomNameText.applyTheme(theme, getName(), "md_playcount", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
 
 	sortChildren();
 }
@@ -190,6 +213,8 @@ void DetailedGameListView::initMDValues()
 	mPlayers.setFont(defaultFont);
 	mLastPlayed.setFont(defaultFont);
 	mPlayCount.setFont(defaultFont);
+	mLblRomName.setFont(defaultFont);
+	mRomNameText.setFont(defaultFont);
 
 	float bottom = 0.0f;
 
@@ -204,10 +229,34 @@ void DetailedGameListView::initMDValues()
 		float testBot = values[i]->getPosition().y() + values[i]->getSize().y();
 		if(testBot > bottom)
 			bottom = testBot;
+
+		float labelBot = labels[i]->getPosition().y() + labels[i]->getSize().y();
+		if(labelBot > bottom)
+			bottom = labelBot;
 	}
 
-	mDescContainer.setPosition(mDescContainer.getPosition().x(), bottom + mSize.y() * 0.01f);
-	mDescContainer.setSize(mDescContainer.getSize().x(), mSize.y() - mDescContainer.getPosition().y());
+	const float rowY = bottom;
+	const float lineH = defaultFont->getHeight();
+
+	mLblRomName.setPosition(Vector3f(mLblPublisher.getPosition().x(), rowY, 0.0f));
+	mLblRomName.setDefaultZIndex(40);
+	const float labelW = mLblRomName.getSize().x();
+	mRomNameContainer.setPosition(mLblRomName.getPosition() + Vector3f(labelW, 0.0f, 0.0f));
+	mRomNameContainer.setSize(mSize.x() * 0.48f - labelW, lineH);
+
+	mRomNameText.setPosition(Vector3f(0, 0, 0));
+	mRomNameText.setSize(0, lineH);
+	mRomNameText.setDefaultZIndex(40);
+
+	const float rowPadding = 0.01f * mSize.y();
+	const float rowBottom = rowY + mLblRomName.getSize().y();
+
+	// Preserve theme bottom edge: capture it after applyTheme, shrink top to fit ROM name row.
+	const float descBottom = mDescContainer.getPosition().y() + mDescContainer.getSize().y();
+	const float newDescY = rowBottom + rowPadding;
+	mDescContainer.setPosition(mDescContainer.getPosition().x(), newDescY);
+	mDescContainer.setSize(mDescContainer.getSize().x(), descBottom - newDescY);
+
 }
 
 void DetailedGameListView::updateInfoPanel()
@@ -234,12 +283,12 @@ void DetailedGameListView::updateInfoPanel()
 		mGenre.setValue(file->metadata.get("genre"));
 		mPlayers.setValue(file->metadata.get("players"));
 		mName.setValue(file->metadata.get("name"));
-
-		if(file->getType() == GAME)
-		{
-			mLastPlayed.setValue(file->metadata.get("lastplayed"));
-			mPlayCount.setValue(file->metadata.get("playcount"));
-		}
+		const RomData* preferred = file->getPreferredRom();
+		if(preferred != NULL && !preferred->romName.empty())
+			mRomNameText.setValue(preferred->romName);
+		else
+			mRomNameText.setValue(file->getName());
+		mRomNameContainer.reset();
 
 		fadingOut = false;
 	}
@@ -250,6 +299,8 @@ void DetailedGameListView::updateInfoPanel()
 	comps.push_back(&mImage);
 	comps.push_back(&mDescription);
 	comps.push_back(&mName);
+	comps.push_back(&mRomNameText);
+	comps.push_back(&mLblRomName);
 	std::vector<TextComponent*> labels = getMDLabels();
 	comps.insert(comps.cend(), labels.cbegin(), labels.cend());
 

--- a/es-app/src/views/gamelist/DetailedGameListView.cpp
+++ b/es-app/src/views/gamelist/DetailedGameListView.cpp
@@ -154,16 +154,12 @@ void DetailedGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& them
 		values[i]->applyTheme(theme, getName(), valElements[i], ALL ^ ThemeFlags::TEXT);
 	}
 
-	// Apply publisher-row colors + z-index to the ROM name row so it sorts correctly.
-	mLblRomName.applyTheme(theme, getName(), "md_lbl_publisher", ThemeFlags::COLOR | ThemeFlags::Z_INDEX);
-	mRomNameText.applyTheme(theme, getName(), "md_publisher", ThemeFlags::COLOR | ThemeFlags::Z_INDEX);
-	// Container has no matching theme element; set z-index directly.
-	mRomNameContainer.setZIndex(mLblRomName.getZIndex());
-
 	mDescription.setSize(mDescContainer.getSize().x(), 0);
 	mDescription.applyTheme(theme, getName(), "md_description", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
-	mLblRomName.applyTheme(theme, getName(), "md_lbl_playcount", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | ROTATION));
-	mRomNameText.applyTheme(theme, getName(), "md_playcount", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
+	mLblRomName.applyTheme(theme, getName(), "md_lbl_romname", ALL ^ ROTATION);
+	mRomNameContainer.applyTheme(theme, getName(), "md_romname", POSITION | ThemeFlags::SIZE | Z_INDEX | VISIBLE);
+	mRomNameText.applyTheme(theme, getName(), "md_romname", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
+	mRomNameContainer.setZIndex(mLblRomName.getZIndex());
 
 	sortChildren();
 }

--- a/es-app/src/views/gamelist/DetailedGameListView.h
+++ b/es-app/src/views/gamelist/DetailedGameListView.h
@@ -45,6 +45,10 @@ private:
 	std::vector<TextComponent*> getMDLabels();
 	std::vector<GuiComponent*> getMDValues();
 
+	TextComponent mLblRomName;
+	ScrollableContainer mRomNameContainer;
+	TextComponent mRomNameText;
+
 	ScrollableContainer mDescContainer;
 	TextComponent mDescription;
 };

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -20,10 +20,11 @@ GridGameListView::GridGameListView(Window* window, FileData* root) :
 	mDescContainer(window, DESCRIPTION_SCROLL_DELAY), mDescription(window),
 
 	mLblRating(window), mLblReleaseDate(window), mLblDeveloper(window), mLblPublisher(window),
-	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window),
+	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window), mLblRomName(window),
 
 	mRating(window), mReleaseDate(window), mDeveloper(window), mPublisher(window),
 	mGenre(window), mPlayers(window), mLastPlayed(window), mPlayCount(window),
+	mRomNameContainer(window), mRomNameText(window),
 	mName(window)
 {
 	const float padding = 0.01f;
@@ -71,6 +72,17 @@ GridGameListView::GridGameListView(Window* window, FileData* root) :
 	mLblPlayCount.setText("Times played: ");
 	addChild(&mLblPlayCount);
 	addChild(&mPlayCount);
+	mLblRomName.setText("Rom Name: ");
+	mLblRomName.setColor(0x777777FF);
+	mLblRomName.setDefaultZIndex(40);
+	addChild(&mLblRomName);
+
+	mRomNameContainer.setAutoScroll(true, true); // horizontal marquee
+	mRomNameContainer.setDefaultZIndex(40);
+	addChild(&mRomNameContainer);
+	mRomNameText.setColor(0xFFFFFFFF);
+	mRomNameText.setDefaultZIndex(40);
+	mRomNameContainer.addChild(&mRomNameText);
 
 	mName.setPosition(mSize.x(), mSize.y());
 	mName.setDefaultZIndex(40);
@@ -212,6 +224,9 @@ void GridGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 		labels[i]->applyTheme(theme, getName(), lblElements[i], ALL);
 	}
 
+	// Apply desc container position/size from theme BEFORE initMDValues() so that
+	// initMDValues() can nudge the y below the ROM name row while preserving theme x/width.
+	mDescContainer.applyTheme(theme, getName(), "md_description", POSITION | ThemeFlags::SIZE | Z_INDEX | VISIBLE);
 
 	initMDValues();
 	std::vector<GuiComponent*> values = getMDValues();
@@ -226,9 +241,11 @@ void GridGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 		values[i]->applyTheme(theme, getName(), valElements[i], ALL ^ ThemeFlags::TEXT);
 	}
 
-	mDescContainer.applyTheme(theme, getName(), "md_description", POSITION | ThemeFlags::SIZE | Z_INDEX | VISIBLE);
 	mDescription.setSize(mDescContainer.getSize().x(), 0);
 	mDescription.applyTheme(theme, getName(), "md_description", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
+	mLblRomName.applyTheme(theme, getName(), "md_lbl_playcount", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | ROTATION) | ThemeFlags::Z_INDEX);
+	mRomNameText.applyTheme(theme, getName(), "md_playcount", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION) | ThemeFlags::Z_INDEX);
+	mRomNameContainer.setZIndex(mLblRomName.getZIndex());
 
 	// Repopulate list in case new theme is displaying a different image.  Preserve selection.
 	FileData* file = mGrid.getSelected();
@@ -283,6 +300,8 @@ void GridGameListView::initMDValues()
 	mPlayers.setFont(defaultFont);
 	mLastPlayed.setFont(defaultFont);
 	mPlayCount.setFont(defaultFont);
+	mLblRomName.setFont(defaultFont);
+	mRomNameText.setFont(defaultFont);
 
 	float bottom = 0.0f;
 
@@ -297,10 +316,33 @@ void GridGameListView::initMDValues()
 		float testBot = values[i]->getPosition().y() + values[i]->getSize().y();
 		if(testBot > bottom)
 			bottom = testBot;
+
+		float labelBot = labels[i]->getPosition().y() + labels[i]->getSize().y();
+		if(labelBot > bottom)
+			bottom = labelBot;
 	}
 
-	mDescContainer.setPosition(mDescContainer.getPosition().x(), bottom + mSize.y() * 0.01f);
-	mDescContainer.setSize(mDescContainer.getSize().x(), mSize.y() - mDescContainer.getPosition().y());
+	const float rowY = bottom;
+	const float lineH = defaultFont->getHeight();
+
+	mLblRomName.setPosition(Vector3f(mLblPublisher.getPosition().x(), rowY, 0.0f));
+	mLblRomName.setDefaultZIndex(40);
+	const float labelW = mLblRomName.getSize().x();
+	mRomNameContainer.setPosition(mLblRomName.getPosition() + Vector3f(labelW, 0.0f, 0.0f));
+	mRomNameContainer.setSize(mSize.x() * 0.48f - labelW, lineH);
+
+	mRomNameText.setPosition(Vector3f(0, 0, 0));
+	mRomNameText.setSize(0, lineH);
+	mRomNameText.setDefaultZIndex(40);
+
+	const float rowPadding = 0.01f * mSize.y();
+	const float rowBottom = rowY + mLblRomName.getSize().y();
+
+	// Preserve theme bottom edge: capture it after applyTheme, shrink top to fit ROM name row.
+	const float descBottom = mDescContainer.getPosition().y() + mDescContainer.getSize().y();
+	const float newDescY = rowBottom + rowPadding;
+	mDescContainer.setPosition(mDescContainer.getPosition().x(), newDescY);
+	mDescContainer.setSize(mDescContainer.getSize().x(), descBottom - newDescY);
 }
 
 void GridGameListView::updateInfoPanel()
@@ -337,6 +379,12 @@ void GridGameListView::updateInfoPanel()
 		mGenre.setValue(file->metadata.get("genre"));
 		mPlayers.setValue(file->metadata.get("players"));
 		mName.setValue(file->metadata.get("name"));
+		const RomData* preferred = file->getPreferredRom();
+		if(preferred != NULL && !preferred->romName.empty())
+			mRomNameText.setValue(preferred->romName);
+		else
+			mRomNameText.setValue(file->getName());
+		mRomNameContainer.reset();
 
 		if(file->getType() == GAME)
 		{
@@ -353,6 +401,8 @@ void GridGameListView::updateInfoPanel()
 	comps.push_back(&mMarquee);
 	comps.push_back(mVideo);
 	comps.push_back(&mImage);
+	comps.push_back(&mLblRomName);
+	comps.push_back(&mRomNameText);
 	std::vector<TextComponent*> labels = getMDLabels();
 	comps.insert(comps.cend(), labels.cbegin(), labels.cend());
 

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -243,8 +243,9 @@ void GridGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 
 	mDescription.setSize(mDescContainer.getSize().x(), 0);
 	mDescription.applyTheme(theme, getName(), "md_description", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
-	mLblRomName.applyTheme(theme, getName(), "md_lbl_playcount", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | ROTATION) | ThemeFlags::Z_INDEX);
-	mRomNameText.applyTheme(theme, getName(), "md_playcount", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION) | ThemeFlags::Z_INDEX);
+	mLblRomName.applyTheme(theme, getName(), "md_lbl_romname", ALL ^ ROTATION);
+	mRomNameContainer.applyTheme(theme, getName(), "md_romname", POSITION | ThemeFlags::SIZE | Z_INDEX | VISIBLE);
+	mRomNameText.applyTheme(theme, getName(), "md_romname", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
 	mRomNameContainer.setZIndex(mLblRomName.getZIndex());
 
 	// Repopulate list in case new theme is displaying a different image.  Preserve selection.

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -533,7 +533,7 @@ std::vector<HelpPrompt> GridGameListView::getHelpPrompts()
 	if(!UIModeController::getInstance()->isUIModeKid())
 		prompts.push_back(HelpPrompt("select", "options"));
 	if(mRoot->getSystem()->isGameSystem())
-		prompts.push_back(HelpPrompt("x", "roms"));
+		prompts.push_back(HelpPrompt("x", "random"));
 	if(mRoot->getSystem()->isGameSystem() && !UIModeController::getInstance()->isUIModeKid())
 	{
 		std::string prompt = CollectionSystemManager::get()->getEditingCollection();

--- a/es-app/src/views/gamelist/GridGameListView.cpp
+++ b/es-app/src/views/gamelist/GridGameListView.cpp
@@ -482,7 +482,7 @@ std::vector<HelpPrompt> GridGameListView::getHelpPrompts()
 	if(!UIModeController::getInstance()->isUIModeKid())
 		prompts.push_back(HelpPrompt("select", "options"));
 	if(mRoot->getSystem()->isGameSystem())
-		prompts.push_back(HelpPrompt("x", "random"));
+		prompts.push_back(HelpPrompt("x", "roms"));
 	if(mRoot->getSystem()->isGameSystem() && !UIModeController::getInstance()->isUIModeKid())
 	{
 		std::string prompt = CollectionSystemManager::get()->getEditingCollection();

--- a/es-app/src/views/gamelist/GridGameListView.h
+++ b/es-app/src/views/gamelist/GridGameListView.h
@@ -51,6 +51,7 @@ private:
 	void initMDValues();
 
 	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount;
+	TextComponent mLblRomName;
 
 	ImageComponent mMarquee;
 	VideoComponent* mVideo;
@@ -64,6 +65,8 @@ private:
 	TextComponent mPlayers;
 	DateTimeComponent mLastPlayed;
 	TextComponent mPlayCount;
+	ScrollableContainer mRomNameContainer;
+	TextComponent mRomNameText;
 	TextComponent mName;
 
 	std::vector<TextComponent*> getMDLabels();

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -45,6 +45,8 @@ namespace
 			if(!mPreferredChanged || mGame == nullptr)
 				return;
 
+			// Preferred ROM changes alter effective media/launch selection, so notify both
+			// the visible entry and canonical source entry to refresh info panels immediately.
 			ViewController::get()->onFileChanged(mGame, FILE_METADATA_CHANGED);
 			FileData* source = mGame->getSourceFileData();
 			if(source != mGame)
@@ -122,6 +124,7 @@ namespace
 			for(unsigned int i = 0; i < roms.size(); ++i)
 				roms[i].preferred = (i == index);
 
+			// Mark metadata dirty so onMetaDataSavePoint() persists updated ROM preference.
 			source->metadata.set("name", source->metadata.get("name"));
 			source->getSystem()->onMetaDataSavePoint();
 
@@ -236,7 +239,14 @@ void ISimpleGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme
 void ISimpleGameListView::onFileChanged(FileData* /*file*/, FileChangeType change)
 {
 	if(change == FILE_METADATA_CHANGED)
+	{
+		FileData* cursor = getCursor();
+		// Keep metadata updates lightweight (avoid full list repopulate/flicker) while
+		// still forcing current row/panel refresh for preferred-ROM media changes.
+		if(cursor != nullptr && !cursor->isPlaceHolder())
+			setCursor(cursor, true);
 		return;
+	}
 
 	// we could be tricky here to be efficient;
 	// but this shouldn't happen very often so we'll just always repopulate

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -147,12 +147,22 @@ namespace
 				return;
 
 			const std::string launchPath = roms[index].path;
+			std::shared_ptr<IGameListView> currentGameList = ViewController::get()->getGameListView(selectedEntry->getSystem());
+			if(currentGameList)
+				currentGameList->onHide();
+
 			// Keep this popup alive so returning from gameplay lands back on the
 			// same ROM selection screen and highlighted row.
 			source->launchGame(mWindow, launchPath);
 			ViewController::get()->onFileChanged(source, FILE_METADATA_CHANGED);
 			if(selectedEntry != source)
 				ViewController::get()->onFileChanged(selectedEntry, FILE_METADATA_CHANGED);
+
+			if(currentGameList)
+			{
+				currentGameList->setCursor(selectedEntry, true);
+				currentGameList->onShow();
+			}
 		}
 
 		void updatePreferredIndicator()

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -1,6 +1,5 @@
 #include "views/gamelist/ISimpleGameListView.h"
 
-#include "guis/GuiSettings.h"
 #include "components/ImageComponent.h"
 #include "components/TextComponent.h"
 #include "views/UIModeController.h"
@@ -11,187 +10,6 @@
 #include "Sound.h"
 #include "SystemData.h"
 #include "Window.h"
-
-namespace
-{
-	class RomPromptTextComponent : public TextComponent
-	{
-	public:
-		RomPromptTextComponent(Window* window, const std::string& text, const std::shared_ptr<Font>& font, unsigned int color)
-			: TextComponent(window, text, font, color)
-		{
-		}
-
-		std::vector<HelpPrompt> getHelpPrompts() override
-		{
-			std::vector<HelpPrompt> prompts;
-			prompts.push_back(HelpPrompt("a", "launch"));
-			prompts.push_back(HelpPrompt("y", "preferred"));
-			return prompts;
-		}
-	};
-
-	class RomSelectionMenu : public GuiSettings
-	{
-	public:
-		RomSelectionMenu(Window* window, FileData* game)
-			: GuiSettings(window, "ROMS"), mGame(game), mPreferredChanged(false)
-		{
-			buildRows();
-		}
-
-		~RomSelectionMenu()
-		{
-			if(!mPreferredChanged || mGame == nullptr)
-				return;
-
-			// Preferred ROM changes alter effective media/launch selection, so notify both
-			// the visible entry and canonical source entry to refresh info panels immediately.
-			ViewController::get()->onFileChanged(mGame, FILE_METADATA_CHANGED);
-			FileData* source = mGame->getSourceFileData();
-			if(source != mGame)
-				ViewController::get()->onFileChanged(source, FILE_METADATA_CHANGED);
-		}
-
-	private:
-		struct RomRowWidgets
-		{
-			std::shared_ptr<ImageComponent> star;
-			std::shared_ptr<TextComponent> name;
-		};
-
-		void buildRows()
-		{
-			if(mGame == nullptr)
-				return;
-
-			const std::vector<RomData>& roms = mGame->getRoms();
-			for(unsigned int i = 0; i < roms.size(); ++i)
-			{
-				ComponentListRow row;
-
-				auto star = std::make_shared<ImageComponent>(mWindow);
-				const float starSize = Font::get(FONT_SIZE_MEDIUM)->getLetterHeight();
-				star->setImage(":/cartridge.svg");
-				star->setResize(starSize, starSize);
-				star->setVisible(roms[i].preferred);
-
-				std::string romName = roms[i].romName.empty() ? mGame->getName() : roms[i].romName;
-				auto label = std::make_shared<RomPromptTextComponent>(mWindow, romName, Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
-
-				row.addElement(star, false, false);
-				row.addElement(label, true);
-				row.input_handler = [this, i](InputConfig* config, Input input) -> bool {
-					if(input.value == 0)
-						return false;
-
-					if(config->isMappedTo("a", input))
-					{
-						launchRom(i);
-						return true;
-					}
-
-					if(config->isMappedTo("y", input))
-					{
-						setPreferredRom(i);
-						return true;
-					}
-
-					return false;
-				};
-
-				addRow(row);
-
-				RomRowWidgets widgets;
-				widgets.star = star;
-				widgets.name = label;
-				mRows.push_back(widgets);
-			}
-
-			updatePreferredIndicator();
-		}
-
-		void setPreferredRom(unsigned int index)
-		{
-			if(mGame == nullptr)
-				return;
-
-			FileData* source = mGame->getSourceFileData();
-			std::vector<RomData>& roms = source->getRomsMutable();
-			if(index >= roms.size())
-				return;
-
-			for(unsigned int i = 0; i < roms.size(); ++i)
-				roms[i].preferred = (i == index);
-
-			// Mark metadata dirty so onMetaDataSavePoint() persists updated ROM preference.
-			source->metadata.set("name", source->metadata.get("name"));
-			source->getSystem()->onMetaDataSavePoint();
-
-			if(mGame != source)
-				mGame->refreshMetadata();
-
-			mPreferredChanged = true;
-			updatePreferredIndicator();
-		}
-
-		void launchRom(unsigned int index)
-		{
-			if(mGame == nullptr)
-				return;
-
-			FileData* selectedEntry = mGame;
-			FileData* source = selectedEntry->getSourceFileData();
-			const std::vector<RomData>& roms = source->getRoms();
-			if(index >= roms.size() || roms[index].path.empty())
-				return;
-
-			const std::string launchPath = roms[index].path;
-			std::shared_ptr<IGameListView> currentGameList = ViewController::get()->getGameListView(selectedEntry->getSystem());
-			if(currentGameList)
-				currentGameList->onHide();
-
-			// Keep this popup alive so returning from gameplay lands back on the
-			// same ROM selection screen and highlighted row.
-			source->launchGame(mWindow, launchPath);
-			ViewController::get()->onFileChanged(source, FILE_METADATA_CHANGED);
-			if(selectedEntry != source)
-				ViewController::get()->onFileChanged(selectedEntry, FILE_METADATA_CHANGED);
-
-			if(currentGameList)
-			{
-				currentGameList->setCursor(selectedEntry, true);
-				currentGameList->onShow();
-			}
-		}
-
-		void updatePreferredIndicator()
-		{
-			if(mGame == nullptr)
-				return;
-
-			const std::vector<RomData>& roms = mGame->getRoms();
-			for(unsigned int i = 0; i < roms.size() && i < mRows.size(); ++i)
-				mRows[i].star->setVisible(roms[i].preferred);
-		}
-
-		FileData* mGame;
-		bool mPreferredChanged;
-		std::vector<RomRowWidgets> mRows;
-	};
-
-	void openRomSelectionMenu(Window* window, FileData* game)
-	{
-		if(game == nullptr || game->getType() != GAME)
-			return;
-
-		const std::vector<RomData>& roms = game->getRoms();
-		if(roms.empty())
-			return;
-
-		window->pushGui(new RomSelectionMenu(window, game));
-	}
-}
 
 ISimpleGameListView::ISimpleGameListView(Window* window, FileData* root) : IGameListView(window, root),
 	mHeaderText(window), mHeaderImage(window), mBackground(window)
@@ -334,12 +152,13 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 		{
 			if (mRoot->getSystem()->isGameSystem())
 			{
-				FileData* cursor = getCursor();
-				if(cursor->getType() == GAME)
+				// go to random system game
+				FileData* randomGame = getCursor()->getSystem()->getRandomGame();
+				if (randomGame)
 				{
-					openRomSelectionMenu(mWindow, cursor);
-					return true;
+					setCursor(randomGame);
 				}
+				return true;
 			}
 		}else if (config->isMappedTo("y", input) && !UIModeController::getInstance()->isUIModeKid())
 		{

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -1,6 +1,7 @@
 #include "views/gamelist/ISimpleGameListView.h"
 
 #include "guis/GuiSettings.h"
+#include "components/ImageComponent.h"
 #include "components/TextComponent.h"
 #include "views/UIModeController.h"
 #include "views/ViewController.h"
@@ -13,6 +14,149 @@
 
 namespace
 {
+	class RomSelectionMenu : public GuiSettings
+	{
+	public:
+		RomSelectionMenu(Window* window, FileData* game)
+			: GuiSettings(window, "ROMS"), mGame(game), mPreferredChanged(false)
+		{
+			buildRows();
+		}
+
+		~RomSelectionMenu()
+		{
+			if(!mPreferredChanged || mGame == nullptr)
+				return;
+
+			ViewController::get()->onFileChanged(mGame, FILE_METADATA_CHANGED);
+			FileData* source = mGame->getSourceFileData();
+			if(source != mGame)
+				ViewController::get()->onFileChanged(source, FILE_METADATA_CHANGED);
+		}
+
+		std::vector<HelpPrompt> getHelpPrompts() override
+		{
+			std::vector<HelpPrompt> prompts = GuiSettings::getHelpPrompts();
+			prompts.push_back(HelpPrompt("y", "preferred"));
+			return prompts;
+		}
+
+	private:
+		struct RomRowWidgets
+		{
+			std::shared_ptr<ImageComponent> star;
+			std::shared_ptr<TextComponent> name;
+		};
+
+		void buildRows()
+		{
+			if(mGame == nullptr)
+				return;
+
+			const std::vector<RomData>& roms = mGame->getRoms();
+			for(unsigned int i = 0; i < roms.size(); ++i)
+			{
+				ComponentListRow row;
+
+				auto star = std::make_shared<ImageComponent>(mWindow);
+				const float starSize = Font::get(FONT_SIZE_MEDIUM)->getLetterHeight();
+				star->setImage(":/star_filled.svg");
+				star->setResize(starSize, starSize);
+				star->setVisible(roms[i].preferred);
+
+				std::string romName = roms[i].romName.empty() ? mGame->getName() : roms[i].romName;
+				auto label = std::make_shared<TextComponent>(mWindow, romName, Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+
+				row.addElement(star, false, false);
+				row.addElement(label, true);
+				row.input_handler = [this, i](InputConfig* config, Input input) -> bool {
+					if(input.value == 0)
+						return false;
+
+					if(config->isMappedTo("a", input))
+					{
+						launchRom(i);
+						return true;
+					}
+
+					if(config->isMappedTo("y", input))
+					{
+						setPreferredRom(i);
+						return true;
+					}
+
+					return false;
+				};
+
+				addRow(row);
+
+				RomRowWidgets widgets;
+				widgets.star = star;
+				widgets.name = label;
+				mRows.push_back(widgets);
+			}
+
+			updatePreferredIndicator();
+		}
+
+		void setPreferredRom(unsigned int index)
+		{
+			if(mGame == nullptr)
+				return;
+
+			FileData* source = mGame->getSourceFileData();
+			std::vector<RomData>& roms = source->getRomsMutable();
+			if(index >= roms.size())
+				return;
+
+			for(unsigned int i = 0; i < roms.size(); ++i)
+				roms[i].preferred = (i == index);
+
+			source->metadata.set("name", source->metadata.get("name"));
+			source->getSystem()->onMetaDataSavePoint();
+
+			if(mGame != source)
+				mGame->refreshMetadata();
+
+			mPreferredChanged = true;
+			updatePreferredIndicator();
+		}
+
+		void launchRom(unsigned int index)
+		{
+			if(mGame == nullptr)
+				return;
+
+			FileData* selectedEntry = mGame;
+			FileData* source = selectedEntry->getSourceFileData();
+			const std::vector<RomData>& roms = source->getRoms();
+			if(index >= roms.size() || roms[index].path.empty())
+				return;
+
+			const std::string launchPath = roms[index].path;
+			delete this;
+
+			source->launchGame(mWindow, launchPath);
+			ViewController::get()->onFileChanged(source, FILE_METADATA_CHANGED);
+			if(selectedEntry != source)
+				ViewController::get()->onFileChanged(selectedEntry, FILE_METADATA_CHANGED);
+		}
+
+		void updatePreferredIndicator()
+		{
+			if(mGame == nullptr)
+				return;
+
+			const std::vector<RomData>& roms = mGame->getRoms();
+			for(unsigned int i = 0; i < roms.size() && i < mRows.size(); ++i)
+				mRows[i].star->setVisible(roms[i].preferred);
+		}
+
+		FileData* mGame;
+		bool mPreferredChanged;
+		std::vector<RomRowWidgets> mRows;
+	};
+
 	void openRomSelectionMenu(Window* window, FileData* game)
 	{
 		if(game == nullptr || game->getType() != GAME)
@@ -22,16 +166,7 @@ namespace
 		if(roms.empty())
 			return;
 
-		GuiSettings* menu = new GuiSettings(window, "ROMS");
-		for(auto it = roms.cbegin(); it != roms.cend(); ++it)
-		{
-			ComponentListRow row;
-			std::string romName = it->romName.empty() ? game->getName() : it->romName;
-			row.addElement(std::make_shared<TextComponent>(window, romName, Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
-			menu->addRow(row);
-		}
-
-		window->pushGui(menu);
+		window->pushGui(new RomSelectionMenu(window, game));
 	}
 }
 

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -147,9 +147,10 @@ namespace
 				return;
 
 			const std::string launchPath = roms[index].path;
+			Window* window = mWindow;
 			delete this;
 
-			source->launchGame(mWindow, launchPath);
+			source->launchGame(window, launchPath);
 			ViewController::get()->onFileChanged(source, FILE_METADATA_CHANGED);
 			if(selectedEntry != source)
 				ViewController::get()->onFileChanged(selectedEntry, FILE_METADATA_CHANGED);

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -14,6 +14,23 @@
 
 namespace
 {
+	class RomPromptTextComponent : public TextComponent
+	{
+	public:
+		RomPromptTextComponent(Window* window, const std::string& text, const std::shared_ptr<Font>& font, unsigned int color)
+			: TextComponent(window, text, font, color)
+		{
+		}
+
+		std::vector<HelpPrompt> getHelpPrompts() override
+		{
+			std::vector<HelpPrompt> prompts;
+			prompts.push_back(HelpPrompt("a", "launch"));
+			prompts.push_back(HelpPrompt("y", "preferred"));
+			return prompts;
+		}
+	};
+
 	class RomSelectionMenu : public GuiSettings
 	{
 	public:
@@ -32,13 +49,6 @@ namespace
 			FileData* source = mGame->getSourceFileData();
 			if(source != mGame)
 				ViewController::get()->onFileChanged(source, FILE_METADATA_CHANGED);
-		}
-
-		std::vector<HelpPrompt> getHelpPrompts() override
-		{
-			std::vector<HelpPrompt> prompts = GuiSettings::getHelpPrompts();
-			prompts.push_back(HelpPrompt("y", "preferred"));
-			return prompts;
 		}
 
 	private:
@@ -65,7 +75,7 @@ namespace
 				star->setVisible(roms[i].preferred);
 
 				std::string romName = roms[i].romName.empty() ? mGame->getName() : roms[i].romName;
-				auto label = std::make_shared<TextComponent>(mWindow, romName, Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
+				auto label = std::make_shared<RomPromptTextComponent>(mWindow, romName, Font::get(FONT_SIZE_MEDIUM), 0x777777FF);
 
 				row.addElement(star, false, false);
 				row.addElement(label, true);

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -1,5 +1,7 @@
 #include "views/gamelist/ISimpleGameListView.h"
 
+#include "guis/GuiSettings.h"
+#include "components/TextComponent.h"
 #include "views/UIModeController.h"
 #include "views/ViewController.h"
 #include "CollectionSystemManager.h"
@@ -7,6 +9,31 @@
 #include "Settings.h"
 #include "Sound.h"
 #include "SystemData.h"
+#include "Window.h"
+
+namespace
+{
+	void openRomSelectionMenu(Window* window, FileData* game)
+	{
+		if(game == nullptr || game->getType() != GAME)
+			return;
+
+		const std::vector<RomData>& roms = game->getRoms();
+		if(roms.empty())
+			return;
+
+		GuiSettings* menu = new GuiSettings(window, "ROMS");
+		for(auto it = roms.cbegin(); it != roms.cend(); ++it)
+		{
+			ComponentListRow row;
+			std::string romName = it->romName.empty() ? game->getName() : it->romName;
+			row.addElement(std::make_shared<TextComponent>(window, romName, Font::get(FONT_SIZE_MEDIUM), 0x777777FF), true);
+			menu->addRow(row);
+		}
+
+		window->pushGui(menu);
+	}
+}
 
 ISimpleGameListView::ISimpleGameListView(Window* window, FileData* root) : IGameListView(window, root),
 	mHeaderText(window), mHeaderImage(window), mBackground(window)
@@ -139,13 +166,12 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 		{
 			if (mRoot->getSystem()->isGameSystem())
 			{
-				// go to random system game
-				FileData* randomGame = getCursor()->getSystem()->getRandomGame();
-				if (randomGame)
+				FileData* cursor = getCursor();
+				if(cursor->getType() == GAME)
 				{
-					setCursor(randomGame);
+					openRomSelectionMenu(mWindow, cursor);
+					return true;
 				}
-				return true;
 			}
 		}else if (config->isMappedTo("y", input) && !UIModeController::getInstance()->isUIModeKid())
 		{

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -233,8 +233,11 @@ void ISimpleGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme
 	}
 }
 
-void ISimpleGameListView::onFileChanged(FileData* /*file*/, FileChangeType /*change*/)
+void ISimpleGameListView::onFileChanged(FileData* /*file*/, FileChangeType change)
 {
+	if(change == FILE_METADATA_CHANGED)
+		return;
+
 	// we could be tricky here to be efficient;
 	// but this shouldn't happen very often so we'll just always repopulate
 	FileData* cursor = getCursor();

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -147,10 +147,9 @@ namespace
 				return;
 
 			const std::string launchPath = roms[index].path;
-			Window* window = mWindow;
-			delete this;
-
-			source->launchGame(window, launchPath);
+			// Keep this popup alive so returning from gameplay lands back on the
+			// same ROM selection screen and highlighted row.
+			source->launchGame(mWindow, launchPath);
 			ViewController::get()->onFileChanged(source, FILE_METADATA_CHANGED);
 			if(selectedEntry != source)
 				ViewController::get()->onFileChanged(selectedEntry, FILE_METADATA_CHANGED);

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -72,7 +72,7 @@ namespace
 
 				auto star = std::make_shared<ImageComponent>(mWindow);
 				const float starSize = Font::get(FONT_SIZE_MEDIUM)->getLetterHeight();
-				star->setImage(":/star_filled.svg");
+				star->setImage(":/cartridge.svg");
 				star->setResize(starSize, starSize);
 				star->setVisible(roms[i].preferred);
 

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -188,8 +188,9 @@ void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 
 	mDescription.setSize(mDescContainer.getSize().x(), 0);
 	mDescription.applyTheme(theme, getName(), "md_description", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
-	mLblRomName.applyTheme(theme, getName(), "md_lbl_playcount", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | ROTATION) | ThemeFlags::Z_INDEX);
-	mRomNameText.applyTheme(theme, getName(), "md_playcount", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION) | ThemeFlags::Z_INDEX);
+	mLblRomName.applyTheme(theme, getName(), "md_lbl_romname", ALL ^ ROTATION);
+	mRomNameContainer.applyTheme(theme, getName(), "md_romname", POSITION | ThemeFlags::SIZE | Z_INDEX | VISIBLE);
+	mRomNameText.applyTheme(theme, getName(), "md_romname", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
 	mRomNameContainer.setZIndex(mLblRomName.getZIndex());
 
 	sortChildren();

--- a/es-app/src/views/gamelist/VideoGameListView.cpp
+++ b/es-app/src/views/gamelist/VideoGameListView.cpp
@@ -21,10 +21,11 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 	mVideoPlaying(false),
 
 	mLblRating(window), mLblReleaseDate(window), mLblDeveloper(window), mLblPublisher(window),
-	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window),
+	mLblGenre(window), mLblPlayers(window), mLblLastPlayed(window), mLblPlayCount(window), mLblRomName(window),
 
 	mRating(window), mReleaseDate(window), mDeveloper(window), mPublisher(window),
 	mGenre(window), mPlayers(window), mLastPlayed(window), mPlayCount(window),
+	mRomNameContainer(window), mRomNameText(window),
 	mName(window)
 {
 	const float padding = 0.01f;
@@ -105,6 +106,17 @@ VideoGameListView::VideoGameListView(Window* window, FileData* root) :
 	mLblPlayCount.setText("Times played: ");
 	addChild(&mLblPlayCount);
 	addChild(&mPlayCount);
+	mLblRomName.setText("Rom Name: ");
+	mLblRomName.setColor(0x777777FF);
+	mLblRomName.setDefaultZIndex(40);
+	addChild(&mLblRomName);
+
+	mRomNameContainer.setAutoScroll(true, true); // horizontal marquee
+	mRomNameContainer.setDefaultZIndex(40);
+	addChild(&mRomNameContainer);
+	mRomNameText.setColor(0xFFFFFFFF);
+	mRomNameText.setDefaultZIndex(40);
+	mRomNameContainer.addChild(&mRomNameText);
 
 	mName.setPosition(mSize.x(), mSize.y());
 	mName.setDefaultZIndex(40);
@@ -157,6 +169,10 @@ void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 	}
 
 
+	// Apply desc container position/size from theme BEFORE initMDValues() so that
+	// initMDValues() can nudge the y below the ROM name row while preserving theme x/width.
+	mDescContainer.applyTheme(theme, getName(), "md_description", POSITION | ThemeFlags::SIZE | Z_INDEX | VISIBLE);
+
 	initMDValues();
 	std::vector<GuiComponent*> values = getMDValues();
 	assert(values.size() == 8);
@@ -170,9 +186,11 @@ void VideoGameListView::onThemeChanged(const std::shared_ptr<ThemeData>& theme)
 		values[i]->applyTheme(theme, getName(), valElements[i], ALL ^ ThemeFlags::TEXT);
 	}
 
-	mDescContainer.applyTheme(theme, getName(), "md_description", POSITION | ThemeFlags::SIZE | Z_INDEX | VISIBLE);
 	mDescription.setSize(mDescContainer.getSize().x(), 0);
 	mDescription.applyTheme(theme, getName(), "md_description", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION));
+	mLblRomName.applyTheme(theme, getName(), "md_lbl_playcount", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | ROTATION) | ThemeFlags::Z_INDEX);
+	mRomNameText.applyTheme(theme, getName(), "md_playcount", ALL ^ (POSITION | ThemeFlags::SIZE | ThemeFlags::ORIGIN | TEXT | ROTATION) | ThemeFlags::Z_INDEX);
+	mRomNameContainer.setZIndex(mLblRomName.getZIndex());
 
 	sortChildren();
 }
@@ -222,6 +240,8 @@ void VideoGameListView::initMDValues()
 	mPlayers.setFont(defaultFont);
 	mLastPlayed.setFont(defaultFont);
 	mPlayCount.setFont(defaultFont);
+	mLblRomName.setFont(defaultFont);
+	mRomNameText.setFont(defaultFont);
 
 	float bottom = 0.0f;
 
@@ -236,10 +256,34 @@ void VideoGameListView::initMDValues()
 		float testBot = values[i]->getPosition().y() + values[i]->getSize().y();
 		if(testBot > bottom)
 			bottom = testBot;
+
+		float labelBot = labels[i]->getPosition().y() + labels[i]->getSize().y();
+		if(labelBot > bottom)
+			bottom = labelBot;
 	}
 
-	mDescContainer.setPosition(mDescContainer.getPosition().x(), bottom + mSize.y() * 0.01f);
-	mDescContainer.setSize(mDescContainer.getSize().x(), mSize.y() - mDescContainer.getPosition().y());
+
+	const float rowY = bottom;
+	const float lineH = defaultFont->getHeight();
+
+	mLblRomName.setPosition(Vector3f(mLblPublisher.getPosition().x(), rowY, 0.0f));
+	mLblRomName.setDefaultZIndex(40);
+	const float labelW = mLblRomName.getSize().x();
+	mRomNameContainer.setPosition(mLblRomName.getPosition() + Vector3f(labelW, 0.0f, 0.0f));
+	mRomNameContainer.setSize(mSize.x() * 0.48f - labelW, lineH);
+
+	mRomNameText.setPosition(Vector3f(0, 0, 0));
+	mRomNameText.setSize(0, lineH);
+	mRomNameText.setDefaultZIndex(40);
+
+	const float rowPadding = 0.01f * mSize.y();
+	const float rowBottom = rowY + mLblRomName.getSize().y();
+
+	// Preserve theme bottom edge: capture it after applyTheme, shrink top to fit ROM name row.
+	const float descBottom = mDescContainer.getPosition().y() + mDescContainer.getSize().y();
+	const float newDescY = rowBottom + rowPadding;
+	mDescContainer.setPosition(mDescContainer.getPosition().x(), newDescY);
+	mDescContainer.setSize(mDescContainer.getSize().x(), descBottom - newDescY);
 }
 
 
@@ -280,6 +324,12 @@ void VideoGameListView::updateInfoPanel()
 		mGenre.setValue(file->metadata.get("genre"));
 		mPlayers.setValue(file->metadata.get("players"));
 		mName.setValue(file->metadata.get("name"));
+		const RomData* preferred = file->getPreferredRom();
+		if(preferred != NULL && !preferred->romName.empty())
+			mRomNameText.setValue(preferred->romName);
+		else
+			mRomNameText.setValue(file->getName());
+		mRomNameContainer.reset();
 
 		if(file->getType() == GAME)
 		{
@@ -297,6 +347,8 @@ void VideoGameListView::updateInfoPanel()
 	comps.push_back(&mDescription);
 	comps.push_back(&mImage);
 	comps.push_back(&mName);
+	comps.push_back(&mLblRomName);
+	comps.push_back(&mRomNameText);
 	std::vector<TextComponent*> labels = getMDLabels();
 	comps.insert(comps.cend(), labels.cbegin(), labels.cend());
 

--- a/es-app/src/views/gamelist/VideoGameListView.h
+++ b/es-app/src/views/gamelist/VideoGameListView.h
@@ -39,6 +39,7 @@ private:
 	ImageComponent mImage;
 
 	TextComponent mLblRating, mLblReleaseDate, mLblDeveloper, mLblPublisher, mLblGenre, mLblPlayers, mLblLastPlayed, mLblPlayCount;
+	TextComponent mLblRomName;
 
 	RatingComponent mRating;
 	DateTimeComponent mReleaseDate;
@@ -48,6 +49,8 @@ private:
 	TextComponent mPlayers;
 	DateTimeComponent mLastPlayed;
 	TextComponent mPlayCount;
+	ScrollableContainer mRomNameContainer;
+	TextComponent mRomNameText;
 	TextComponent mName;
 
 	std::vector<TextComponent*> getMDLabels();

--- a/es-core/src/components/ScrollableContainer.cpp
+++ b/es-core/src/components/ScrollableContainer.cpp
@@ -34,11 +34,11 @@ void ScrollableContainer::render(const Transform4x4f& parentTrans)
 	Renderer::popClipRect();
 }
 
-void ScrollableContainer::setAutoScroll(bool autoScroll)
+void ScrollableContainer::setAutoScroll(bool autoScroll, bool horizontal)
 {
 	if(autoScroll)
 	{
-		mScrollDir = Vector2f(0, 1);
+		mScrollDir = horizontal ? Vector2f(1, 0) : Vector2f(0, 1);
 		if (mAutoScrollDelay == 0)
 		{
 			mAutoScrollDelay = AUTO_SCROLL_DELAY;
@@ -85,7 +85,11 @@ void ScrollableContainer::update(int deltaTime)
 		mScrollPos[1] = 0;
 
 	const Vector2f contentSize = getContentSize();
-	if(mScrollPos.x() + getSize().x() > contentSize.x())
+	if(contentSize.x() < getSize().x())
+	{
+		mScrollPos[0] = 0;
+	}
+	else if(mScrollPos.x() + getSize().x() > contentSize.x())
 	{
 		mScrollPos[0] = contentSize.x() - getSize().x();
 		mAtEnd = true;

--- a/es-core/src/components/ScrollableContainer.h
+++ b/es-core/src/components/ScrollableContainer.h
@@ -11,7 +11,7 @@ public:
 
 	Vector2f getScrollPos() const;
 	void setScrollPos(const Vector2f& pos);
-	void setAutoScroll(bool autoScroll);
+	void setAutoScroll(bool autoScroll, bool horizontal = false);
 	void reset();
 
 	void update(int deltaTime) override;


### PR DESCRIPTION
It can be rather ugly when you have multiple roms of different regions when they are the same game. For example there can be a european rom, a japanese rom, an american rom, etc.. (same for revisions) each showing up as a line item in a Game List

Introduce new gamelist xml items under `roms` with each individual `rom` map to a file path (the rom file) along with media specific for that rom (some can have a japanese marquee or an european name... or whatever). This also maintains support for games that have a 'flat' list and will still work with existing gamelist.xml that have not been modified for this.

There is still a top level metadata images which are loaded as a fallback if there is no path or item for the individual rom metadata images.

Example XML with Banjo Kazooie

```xml
<game>
		<name>Banjo-Kazooie</name>
		<desc>Banjo-Kazooie's fairy tale back story is reminiscent of Snow White's. A gnarled, ugly witch named Gruntilda asks her magical cauldron who is the fairest of them all. Of course, the pot's answer doesn't please the hag-- he singles out Banjo's sister, Tooty. When Tooty turns up missing, Banjo and his birdie buddy Kazooie set out to find her.

The worlds in Banjo-Kazooie are gigantic, and chock full of crazy items to collect. Musical Notes, Puzzle Pieces ("Jiggies"), Mumbo Tokens, and Jinjoes are just some of the swag that Banjo must stuff in his backpack to complete his adventure. While some of the necessary items are simply stashed off the beaten path, others will require puzzle solving skills to turn up.</desc>
		<image>./media/screenshots/Banjo-Kazooie (USA).png</image>
		<marquee>./media/marquees/Banjo-Kazooie (USA).png</marquee>
		<rating>0.95</rating>
		<developer>Rareware</developer>
		<publisher>Nintendo</publisher>
		<genre>Platform</genre>
		<kidgame>true</kidgame>
		<playcount></playcount>
		<lastplayed></lastplayed>
		<roms>
			<rom>
				<path>./Banjo-Kazooie (USA).z64</path>
				<romname>Banjo-Kazooie (USA).z64</romname>
				<regions>
					<region>us</region>
				</regions>
				<releasedate>19980629T000000</releasedate>
				<image>./media/screenshots/Banjo-Kazooie (USA).png</image>
				<marquee>./media/marquees/Banjo-Kazooie (USA).png</marquee>
			</rom>
			<rom>
				<path>./Banjo to Kazooie no Daibouken (Japan).z64</path>
				<romname>Banjo to Kazooie no Daibouken (Japan).z64</romname>
				<regions>
					<region>jp</region>
				</regions>
				<languages>
					<language>en</language>
					<language>fr</language>
					<language>de</language>
				</languages>
				<releasedate>19981206T000000</releasedate>
				<image>./media/screenshots/Banjo to Kazooie no Daibouken (Japan).png</image>
				<marquee>./media/marquees/Banjo to Kazooie no Daibouken (Japan).png</marquee>
			</rom>
			<rom preferred="true">
				<path>./Banjo-Kazooie (USA) (Rev A).z64</path>
				<romname>Banjo-Kazooie (USA) (Rev A).z64</romname>
				<regions>
					<region>us</region>
				</regions>
				<releasedate>19980629T000000</releasedate>
				<image>./media/screenshots/Banjo-Kazooie (USA) (Rev A).png</image>
				<marquee>./media/marquees/Banjo-Kazooie (USA) (Rev A).png</marquee>
			</rom>
			<rom>
				<path>./Banjo-Kazooie (Europe) (En,Fr,De).z64</path>
				<romname>Banjo-Kazooie (Europe) (En,Fr,De).z64</romname>
				<regions>
					<region>eu</region>
				</regions>
				<languages>
					<language>en</language>
					<language>fr</language>
					<language>de</language>
				</languages>
				<releasedate>19980717T000000</releasedate>
				<image>./media/screenshots/Banjo-Kazooie (Europe) (En,Fr,De).png</image>
				<marquee>./media/marquees/Banjo-Kazooie (Europe) (En,Fr,De).png</marquee>
			</rom>
		</roms>
	</game>
```

Preferred is used to select which is the "default" ROM to launch

The "X" button, which used to be for "RANDOM", was taken over in order to open a menu to select which specific ROM to launch and to select the perferred ROM which will launch without needing to go in to the ROM list.

I modified skyscraper because the emulationstation scraper looks at filenames and skyscraper will use a checksum which it can find specfic to that rom and get the specific game too it (also because skyscraper works better for LARGER filelists)

this was done a fork here: https://github.com/XenuIsWatching/skyscraper/tree/emulationstation2
This added a new 'frontend' which is used at the command line as just called `emulationstation2` for now (because i really couldn't come up with a better name which will write the new format with an existing cache.

an example usage
```
Skyscraper \
    -p n64 \
    -s cache \
    -f emulationstation2 \
    --flags unattend,nobrackets,videos,relative \
    --region us \
    -i n64 \
    -o "n64/.media" \
    -g n64
```

Video Example

https://github.com/user-attachments/assets/139c6014-c107-4ff2-bc49-a43e5c8b0879

